### PR TITLE
fix: update allegro.pl

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -3315,7 +3315,7 @@
     "s": "Allegro",
     "d": "allegro.pl",
     "t": "allegro",
-    "u": "http://allegro.pl/listing.php/search?string={{{s}}}",
+    "u": "https://allegro.pl/listing?string={{{s}}}",
     "c": "Shopping",
     "sc": "Online (intl)"
   },


### PR DESCRIPTION
The search link has been broken for quite a while.

`!allegro airpods` -> http://allegro.pl/listing.php/search?string=airpods -> 404 page

https://allegro.pl/listing?string=airpods -> proper listing