### PR TITLE
patft.uspto.gov is retired, and bang no longer works

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -70901,14 +70901,6 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "US Patent Database Search",
-    "d": "patft.uspto.gov",
-    "t": "patft",
-    "u": "http://patft.uspto.gov/netacgi/nph-Parser?Sect1=PTO2&Sect2=HITOFF&u=%2Fnetahtml%2FPTO%2Fsearch-adv.htm&r=0&f=S&l=50&d=PTXT&OS=&RS=%22{{{s}}}%22&Query=%22{{{s}}}%22&TD=&Srch1=%22{{{s}}}%22&NextList1=xxx",
-    "c": "Research",
-    "sc": "Government"
-  },
-  {
     "s": "patents.google.com",
     "d": "patents.google.com",
     "t": "patg",


### PR DESCRIPTION
See https://www.uspto.gov/about-us/news-updates/uspto-launches-new-patent-public-search-tool-and-webpage:

"Based on the advanced Patents End-to-End (PE2E) search tool USPTO examiners use to identify prior art, this free, cloud-based platform combines the capabilities of four existing search tools **scheduled to be retired in September 2022**: Public-Examiner’s Automated Search Tool (PubEAST), Public-Web-based Examiner’s Search Tool (PubWEST), **Patent Full-Text and Image Database (PatFT)**, and Patent Application Full-Text and Image Database (AppFT)."