### PR TITLE
fix: Fix query url for Namu wiki

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -64114,7 +64114,7 @@
     "s": "namuwiki",
     "d": "namu.wiki",
     "t": "namu",
-    "u": "https://namu.wiki/go/{{{s}}}",
+    "u": "https://namu.wiki/Search?q={{{s}}}",
     "c": "Research",
     "sc": "Reference"
   },


### PR DESCRIPTION
This PR fixes broken query url for Namu wiki.