### PR TITLE
Fix APKPure

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -5173,9 +5173,9 @@
   },
   {
     "s": "ApkPure",
-    "d": "apkpure.com",
+    "d": "apkpure.net",
     "t": "apkd",
-    "u": "https://apkpure.com/search?q={{{s}}}",
+    "u": "https://apkpure.net/search?q={{{s}}}",
     "c": "Tech",
     "sc": "Downloads (apps)"
   },
@@ -5205,9 +5205,9 @@
   },
   {
     "s": "APKPure",
-    "d": "apkpure.com",
+    "d": "apkpure.net",
     "t": "apkpure",
-    "u": "https://apkpure.com/search?q={{{s}}}",
+    "u": "https://apkpure.net/search?q={{{s}}}",
     "c": "Tech",
     "sc": "Downloads (apps)"
   },


### PR DESCRIPTION
apkpure.com has been down since January. It is now accessible through apkpure.net
https://apkpure.net/news/important-notice-regarding-apkpure-com-site