### PR TITLE
Fix Meijer URL template

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -59754,7 +59754,7 @@
     "s": "Meijer",
     "d": "www.meijer.com",
     "t": "meijer",
-    "u": "https://www.meijer.com/catalog/search_command.cmd?keyword={{{s}}}&tierId=",
+    "u": "https://www.meijer.com/shopping/search.html?text={{{s}}}",
     "c": "Shopping",
     "sc": "Big box/department"
   },


### PR DESCRIPTION
The previous (broken) URL template would always respond with a 404 error.
The new URL template correctly responds with search results.