### PR TITLE
Fix and flesh out LibGen bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -36134,6 +36134,30 @@
     "sc": "Academic"
   },
   {
+    "s": "Library Genesis (Non-Fiction)",
+    "d": "libgen.rs",
+    "t": "libg",
+    "u": "https://libgen.rs/search.php?req={{{s}}}",
+    "c": "Research",
+    "sc": "Academic"
+  },
+  {
+    "s": "Library Genesis (Fiction)",
+    "d": "libgen.rs",
+    "t": "libgfic",
+    "u": "https://libgen.rs/fiction/?q={{{s}}}",
+    "c": "Multimedia",
+    "sc": "Books"
+  },
+  {
+    "s": "Library Genesis (Scientific Articles)",
+    "d": "libgen.rs",
+    "t": "libgsci",
+    "u": "https://libgen.rs/scimag/?q={{{s}}}",
+    "c": "Research",
+    "sc": "Academic"
+  },
+  {
     "s": "Genius",
     "d": "genius.com",
     "t": "gen",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -36126,10 +36126,10 @@
     "sc": "Music"
   },
   {
-    "s": "Library Genesis",
-    "d": "gen.lib.rus.ec",
+    "s": "Library Genesis (Non-Fiction)",
+    "d": "libgen.rs",
     "t": "genesis",
-    "u": "http://gen.lib.rus.ec/search.php?req={{{s}}}&lg_topic=libgen&open=0&view=simple&res=25&phrase=1&column=def",
+    "u": "https://libgen.rs/search.php?req={{{s}}}",
     "c": "Research",
     "sc": "Academic"
   },


### PR DESCRIPTION
## Fixes existing LibGen `!genesis` bang

The existing bang was using a domain that no longer functions (`gen.lib.rus.ec`); I've modified it to use a domain that functions (`libgen.rs`).

I got the new domain from this [reddit announcement](https://old.reddit.com/r/libgen/comments/15p8h24/announcement_access_library_genesis_via_the/), and [LibGen's Wikipedia page](https://en.wikipedia.org/wiki/Library_Genesis) also shows it.

## Adds 3 new LibGen bangs

LibGen categorizes most of its data into three buckets; each one is searched via a distinct URL. I've added one bang for each:

1. `!libg` - searches  "Non-Fiction"; behaviorally identical to `!genesis`, but shorter and syntactically consistent with the next two (which must be longer because of their category specifiers)
2. `!libgfic` - searches "Fiction"
3. `!libgsci` - searches "Scientific Articles"