### PR TITLE
Add bangs for Typst

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -95357,6 +95357,22 @@
     "sc": "Tools"
   },
   {
+    "s": "Typst Documentation",
+    "d": "kagi.com",
+    "t": "typst",
+    "u": "/search?q={{{s}}}+site%3Atypst.app%2Fdocs",
+    "c": "Tech",
+    "sc": "Languages (other)"
+  },
+  {
+    "s": "Typst Universe",
+    "d": "typst.app",
+    "t": "typstu",
+    "u": "https://typst.app/universe/search?q={{{s}}}",
+    "c": "Tech",
+    "sc": "Languages (other)"
+  },
+  {
     "s": "YouTube",
     "d": "www.youtube.com",
     "t": "ty",


### PR DESCRIPTION
Typst is “A new markup-based typesetting system that is powerful and easy to learn.”

This PR adds a bang to search its documentation `!typst`, as well as one to look for packages `!typstu`.

In the future, I intend to change the documentation search to use Typst's own site directly, but at the moment you can't pass query parameters, so, Kagi with `site:` it is.