### PR TITLE
Fix yr.no

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -107095,7 +107095,7 @@
     "s": "yr.no/NRK/Meteorologisk institutt Weather",
     "d": "www.yr.no",
     "t": "yr",
-    "u": "https://www.yr.no/soek/soek.aspx?sted={{{s}}}",
+    "u": "https://www.yr.no/nb/søk?q={{{s}}}",
     "c": "News",
     "sc": "Weather"
   },


### PR DESCRIPTION
Updates the URL template for the Norwegian weather forecasting website [yr.no](https://www.yr.no)

We are sadly forced to choose a language in the URL, which ignores the browser language cookie. So I opted for the most common one.