### PR TITLE
Add vinmonopolet.no

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Accepted changes are deployed to our website weekly.
 Kagi Staff and maintainers of this repo have final say, but a good bang submission should follow some basic guidelines.
 
 - The website must be reasonably well-known and widely used.
-  For example, popular commerical services and forums are OK.
+  For example, popular commercial services and forums are OK.
   Low-traffic independent sites, such as startups, local businesses, or personal blogs, are not OK.
 
 - The trigger must be specific to the website, not a generic term or word.

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -98767,6 +98767,14 @@
     "sc": "Online (deals)"
   },
   {
+    "s": "Vinmonopolet",
+    "d": "vinmonopolet.no",
+    "t": "vinmonopolet",
+    "u": "https://www.vinmonopolet.no/search?q={{{s}}}",
+    "c": "Shopping",
+    "sc": "Online"
+  },
+  {
     "s": "Vipon",
     "d": "www.vipon.com",
     "t": "vipon",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -98775,6 +98775,14 @@
     "sc": "Online"
   },
   {
+    "s": "Vinmonopolet",
+    "d": "vinmonopolet.no",
+    "t": "polet",
+    "u": "https://www.vinmonopolet.no/search?q={{{s}}}",
+    "c": "Shopping",
+    "sc": "Online"
+  },
+  {
     "s": "Vipon",
     "d": "www.vipon.com",
     "t": "vipon",


### PR DESCRIPTION
Adds the `!vinmonopolet` bang for [vinmonopolet.no](https://www.vinmonopolet.no), the website for the Norwegian Wine Monopoly. Basically the Norwegian equivalent of `!systembolaget`.