### PR TITLE
add Android Code Search

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -2464,6 +2464,14 @@
     "sc": "Programming"
   },
   {
+    "s": "Android Code Search",
+    "d": "cs.android.com",
+    "t": "csa",
+    "u": "https://cs.android.com/search?q={{{s}}}",
+    "c": "Tech",
+    "sc": "Programming"
+  },
+  {
     "s": "arturogoga",
     "d": "www.arturogoga.com",
     "t": "agoga",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -2472,6 +2472,14 @@
     "sc": "Programming"
   },
   {
+    "s": "Android Code Search",
+    "d": "cs.android.com",
+    "t": "android-code",
+    "u": "https://cs.android.com/search?q={{{s}}}",
+    "c": "Tech",
+    "sc": "Programming"
+  },
+  {
     "s": "arturogoga",
     "d": "www.arturogoga.com",
     "t": "agoga",


### PR DESCRIPTION
Android Code Search is a nice tool to search in the Android codebase.
It also includes AndroidX, Android Studio and Android-llvm.

The bang is `csa` for Code Search Android because `acs` was already taken.
It matches the 3 first letters of the subdomain and the tld.