### PR TITLE
Update various wikis

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -107804,14 +107804,6 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Zeldapedia",
-    "d": "zelda.wikia.com",
-    "t": "zeldapedia",
-    "u": "http://zelda.wikia.com/wiki/Special:Search?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (specific)"
-  },
-  {
     "s": "Zelda Universe",
     "d": "www.zeldauniverse.net",
     "t": "zeldauniverse",
@@ -107821,9 +107813,25 @@
   },
   {
     "s": "Zelda Wiki",
-    "d": "zelda.gamepedia.com",
+    "d": "zeldawiki.wiki",
     "t": "zeldawiki",
-    "u": "https://zelda.gamepedia.com/index.php?search={{{s}}}",
+    "u": "https://zeldawiki.wiki/w/index.php?search={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (specific)"
+  },
+  {
+    "s": "Zelda Wiki",
+    "d": "zeldawiki.wiki",
+    "t": "zw",
+    "u": "https://zeldawiki.wiki/w/index.php?search={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (specific)"
+  },
+  {
+    "s": "Zelda Wiki",
+    "d": "zeldawiki.wiki",
+    "t": "zeldapedia",
+    "u": "https://zeldawiki.wiki/w/index.php?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },
@@ -108186,14 +108194,6 @@
     "u": "https://www.zalando.de/katalog/?q={{{s}}}",
     "c": "Shopping",
     "sc": "Online"
-  },
-  {
-    "s": "Zelda Wiki",
-    "d": "zelda.gamepedia.com",
-    "t": "zw",
-    "u": "https://zelda.gamepedia.com/index.php?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (specific)"
   },
   {
     "s": "Zephyr Cross Reference",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -75636,9 +75636,9 @@
   },
   {
     "s": "PLAYERUNKNOWN'S BATTLEGROUNDS Wiki",
-    "d": "pubg.gamepedia.com",
+    "d": "pubg.wiki.gg",
     "t": "pubgwiki",
-    "u": "https://pubg.gamepedia.com/index.php?search={{{s}}}",
+    "u": "https://pubg.wiki.gg/index.php?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -50286,9 +50286,9 @@
   },
   {
     "s": "JoJo's Bizarre Encyclopedia",
-    "d": "jojo.wikia.com",
+    "d": "jojowiki.com",
     "t": "jojo",
-    "u": "http://jojo.wikia.com/wiki/Special:Search?search={{{s}}}&fulltext=Search",
+    "u": "https://jojowiki.com/index.php?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Comics"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -23691,9 +23691,9 @@
   },
   {
     "s": "Dungeons and Dragons Wiki",
-    "d": "dungeons.wikia.com",
+    "d": "dnd-wiki.org",
     "t": "dndwiki",
-    "u": "http://dungeons.wikia.com/wiki/Special:Search?search={{{s}}}",
+    "u": "https://dnd-wiki.org/w/index.php?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -43917,9 +43917,17 @@
   },
   {
     "s": "Hearthstone Wiki",
-    "d": "hearthstone.gamepedia.com",
+    "d": "hearthstone.wiki.gg",
     "t": "hearthstone",
-    "u": "http://hearthstone.gamepedia.com/?search={{{s}}}",
+    "u": "https://hearthstone.wiki.gg/index.php?search={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (specific)"
+  },
+  {
+    "s": "Hearthstone Wiki",
+    "d": "hearthstone.wiki.gg",
+    "t": "hswiki",
+    "u": "https://hearthstone.wiki.gg/index.php?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },
@@ -45514,14 +45522,6 @@
     "u": "http://computer.howstuffworks.com/search.php?terms={{{s}}}",
     "c": "Research",
     "sc": "Reference"
-  },
-  {
-    "s": "Hearthstone: Heroes of Warcraft Wiki",
-    "d": "hearthstone.gamepedia.com",
-    "t": "hswiki",
-    "u": "http://hearthstone.gamepedia.com/index.php?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (specific)"
   },
   {
     "s": "HookTube",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -73621,14 +73621,6 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Path of Exile Gamepedia",
-    "d": "pathofexile.gamepedia.com",
-    "t": "poegp",
-    "u": "https://pathofexile.gamepedia.com/index.php?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (specific)"
-  },
-  {
     "s": "PoemHunter",
     "d": "www.poemhunter.com",
     "t": "poem",
@@ -73646,19 +73638,19 @@
   },
   {
     "s": "Path of Exile page",
-    "d": "pathofexile.gamepedia.com",
+    "d": "www.poewiki.net",
     "t": "poepage",
-    "u": "http://pathofexile.gamepedia.com/{{{s}}}",
+    "u": "https://www.poewiki.net/wiki/{{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },
   {
     "s": "Path of Exile Wiki",
-    "d": "pathofexile.gamepedia.com",
+    "d": "www.poewiki.net",
     "t": "poe",
-    "u": "http://pathofexile.gamepedia.com/index.php?search={{{s}}}",
-    "c": "Online Services",
-    "sc": "Tools"
+    "u": "https://www.poewiki.net/index.php?search={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (specific)"
   },
   {
     "s": "Path of Exile Subreddit",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -92110,9 +92110,9 @@
   },
   {
     "s": "Official Thorium Mod Wiki",
-    "d": "thoriummod.gamepedia.com",
+    "d": "thoriummod.wiki.gg",
     "t": "thoriummod",
-    "u": "https://thoriummod.gamepedia.com/index.php?search={{{s}}}",
+    "u": "https://thoriummod.wiki.gg/index.php?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (general)"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -24138,10 +24138,18 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "http://dont-starve-game.wikia.com/wiki/Don%27t_Starve_Wiki",
-    "d": "dont-starve-game.wikia.com",
+    "s": "Don't Starve Wiki",
+    "d": "dontstarve.wiki.gg",
     "t": "dontstarve",
-    "u": "http://dont-starve-game.wikia.com/wiki/Special:Search?search={{{s}}}&fulltext=Search",
+    "u": "https://dontstarve.wiki.gg/index.php?search={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (specific)"
+  },
+  {
+    "s": "Don't Starve Wiki",
+    "d": "dontstarve.wiki.gg",
+    "t": "dstarve",
+    "u": "https://dontstarve.wiki.gg/index.php?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },
@@ -25172,14 +25180,6 @@
     "u": "http://snapshot.debian.org/package/?src={{{s}}}",
     "c": "Tech",
     "sc": "Sysadmin (debian)"
-  },
-  {
-    "s": "Don't Starve Wiki",
-    "d": "dont-starve-game.wikia.com",
-    "t": "dstarve",
-    "u": "http://dont-starve-game.wikia.com/wiki/Special:Search?search={{{s}}}&fulltext=Search",
-    "c": "Entertainment",
-    "sc": "Games (general)"
   },
   {
     "s": "Debian Security Tracker",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -79716,9 +79716,9 @@
   },
   {
     "s": "Risk of Rain 2 Wiki",
-    "d": "riskofrain2.fandom.com",
+    "d": "riskofrain2.wiki.gg",
     "t": "ror2",
-    "u": "https://riskofrain2.fandom.com/wiki/Special:Search?query={{{s}}}",
+    "u": "https://riskofrain2.wiki.gg/index.php?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -52349,10 +52349,10 @@
     "sc": "Movies"
   },
   {
-    "s": "KOEI Wiki",
-    "d": "koei.wikia.com",
+    "s": "Koei Tecmo Wiki",
+    "d": "koeitecmo.wiki",
     "t": "koei",
-    "u": "http://koei.wikia.com/wiki/Special:Search?search={{{s}}}&fulltext=Search",
+    "u": "https://koeitecmo.wiki/w/index.php?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (offline)"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -94446,9 +94446,9 @@
   },
   {
     "s": "Toontown Rewritten",
-    "d": "toontownrewritten.wikia.com",
+    "d": "toontownrewritten.wiki",
     "t": "ttr",
-    "u": "http://toontownrewritten.wikia.com/wiki/Special:Search?search={{{s}}}",
+    "u": "https://toontownrewritten.wiki/index.php?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -91118,19 +91118,11 @@
   },
   {
     "s": "Official Terraria Wiki",
-    "d": "terraria.gamepedia.com",
+    "d": "terraria.wiki.gg",
     "t": "terraria",
-    "u": "https://terraria.gamepedia.com/index.php?title=Special%3ASearch&profile=default&search={{{s}}}&fulltext=Search",
+    "u": "https://terraria.wiki.gg/index.php?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
-  },
-  {
-    "s": "Terraria Gamepedia Wiki",
-    "d": "terraria.gamepedia.com",
-    "t": "terrg",
-    "u": "http://terraria.gamepedia.com/index.php?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (general)"
   },
   {
     "s": "TYPO3 Extension repository",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -66248,9 +66248,9 @@
   },
   {
     "s": "Noita Wiki",
-    "d": "noita.gamepedia.com",
+    "d": "noita.wiki.gg",
     "t": "noita",
-    "u": "https://noita.gamepedia.com/{{{s}}}",
+    "u": "https://noita.wiki.gg/index.php?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },


### PR DESCRIPTION
- Terraria Wiki: https://forums.terraria.org/index.php?threads/new-official-terraria-wiki-launches-today.111239/
- Don't Starve Wiki: https://www.reddit.com/r/dontstarve/comments/15z7bbl/dont_starve_wiki_moved_to_wikigg/
- Dungeons & Dragons Wiki: https://dungeons.fandom.com/wiki/Forum:We%27re_Moving
- Hearthstone Wiki: https://www.reddit.com/r/hearthstone/comments/16l9vzo/hearthstone_wiki_has_migrated_from_fandom_to/
- Noita Wiki: https://www.reddit.com/r/noita/comments/xnxx22/noita_wiki_has_migrated_to_wikigg/
- Thorium Wiki (Linked from mod forum post https://forums.terraria.org/index.php?threads/the-thorium-mod.40788/)
- PUBG: https://www.reddit.com/r/PUBATTLEGROUNDS/comments/127ln33/pubg_wiki_is_moving_to_wikigg/
- Toontown Rewritten Wiki: https://www.reddit.com/r/toontownrewritten/comments/17s1kux/the_toontown_rewritten_wiki_has_migrated/
- Zelda Wiki: https://zelda.fandom.com/wiki/Zelda_Wiki:Fork_Announcement
- JoJo's Bizarre Encyclopedia: https://jojo.fandom.com/f/p/3678094237892900919
- Koei Tecmo Wiki: https://koei.fandom.com/wiki/User_blog:Humble_Novice/Very_Important_Announcement!_The_Koei_Tecmo_Wiki_Is_Officially_Moving!
- Risk of Rain 2 Fandom -> riskofrain2.wiki.gg (New official wiki)
- Path of Exile Fandom -> poewiki.net (New official wiki)