### PR TITLE
Fix finn.no + subbangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -32196,6 +32196,30 @@
     "sc": "Online (marketplace)"
   },
   {
+    "s": "Finn.no Torget",
+    "d": "www.finn.no",
+    "t": "finntorget",
+    "u": "https://www.finn.no/bap/forsale/search.html?q={{{s}}}",
+    "c": "Shopping",
+    "sc": "Online (marketplace)"
+  },
+  {
+    "s": "Finn.no Torget",
+    "d": "www.finn.no",
+    "t": "finntorg",
+    "u": "https://www.finn.no/bap/forsale/search.html?q={{{s}}}",
+    "c": "Shopping",
+    "sc": "Online (marketplace)"
+  },
+  {
+    "s": "Finn.no Jobb",
+    "d": "www.finn.no",
+    "t": "finnjobb",
+    "u": "https://www.finn.no/job/fulltime/search.html?q={{{s}}}",
+    "c": "Online Services",
+    "sc": "Jobs"
+  },
+  {
     "s": "Finnkino",
     "d": "www.finnkino.fi",
     "t": "finnkinoen",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -32191,7 +32191,7 @@
     "s": "Finn.no",
     "d": "www.finn.no",
     "t": "finn",
-    "u": "https://www.finn.no/globalsearchlander.html?searchKeys=&q={{{s}}}",
+    "u": "https://www.finn.no/globalsearchlander?q={{{s}}}",
     "c": "Shopping",
     "sc": "Online (marketplace)"
   },


### PR DESCRIPTION
Fixed the URL template for the `!finn` bang for [finn.no](https://www.finn.no/) (Norwegian classified advertisements website).

Also added some "subbangs" for the subsections "Torget" (marketplace) and "Jobb" (recruitment ads)-