### PR TITLE
Fix !metacritic bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -60160,7 +60160,7 @@
     "s": "Metacritic",
     "d": "www.metacritic.com",
     "t": "metacritic",
-    "u": "https://www.metacritic.com/search/all/{{{s}}}/results",
+    "u": "https://www.metacritic.com/search/{{{s}}}/",
     "c": "Entertainment",
     "sc": "Misc"
   },


### PR DESCRIPTION
The !metacritic bang was leading to an error page. This replaces its URL to match the !mc bang, which works.