### PR TITLE
Add !mazemap

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -58585,6 +58585,14 @@
     "sc": "Health"
   },
   {
+    "s": "MazeMap",
+    "d": "use.mazemap.com",
+    "t": "mazemap",
+    "u": "https://use.mazemap.com/?search={{{s}}}",
+    "c": "Online Services",
+    "sc": "Maps"
+  },
+  {
     "s": "Malwarebytes Unpacked",
     "d": "blog.malwarebytes.org",
     "t": "mbamblog",


### PR DESCRIPTION
Adds `!mazemap` for the MazeMap web application at [use.mazemap.com](https://use.mazemap.com/). This is a popular service for indoor maps and wayfinding at universities, hospitals and office buildings.