### PR TITLE
Add matprat.no

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -58529,6 +58529,14 @@
     "sc": "Languages (python)"
   },
   {
+    "s": "MatPrat",
+    "d": "matprat.no",
+    "t": "matprat",
+    "u": "https://www.matprat.no/sok/#1/all/{{{s}}}/",
+    "c": "Research",
+    "sc": "Food"
+  },
+  {
     "s": "MatWeb",
     "d": "www.matweb.com",
     "t": "matweb",


### PR DESCRIPTION
Adds `!matprat` for [matprat.no](https://www.matprat.no/), a website for recipes and articles from the Norwegian Information Office for Eggs and Meat.
