### PR TITLE
Add Expresso search engine to bangs.json

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -27774,6 +27774,14 @@
     "sc": "Games (general)"
   },
   {
+    "s": "Expresso",
+    "d": "expresso.pt",
+    "t": "expresso",
+    "u": "https://expresso.pt/pesquisa?q={{{s}}}",
+    "c": "News",
+    "sc": "Newspaper"
+  },
+  {
     "s": "Kagi Search",
     "d": "kagi.com",
     "t": "emacs",


### PR DESCRIPTION
Expresso is a flagship weekly publication of the Impresa Group for Portugal.