### PR TITLE
Update BotB bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -11667,7 +11667,7 @@
     "s": "Kagi Search",
     "d": "kagi.com",
     "t": "botb",
-    "u": "/search?q={{{s}}}+site%3Abattleofthebits.org",
+    "u": "/search?q={{{s}}}+site%3Abattleofthebits.com",
     "c": "Multimedia",
     "sc": "Music"
   },


### PR DESCRIPTION
the !botb bang appends site:battleofthebits.org to a query, which leads to broken links. an example query is "!botb test", which transforms into "test site:battleofthebits.org", which results in all broken links

the current domain is battleofthebits.com - please see https://battleofthebits.com/academy/GroupThread/35044/we+may+have+lost+our+.org. "!botb test" should instead translate to "test site:battleofthebits.com"