### PR TITLE
Add more bangs for CourtListener

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -77803,10 +77803,34 @@
     "sc": "Law"
   },
   {
+    "s": "CourtListener - RECAP Archive",
+    "d": "www.courtlistener.com",
+    "t": "cl-recap",
+    "u": "https://www.courtlistener.com/?type=r&q={{{s}}}&order_by=score%20desc",
+    "c": "Research",
+    "sc": "Law"
+  },
+  {
     "s": "CourtListener - Case Law",
     "d": "www.courtlistener.com",
     "t": "courtlistener",
     "u": "https://www.courtlistener.com/?type=o&q={{{s}}}&order_by=score%20desc",
+    "c": "Research",
+    "sc": "Law"
+  },
+  {
+    "s": "CourtListener - Case Law",
+    "d": "www.courtlistener.com",
+    "t": "cl-law",
+    "u": "https://www.courtlistener.com/?type=o&q={{{s}}}&order_by=score%20desc",
+    "c": "Research",
+    "sc": "Law"
+  },
+  {
+    "s": "CourtListener - Oral Argument Audio",
+    "d": "www.courtlistener.com",
+    "t": "cl-audio",
+    "u": "https://www.courtlistener.com/?type=oa&q={{{s}}}&order_by=score%20desc",
     "c": "Research",
     "sc": "Law"
   },


### PR DESCRIPTION
Per the discussion [here](https://github.com/kagisearch/bangs/pull/8#issuecomment-1959648030), this adds additional bangs for the CourtListener website:

 - `cl-law` is a mirror of the `courtlistener` bang to make it shorter.
 - `cl-audio` searches our oral argument audio database
 - `cl-recap` is a mirror of the `recap` bang, to make it available under the `cl-` namespace we're using for other bangs.

With this complete, we'll have five bangs:

 - `cl-recap` and `recap` will search the RECAP Archive.
 - `cl-law` and `courtlistener` will search our case law.
 - `cl-audio` will search our audio files.

Thank you for making this possible!