### PR TITLE
Fix PriceRunner and Prisjakt, remove OpenPorts

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -72882,7 +72882,7 @@
     "t": "pjno",
     "u": "https://www.prisjakt.no/search?search={{{s}}}",
     "c": "Shopping",
-    "sc": "Online"
+    "sc": "Online (deals)"
   },
   {
     "s": "Prisjakt",
@@ -72890,7 +72890,7 @@
     "t": "pj",
     "u": "https://www.prisjakt.nu/search?search={{{s}}}",
     "c": "Shopping",
-    "sc": "Services"
+    "sc": "Online (deals)"
   },
   {
     "s": "pikabu.ru",
@@ -74816,7 +74816,7 @@
     "t": "pricerunner",
     "u": "https://www.pricerunner.se/results?q={{{s}}}",
     "c": "Shopping",
-    "sc": "Services"
+    "sc": "Online (deals)"
   },
   {
     "s": "Pricerunner",
@@ -74960,7 +74960,7 @@
     "t": "prisjakt",
     "u": "https://www.prisjakt.nu/search?search={{{s}}}",
     "c": "Shopping",
-    "sc": "Services"
+    "sc": "Online (deals)"
   },
   {
     "s": "Prisjakt",
@@ -74968,7 +74968,7 @@
     "t": "pris",
     "u": "https://www.prisjakt.nu/search?search={{{s}}}",
     "c": "Shopping",
-    "sc": "Online"
+    "sc": "Online (deals)"
   },
   {
     "s": "r/privacy Subreddit",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -68959,14 +68959,6 @@
     "sc": "Government"
   },
   {
-    "s": "OpenPorts",
-    "d": "openports.se",
-    "t": "openports",
-    "u": "https://openports.se/search.php?so={{{s}}}",
-    "c": "Tech",
-    "sc": "Downloads (software)"
-  },
-  {
     "s": "OpenProcessing",
     "d": "www.openprocessing.org",
     "t": "openprocessing",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -74814,7 +74814,7 @@
     "s": "PriceRunner",
     "d": "www.pricerunner.se",
     "t": "pricerunner",
-    "u": "https://www.pricerunner.se/pl/360-364563094/Herrklaeder/Jam-OD-Yellow-Yellow-over-dyed-jean-jacket-priser?other_hits=%3B25607%3B%3B&q=acne+jam+od+yellow+yellow&ref=redirect&search={{{s}}}&sort=4",
+    "u": "https://www.pricerunner.se/results?q={{{s}}}",
     "c": "Shopping",
     "sc": "Services"
   },
@@ -74822,7 +74822,7 @@
     "s": "Pricerunner",
     "d": "www.pricerunner.dk",
     "t": "pricerun",
-    "u": "https://www.pricerunner.dk/search?q={{{s}}}",
+    "u": "https://www.pricerunner.dk/results?q={{{s}}}",
     "c": "Shopping",
     "sc": "Online (deals)"
   },


### PR DESCRIPTION
This PR contains three distinct changes, each in it's own commit with a message describing the change. Hopefully the summary and example URL:s below are helpful as well.

Here's an example of how the current PriceRunner bang works compared to the new template from the [first commit](cea3c2f3d0c7f5a0191f06f9dab6be9718668422)
Current: https://kagi.com/search?q=!pricerunner%20laptop
New: https://www.pricerunner.se/results?q=laptop

The [second commit](2fd4b9519529c2a7cd9b1ded599548cd6c2a9673) is just to make the subcategories consistent across PriceRunner and Prisjakt which are very similar sites.

The [third commit](2ccf89e2034b015f6a4a738fb87ee4a6d9293ba2) removes OpenPorts since it has been closed-down.
Message about the closure: https://openports.se/
Result using the bang: https://kagi.com/search?q=!openports%20test