### PR TITLE
Add RSpec tests + assistant bangs

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,1 @@
+BUNDLE_PATH: ./vendor/bundle

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Validate JSON
         uses: walbo/validate-json@v1.1.0
         with:
-          files: ./data/bangs.json
+          files: data/*.json
 
           # optional, defaults to `$schema` in your JSON file
           schema: ./data/bangs.schema.json
@@ -37,3 +37,17 @@ jobs:
 
           # optional, default: true
           allow-union-types: true
+  run-rspec-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          # Not needed with a .ruby-version file
+          ruby-version: 3.0
+          # runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
+      - name: Run tests
+        run: |
+          bundle exec rspec

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Validate JSON
         uses: walbo/validate-json@v1.1.0
         with:
-          files: data/*.json
+          files: data/*bangs.json
 
           # optional, defaults to `$schema` in your JSON file
           schema: ./data/bangs.schema.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+/vendor

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,8 @@
     {
       "fileMatch": [
         "/data/bangs.json",
-        "/data/kagi_bangs.json"
+        "/data/kagi_bangs.json",
+        "/data/assistant_bangs.json"
       ],
       "url": "./data/bangs.schema.json"
     }

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem "json"
+gem "rspec", "~> 3.13"
+gem 'addressable', '~> 2.8', '>= 2.8.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,33 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
+    diff-lcs (1.5.1)
+    json (2.7.1)
+    public_suffix (5.0.4)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  addressable (~> 2.8, >= 2.8.6)
+  json
+  rspec (~> 3.13)
+
+BUNDLED WITH
+   2.5.4

--- a/data/assistant_bangs.json
+++ b/data/assistant_bangs.json
@@ -2,16 +2,6 @@
   {
     "s": "Kagi Assistant",
     "d": "kagi.com",
-    "t": "ka",
-    "u": "/assistant?q={{{s}}}",
-    "fmt": [
-      "url_encode_placeholder",
-      "url_encode_space_to_plus"
-    ]
-  },
-  {
-    "s": "Kagi Assistant",
-    "d": "kagi.com",
     "t": "ai",
     "u": "/assistant?q={{{s}}}",
     "fmt": [
@@ -42,7 +32,7 @@
   {
     "s": "Kagi Assistant - Research",
     "d": "kagi.com",
-    "t": "ask",
+    "t": "ai-res",
     "u": "/assistant?q={{{s}}}&mode=7",
     "fmt": [
       "url_encode_placeholder",
@@ -122,7 +112,7 @@
   {
     "s": "Kagi Assistant - Research/Expert",
     "d": "kagi.com",
-    "t": "expert",
+    "t": "ai-expert",
     "u": "/assistant?q={{{s}}}&mode=7&sub_mode=2",
     "fmt": [
       "url_encode_placeholder",
@@ -152,7 +142,7 @@
   {
     "s": "Kagi Assistant - Code",
     "d": "kagi.com",
-    "t": "code",
+    "t": "kcode",
     "u": "/assistant?q={{{s}}}&mode=5",
     "fmt": [
       "url_encode_placeholder",

--- a/data/assistant_bangs.json
+++ b/data/assistant_bangs.json
@@ -1,0 +1,172 @@
+[
+  {
+    "s": "Kagi Assistant",
+    "d": "kagi.com",
+    "t": "ka",
+    "u": "/assistant?q={{{s}}}",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant",
+    "d": "kagi.com",
+    "t": "ai",
+    "u": "/assistant?q={{{s}}}",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant",
+    "d": "kagi.com",
+    "t": "as",
+    "u": "/assistant?q={{{s}}}",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant",
+    "d": "kagi.com",
+    "t": "assistant",
+    "u": "/assistant?q={{{s}}}",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Research",
+    "d": "kagi.com",
+    "t": "ask",
+    "u": "/assistant?q={{{s}}}&mode=7",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Research",
+    "d": "kagi.com",
+    "t": "answer",
+    "u": "/assistant?q={{{s}}}&mode=7",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Research",
+    "d": "kagi.com",
+    "t": "discuss",
+    "u": "/assistant?q={{{s}}}&mode=7",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Research",
+    "d": "kagi.com",
+    "t": "research",
+    "u": "/assistant?q={{{s}}}&mode=7",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Research",
+    "d": "kagi.com",
+    "t": "asks",
+    "u": "/assistant?q={{{s}}}&mode=7",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Research/Fast",
+    "d": "kagi.com",
+    "t": "askf",
+    "u": "/assistant?q={{{s}}}&mode=7&sub_mode=1",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Research/Fast",
+    "d": "kagi.com",
+    "t": "fast",
+    "u": "/assistant?q={{{s}}}&mode=7&sub_mode=1",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Research/Expert",
+    "d": "kagi.com",
+    "t": "aske",
+    "u": "/assistant?q={{{s}}}&mode=7&sub_mode=2",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Research/Expert",
+    "d": "kagi.com",
+    "t": "expert",
+    "u": "/assistant?q={{{s}}}&mode=7&sub_mode=2",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Direct",
+    "d": "kagi.com",
+    "t": "llm",
+    "u": "/assistant?q={{{s}}}&mode=4",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Direct",
+    "d": "kagi.com",
+    "t": "chat",
+    "u": "/assistant?q={{{s}}}&mode=4",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Code",
+    "d": "kagi.com",
+    "t": "code",
+    "u": "/assistant?q={{{s}}}&mode=5",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Custom",
+    "d": "kagi.com",
+    "t": "custom",
+    "u": "/assistant?q={{{s}}}&mode=6",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  }
+]

--- a/data/assistant_bangs.json
+++ b/data/assistant_bangs.json
@@ -32,7 +32,7 @@
   {
     "s": "Kagi Assistant - Research",
     "d": "kagi.com",
-    "t": "ai-res",
+    "t": "research",
     "u": "/assistant?q={{{s}}}&mode=7",
     "fmt": [
       "url_encode_placeholder",
@@ -112,7 +112,7 @@
   {
     "s": "Kagi Assistant - Research/Expert",
     "d": "kagi.com",
-    "t": "ai-expert",
+    "t": "expert",
     "u": "/assistant?q={{{s}}}&mode=7&sub_mode=2",
     "fmt": [
       "url_encode_placeholder",
@@ -142,7 +142,17 @@
   {
     "s": "Kagi Assistant - Code",
     "d": "kagi.com",
-    "t": "kcode",
+    "t": "askc",
+    "u": "/assistant?q={{{s}}}&mode=5",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Kagi Assistant - Code",
+    "d": "kagi.com",
+    "t": "code",
     "u": "/assistant?q={{{s}}}&mode=5",
     "fmt": [
       "url_encode_placeholder",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -16858,7 +16858,7 @@
   {
     "s": "Search Code",
     "d": "www.searchco.de",
-    "t": "code",
+    "t": "sc",
     "u": "http://www.searchco.de/?q={{{s}}}&cs=on",
     "c": "Online Services",
     "sc": "Search (non-US)"
@@ -30200,7 +30200,7 @@
   {
     "s": "Expert",
     "d": "www.expert.nl",
-    "t": "expert",
+    "t": "expert-nl",
     "u": "https://www.expert.nl/catalogsearch/result/?q={{{s}}}",
     "c": "Shopping",
     "sc": "Online"

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -5126,7 +5126,7 @@
   {
     "s": "DuckDuckGo API",
     "d": "api.duckduckgo.com",
-    "t": "api",
+    "t": "ddg-api",
     "u": "https://api.duckduckgo.com/?q={{{s}}}&o=json&pretty=1&no_html=1&no_redirect=1",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -13330,7 +13330,7 @@
   {
     "s": "DuckDuckGo Calculator",
     "d": "duckduckgo.com",
-    "t": "calc",
+    "t": "ddg-calc",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=calculator",
     "c": "Online Services",
     "sc": "Tools"
@@ -13338,7 +13338,7 @@
   {
     "s": "DuckDuckGo Calculator",
     "d": "duckduckgo.com",
-    "t": "calculator",
+    "t": "ddg-calculator",
     "u": "https://duckduckgo.com/?ia=calculator&q={{{s}}}",
     "c": "Online Services",
     "sc": "Tools"
@@ -20204,7 +20204,7 @@
   {
     "s": "DuckDuckGo",
     "d": "duckduckgo.com",
-    "t": "day",
+    "t": "ddg-day",
     "u": "https://duckduckgo.com/?q={{{s}}}&df=d",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -44126,7 +44126,7 @@
   {
     "s": "DuckDuckGo Help",
     "d": "help.duckduckgo.com",
-    "t": "help",
+    "t": "ddg-help",
     "u": "https://help.duckduckgo.com/search?q={{{s}}}",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -46839,7 +46839,7 @@
   {
     "s": "DuckDuckGo Images",
     "d": "duckduckgo.com",
-    "t": "i",
+    "t": "ddg-i",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=images&iax=images",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -47381,7 +47381,7 @@
   {
     "s": "DuckDuckGo Images",
     "d": "duckduckgo.com",
-    "t": "image",
+    "t": "ddg-image",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=images&iax=images",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -47421,7 +47421,7 @@
   {
     "s": "DuckDuckGo Images",
     "d": "duckduckgo.com",
-    "t": "images",
+    "t": "ddg-images",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=images&iax=images",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -47581,7 +47581,7 @@
   {
     "s": "DuckDuckGo Images",
     "d": "duckduckgo.com",
-    "t": "img",
+    "t": "ddg-img",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=images&iax=images",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -47613,7 +47613,7 @@
   {
     "s": "DuckDuckGo Images",
     "d": "duckduckgo.com",
-    "t": "imgs",
+    "t": "ddg-imgs",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=images&iax=images",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -58097,14 +58097,6 @@
     "sc": "Maps"
   },
   {
-    "s": "Google Maps",
-    "d": "maps.google.com",
-    "t": "map",
-    "u": "https://maps.google.com/maps?q={{{s}}}",
-    "c": "Online Services",
-    "sc": "Maps"
-  },
-  {
     "s": "Mapion",
     "d": "www.mapion.co.jp",
     "t": "mapion",
@@ -58151,14 +58143,6 @@
     "u": "https://maps.google.com/maps?hl=fr&q={{{s}}}",
     "c": "Research",
     "sc": "Travel"
-  },
-  {
-    "s": "Google Maps",
-    "d": "google.com",
-    "t": "maps",
-    "u": "https://google.com/maps?q={{{s}}}",
-    "c": "Online Services",
-    "sc": "Maps"
   },
   {
     "s": "Google Maps Directions",
@@ -59189,14 +59173,6 @@
     "sc": "Movies"
   },
   {
-    "s": "Minecraft Wiki (deutsch)",
-    "d": "de.minecraft.wiki",
-    "t": "mcde",
-    "u": "https://de.minecraft.wiki/?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (Minecraft)"
-  },
-  {
     "s": "German Minecraft Wiki",
     "d": "de.minecraftwiki.net",
     "t": "mcwikide",
@@ -59782,7 +59758,7 @@
   },
   {
     "s": "MELPA",
-    "d": "melpa.milkbox.net",
+    "d": "melpa.org",
     "t": "melpa",
     "u": "https://melpa.org/#/?q={{{s}}}",
     "c": "Online Services",
@@ -60475,14 +60451,6 @@
     "sc": "Weather"
   },
   {
-    "s": "Google Maps",
-    "d": "maps.google.com",
-    "t": "m",
-    "u": "https://maps.google.com/maps?q={{{s}}}",
-    "c": "Online Services",
-    "sc": "Maps"
-  },
-  {
     "s": "Managementboek.nl",
     "d": "www.managementboek.nl",
     "t": "mgtbk",
@@ -60769,22 +60737,6 @@
     "u": "https://www.minds.com/search;q={{{s}}}",
     "c": "Online Services",
     "sc": "Social"
-  },
-  {
-    "s": "Minecraft Wiki (deutsch)",
-    "d": "de.minecraft.wiki",
-    "t": "mcde",
-    "u": "https://de.minecraft.wiki/?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (Minecraft)"
-  },
-  {
-    "s": "Minecraft Wiki (deutsch)",
-    "d": "de.minecraft.wiki",
-    "t": "mcde",
-    "u": "https://de.minecraft.wiki/?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (Minecraft)"
   },
   {
     "s": "Official Minecraft Wiki",
@@ -61995,7 +61947,7 @@
   {
     "s": "DuckDuckGo",
     "d": "duckduckgo.com",
-    "t": "month",
+    "t": "ddg-month",
     "u": "https://duckduckgo.com/?q={{{s}}}&df=m",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -65289,7 +65241,7 @@
   {
     "s": "DuckDuckGo News",
     "d": "duckduckgo.com",
-    "t": "news",
+    "t": "ddg-news",
     "u": "https://duckduckgo.com/?q={{{s}}}&iar=news&ia=news",
     "c": "News",
     "sc": "Aggregators"
@@ -65960,7 +65912,7 @@
   },
   {
     "s": "NixOS options",
-    "d": "nixos.org",
+    "d": "search.nixos.org",
     "t": "nixopt",
     "u": "https://search.nixos.org/options?query={{{s}}}",
     "c": "Tech",
@@ -71557,14 +71509,6 @@
     "sc": "Audio"
   },
   {
-    "s": "PDFs",
-    "d": "kagi.com",
-    "t": "pdf",
-    "u": "/search?q={{{s}}}+filetype:pdf",
-    "c": "Online Services",
-    "sc": "Search"
-  },
-  {
     "s": "PrintFriendly & PDF",
     "d": "www.printfriendly.com",
     "t": "pdfy",
@@ -72519,7 +72463,7 @@
   {
     "s": "DuckDuckGo Images",
     "d": "duckduckgo.com",
-    "t": "pics",
+    "t": "ddg-pics",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=images&iax=images",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -72535,7 +72479,7 @@
   {
     "s": "DuckDuckGo Images",
     "d": "duckduckgo.com",
-    "t": "pictures",
+    "t": "ddg-pictures",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=images&iax=images",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -73651,14 +73595,6 @@
     "u": "https://emonitoring.poczta-polska.pl/?numer={{{s}}}",
     "c": "Online Services",
     "sc": "Tracking"
-  },
-  {
-    "s": "Listen Notes",
-    "d": "www.listennotes.com",
-    "t": "podcast",
-    "u": "https://www.listennotes.com/search/?q={{{s}}}&sort_by_date=0",
-    "c": "Multimedia",
-    "sc": "General"
   },
   {
     "s": "podCloud",
@@ -77893,7 +77829,7 @@
   {
     "s": "DuckDuckGo Last Week",
     "d": "duckduckgo.com",
-    "t": "recent",
+    "t": "ddg-recent",
     "u": "https://duckduckgo.com/?q={{{s}}}&df=w",
     "c": "Online Services",
     "sc": "Search"
@@ -80359,14 +80295,6 @@
     "u": "https://rosettacode.org/w/index.php?search={{{s}}}&title=Special%3ASearch&wprov=acrw1",
     "c": "Tech",
     "sc": "Programming"
-  },
-  {
-    "s": "The RuneScape Wiki",
-    "d": "runescape.wiki",
-    "t": "rs",
-    "u": "https://runescape.wiki/?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (specific)"
   },
   {
     "s": "Reddit Subreddit",
@@ -83373,14 +83301,6 @@
     "u": "https://www.suomienglantisanakirja.fi/{{{s}}}",
     "c": "Research",
     "sc": "Learning"
-  },
-  {
-    "s": "StackExchange",
-    "d": "stackexchange.com",
-    "t": "se",
-    "u": "https://stackexchange.com/search?q={{{s}}}",
-    "c": "Online Services",
-    "sc": "Search"
   },
   {
     "s": "Setlist.fm",
@@ -92487,7 +92407,7 @@
   {
     "s": "DuckDuckGo Timer",
     "d": "duckduckgo.com",
-    "t": "tim",
+    "t": "ddg-tim",
     "u": "https://duckduckgo.com/?q=timer+{{{s}}}&ia=answer",
     "c": "Online Services",
     "sc": "Tools"
@@ -92511,7 +92431,7 @@
   {
     "s": "DuckDuckGo Timer",
     "d": "duckduckgo.com",
-    "t": "timer",
+    "t": "ddg-timer",
     "u": "https://duckduckgo.com/?q=timer+{{{s}}}&ia=answer",
     "c": "Online Services",
     "sc": "Tools"
@@ -98065,7 +97985,7 @@
   {
     "s": "DuckDuckGo video search",
     "d": "duckduckgo.com",
-    "t": "v",
+    "t": "ddg-v",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=videos&iax=videos",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -98625,7 +98545,7 @@
   {
     "s": "DuckDuckGo video search",
     "d": "duckduckgo.com",
-    "t": "video",
+    "t": "ddg-video",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=videos&iax=videos",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -98657,7 +98577,7 @@
   {
     "s": "DuckDuckGo Videos",
     "d": "duckduckgo.com",
-    "t": "videos",
+    "t": "ddg-videos",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=videos&iax=1",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -98681,7 +98601,7 @@
   {
     "s": "DuckDuckGo Videos",
     "d": "duckduckgo.com",
-    "t": "vids",
+    "t": "ddg-vids",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=videos&iax=videos",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -100948,7 +100868,7 @@
   {
     "s": "DuckDuckGo",
     "d": "duckduckgo.com",
-    "t": "week",
+    "t": "ddg-week",
     "u": "https://duckduckgo.com/?q={{{s}}}&df=w",
     "c": "Online Services",
     "sc": "Search (DDG)"

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -2818,7 +2818,7 @@
   {
     "s": "www.amazon.in",
     "d": "www.amazon.in",
-    "t": "ai",
+    "t": "azi",
     "u": "https://www.amazon.in/s?k={{{s}}} ",
     "c": "Shopping",
     "sc": "Online (deals)"
@@ -4862,14 +4862,6 @@
     "sc": "Companies"
   },
   {
-    "s": "Yahoo! Answers",
-    "d": "answers.yahoo.com",
-    "t": "answer",
-    "u": "http://answers.yahoo.com/search/search_result;_ylt=AmLr_DtDPVmDQzOuA2T6sxAjzKIX;_ylv=3?p={{{s}}}&submit-go=Search+Y!+Answers",
-    "c": "Online Services",
-    "sc": "Search"
-  },
-  {
     "s": "Antiwar.com",
     "d": "news.antiwar.com",
     "t": "antiwar",
@@ -6452,7 +6444,7 @@
   {
     "s": "Amazon Smile",
     "d": "smile.amazon.com",
-    "t": "as",
+    "t": "azs",
     "u": "https://smile.amazon.com/s?url=search-alias%3Daps&field-keywords={{{s}}}",
     "c": "Shopping",
     "sc": "Online"
@@ -6844,7 +6836,7 @@
   {
     "s": "Addictive Tips",
     "d": "www.addictivetips.com",
-    "t": "at",
+    "t": "addtips",
     "u": "http://www.addictivetips.com/archives/search/?cx=015974260755795457590%3Akigcmyffu6y&cof=FORID%3A11&ie=UTF-8&q={{{s}}}&s=Search",
     "c": "Tech",
     "sc": "Blogs"
@@ -9082,7 +9074,7 @@
   {
     "s": "Block Explorer",
     "d": "blockexplorer.com",
-    "t": "be",
+    "t": "blockexplorer",
     "u": "https://blockexplorer.com/searchgo/{{{s}}}",
     "c": "Tech",
     "sc": "Tools"
@@ -11954,7 +11946,7 @@
   {
     "s": "Baseball-Reference",
     "d": "www.baseball-reference.com",
-    "t": "br",
+    "t": "baseball",
     "u": "https://www.baseball-reference.com/pl/player_search.cgi?search={{{s}}}",
     "c": "Research",
     "sc": "Reference"
@@ -13162,7 +13154,7 @@
   {
     "s": "Amazon Canada",
     "d": "www.amazon.ca",
-    "t": "ca",
+    "t": "azca",
     "u": "https://www.amazon.ca/s?k={{{s}}}",
     "c": "Shopping",
     "sc": "Online"
@@ -15130,7 +15122,7 @@
   {
     "s": "Chequeado",
     "d": "chequeado.com",
-    "t": "ch",
+    "t": "chequeado",
     "u": "https://chequeado.com/?s={{{s}}}",
     "c": "Research",
     "sc": "Government"
@@ -16534,14 +16526,6 @@
     "u": "http://search.cnbc.com/main.do?target=all&keywords={{{s}}}",
     "c": "News",
     "sc": "Broadcast"
-  },
-  {
-    "s": "Charity Navigator",
-    "d": "www.charitynavigator.org",
-    "t": "cn",
-    "u": "https://www.charitynavigator.org/index.cfm?bay=search.results&keyword_list={{{s}}}",
-    "c": "Research",
-    "sc": "Topical"
   },
   {
     "s": "Naver Chinese Dictionary",
@@ -19540,7 +19524,7 @@
   {
     "s": "The Complexity Zoo",
     "d": "complexityzoo.uwaterloo.ca",
-    "t": "cz",
+    "t": "compzoo",
     "u": "https://complexityzoo.uwaterloo.ca/index.php?search={{{s}}}&title=Special%3ASearch",
     "c": "Research",
     "sc": "Academic (math/cs)"
@@ -21610,7 +21594,7 @@
   {
     "s": "German",
     "d": "dict.tu-chemnitz.de",
-    "t": "de",
+    "t": "dict-de",
     "u": "https://dict.tu-chemnitz.de/dings.cgi?query={{{s}}}",
     "c": "Research",
     "sc": "Reference (words intl)"
@@ -23328,14 +23312,6 @@
     "u": "https://www.digikey.ca/product-search/en?x=-1308&y=-74&lang=en&site=ca&KeyWords={{{s}}} ",
     "c": "Shopping",
     "sc": "Tech"
-  },
-  {
-    "s": "docker hub",
-    "d": "store.docker.com",
-    "t": "dk",
-    "u": "https://store.docker.com/search?q={{{s}}}",
-    "c": "Tech",
-    "sc": "Sysadmin"
   },
   {
     "s": "Digikey ES",
@@ -29120,7 +29096,7 @@
   {
     "s": "duckduckgo",
     "d": "duckduckgo.com",
-    "t": "es",
+    "t": "ddg-es",
     "u": "https://duckduckgo.com/?q={{{s}}}&kl=xl-es&kad=es_ES&ia=about",
     "c": "Online Services",
     "sc": "Search (non-US)"
@@ -33958,7 +33934,7 @@
   {
     "s": "Larousse French Dictionary",
     "d": "www.larousse.fr",
-    "t": "fr",
+    "t": "dict-fr",
     "u": "https://www.larousse.fr/dictionnaires/francais/{{{s}}}",
     "c": "Tech",
     "sc": "Programming"
@@ -35352,7 +35328,7 @@
   {
     "s": "Google Books",
     "d": "books.google.com",
-    "t": "gb",
+    "t": "gbks",
     "u": "https://books.google.com/books?q={{{s}}}&btnG=Search+Books",
     "c": "Multimedia",
     "sc": "Books"
@@ -45836,7 +45812,7 @@
   {
     "s": "HealthUnlocked",
     "d": "healthunlocked.com",
-    "t": "hu",
+    "t": "hun",
     "u": "https://healthunlocked.com/search/{{{s}}}",
     "c": "Online Services",
     "sc": "Social (intl)"
@@ -47287,7 +47263,7 @@
   {
     "s": "DuckDuckGo Images",
     "d": "duckduckgo.com",
-    "t": "il",
+    "t": "ddg-il",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=images&iax=images&iaf=size%3Aimagesize-large",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -48333,7 +48309,7 @@
   {
     "s": "Internazionale",
     "d": "www.internazionale.it",
-    "t": "int",
+    "t": "intl",
     "u": "https://www.internazionale.it/search/?q={{{s}}}",
     "c": "News",
     "sc": "International"
@@ -49085,7 +49061,7 @@
   {
     "s": "DuckDuckGo Italy",
     "d": "duckduckgo.com",
-    "t": "it",
+    "t": "ddg-it",
     "u": "https://duckduckgo.com/?q={{{s}}}&kl=it-it",
     "c": "Online Services",
     "sc": "Search (DDG)"
@@ -50491,14 +50467,6 @@
     "u": "https://www.kanjijapanese.com/en/dictionary-japanese-english/{{{s}}}",
     "c": "Research",
     "sc": "Reference (words)"
-  },
-  {
-    "s": "Jet Pens",
-    "d": "www.jetpens.com",
-    "t": "jp",
-    "u": "https://www.jetpens.com/search?q={{{s}}}",
-    "c": "Shopping",
-    "sc": "Online"
   },
   {
     "s": "We Sell Car Plate Number Online, Malaysia",
@@ -52223,7 +52191,7 @@
   {
     "s": "Konsolentreff.de",
     "d": "www.konsolentreff.de",
-    "t": "k",
+    "t": "kon",
     "u": "https://www.konsolentreff.de/search/1/?q={{{s}}}",
     "c": "Entertainment",
     "sc": "Forum"
@@ -64713,7 +64681,7 @@
   {
     "s": "DuckDuckGo News",
     "d": "duckduckgo.com",
-    "t": "n",
+    "t": "ddg-n",
     "u": "https://duckduckgo.com/?q={{{s}}}&iar=news&ia=news",
     "c": "News",
     "sc": "Aggregators"
@@ -66045,14 +66013,6 @@
     "u": "https://translate.google.com/#nl/en/{{{s}}}",
     "c": "Online Services",
     "sc": "Google"
-  },
-  {
-    "s": "http://ncatlab.org/nlab/show/HomePage",
-    "d": "ncatlab.org",
-    "t": "nl",
-    "u": "https://ncatlab.org/nlab/search?query={{{s}}}",
-    "c": "Research",
-    "sc": "Academic (math/cs)"
   },
   {
     "s": "Nintendo Life",
@@ -73199,7 +73159,7 @@
   {
     "s": "Public Lab",
     "d": "publiclab.org",
-    "t": "pl",
+    "t": "plab",
     "u": "https://publiclab.org/search/{{{s}}}",
     "c": "Research",
     "sc": "Reference (science)"
@@ -74491,14 +74451,6 @@
     "sc": "Learning (intl)"
   },
   {
-    "s": "Pinterest",
-    "d": "www.pinterest.com",
-    "t": "p",
-    "u": "https://www.pinterest.com/search/pins/?q={{{s}}}",
-    "c": "Multimedia",
-    "sc": "Images"
-  },
-  {
     "s": "Plymouth (Indiana) Public Library",
     "d": "plymouthpubliclibrary.bibliocommons.com",
     "t": "ppl",
@@ -75579,14 +75531,6 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Power Thesaurus ",
-    "d": "www.powerthesaurus.org",
-    "t": "pt",
-    "u": "https://www.powerthesaurus.org/{{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
     "s": "Pro Tool Reviews",
     "d": "www.protoolreviews.com",
     "t": "ptr",
@@ -76405,7 +76349,7 @@
   {
     "s": "Quora",
     "d": "www.quora.com",
-    "t": "q",
+    "t": "qu",
     "u": "https://www.quora.com/search?q={{{s}}}",
     "c": "Online Services",
     "sc": "Search"
@@ -78517,7 +78461,7 @@
   {
     "s": "PLOS",
     "d": "journals.plos.org",
-    "t": "research",
+    "t": "plos",
     "u": "https://journals.plos.org/plosone/search?unformattedQuery=everything:\"{{{s}}}\"",
     "c": "Research",
     "sc": "Academic"
@@ -84281,7 +84225,7 @@
   {
     "s": "Sports Illustrated",
     "d": "www.si.com",
-    "t": "si",
+    "t": "sportsi",
     "u": "https://www.si.com/search?q={{{s}}}",
     "c": "Entertainment",
     "sc": "Sports"
@@ -88655,7 +88599,7 @@
   {
     "s": "Dictionary of Ukrainian Language (Словник української мови)",
     "d": "sum.in.ua",
-    "t": "sum",
+    "t": "dict-ua",
     "u": "https://sum.in.ua/?swrd={{{s}}} ",
     "c": "Online Services",
     "sc": "Search (non-US)"
@@ -97243,7 +97187,7 @@
   {
     "s": "Userstyles.org",
     "d": "userstyles.org",
-    "t": "us",
+    "t": "ust",
     "u": "https://userstyles.org/styles/browse?search_terms={{{s}}}",
     "c": "Online Services",
     "sc": "Tools"

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -31319,7 +31319,7 @@
   },
   {
     "s": "FedEx",
-    "d": "fedex.com",
+    "d": "www.fedex.com",
     "t": "fedex",
     "u": "https://www.fedex.com/fedextrack/?trknbr={{{s}}}"
   },
@@ -58522,7 +58522,7 @@
   },
   {
     "s": "MatPrat",
-    "d": "matprat.no",
+    "d": "www.matprat.no",
     "t": "matprat",
     "u": "https://www.matprat.no/sok/#1/all/{{{s}}}/",
     "c": "Research",
@@ -98688,7 +98688,7 @@
   },
   {
     "s": "Vinmonopolet",
-    "d": "vinmonopolet.no",
+    "d": "www.vinmonopolet.no",
     "t": "vinmonopolet",
     "u": "https://www.vinmonopolet.no/search?q={{{s}}}",
     "c": "Shopping",
@@ -98696,7 +98696,7 @@
   },
   {
     "s": "Vinmonopolet",
-    "d": "vinmonopolet.no",
+    "d": "www.vinmonopolet.no",
     "t": "polet",
     "u": "https://www.vinmonopolet.no/search?q={{{s}}}",
     "c": "Shopping",

--- a/data/kagi_bangs.json
+++ b/data/kagi_bangs.json
@@ -174,15 +174,9 @@
     "u": "/podcasts?q={{{s}}}"
   },
   {
-    "s": "Kagi Quick Answer",
-    "d": "kagi.com",
-    "t": "answer",
-    "u": "/search?q={{{s}}}&qa=true"
-  },
-  {
     "s": "Kagi Discussion",
     "d": "kagi.com",
-    "t": "discuss",
+    "t": "discussdoc",
     "u": "/discussdoc?url={{{s}}}"
   },
   {

--- a/data/kagi_bangs.json
+++ b/data/kagi_bangs.json
@@ -188,7 +188,7 @@
   {
     "s": "Kagi FastGPT",
     "d": "kagi.com",
-    "t": "fast",
+    "t": "fgpt",
     "u": "/fastgpt?query={{{s}}}"
   },
   {

--- a/spec/bangs_spec.rb
+++ b/spec/bangs_spec.rb
@@ -1,0 +1,82 @@
+require "json"
+require "rspec"
+require "addressable"
+
+bangs_json = JSON.parse(File.read("data/bangs.json"))
+bang_triggers = bangs_json.map{|b| b["t"]}
+
+kagi_bangs_json = JSON.parse(File.read("data/kagi_bangs.json"))
+kagi_triggers = kagi_bangs_json.map{|b| b["t"]}
+
+assist_bangs_json = JSON.parse(File.read("data/assistant_bangs.json"))
+assistant_triggers = assist_bangs_json.map{|b| b["t"]}
+
+def find_dups(*arr)
+  arr.map{ |a| a.uniq }
+    .flatten
+    .group_by { |element| element }
+    .select { |k, v| v.size > 1 }
+    .keys
+end
+
+def match_domains(bangs)
+  bangs.each do |bang|
+    next if bang["u"].start_with?("/")
+
+    it "domains match template urls (#{bang["s"]})" do
+      template = bang["u"].gsub("{{{s}}}", "example").gsub("www.", "")
+      uri = Addressable::URI.parse(template)
+      domain = bang["d"].gsub("{{{s}}}", "example").gsub("www.", "")
+
+      expect(domain).to eq(uri.host)
+    end
+  end
+end
+
+describe "bangs.json" do
+  it "doesn't have duplicate bang triggers" do
+    dups = find_dups(bang_triggers)
+
+    expect(dups).to be_empty, "Duplicate(s) found: #{dups.join(", ")}"
+  end
+
+  it "and kagi_bangs.json don't have duplicate bang triggers" do
+    dups = find_dups(bang_triggers, kagi_triggers)
+
+    expect(dups).to be_empty, "Duplicate(s) found: #{dups.join(", ")}"
+  end
+
+  it "and assist_bangs.json don't have duplicate bang triggers" do
+    dups = find_dups(bang_triggers, assistant_triggers)
+
+    expect(dups).to be_empty, "Duplicate(s) found: #{dups.join(", ")}"
+  end
+
+  match_domains(bangs_json)
+end
+
+describe "kagi_bangs.json" do
+  it "doesn't have duplicate bang triggers" do
+    dups = find_dups(kagi_triggers)
+
+    expect(dups).to be_empty, "Duplicate(s) found: #{dups.join(", ")}"
+  end
+
+  it "and assistant_bangs.json don't have duplicate bang triggers" do
+    dups = find_dups(kagi_triggers, assistant_triggers)
+
+    expect(dups).to be_empty, "Duplicate trigger(s) found: #{dups.join(", ")}"
+  end
+
+  match_domains(kagi_bangs_json)
+end
+
+describe "assistant_bangs.json" do
+  it "doesn't have duplicate bang triggers" do
+    dups = find_dups(assistant_triggers)
+
+    expect(dups).to be_empty, "Duplicate(s) found: #{dups.join(", ")}"
+  end
+
+  match_domains(assist_bangs_json)
+end

--- a/spec/bangs_spec.rb
+++ b/spec/bangs_spec.rb
@@ -24,9 +24,9 @@ def match_domains(bangs)
     next if bang["u"].start_with?("/")
 
     it "domains match template urls (#{bang["s"]})" do
-      template = bang["u"].gsub("{{{s}}}", "example").gsub("www.", "")
+      template = bang["u"].gsub("{{{s}}}", "example")
       uri = Addressable::URI.parse(template)
-      domain = bang["d"].gsub("{{{s}}}", "example").gsub("www.", "")
+      domain = bang["d"].gsub("{{{s}}}", "example")
 
       expect(domain).to eq(uri.host)
     end


### PR DESCRIPTION
This pull requests adds some RSpec tests for use in CI, allowing for better verification of bangs. These do things such as:
- Verifying the domain field matches the domain in the template field
- Ensuring no overlapping/duplicate bangs within each bangs file, and between the bangs files

As well, this PR adds the assistant bangs, and modifies some bangs to remove duplicates.