### PR TITLE
Add !tine for tine.no

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -92495,6 +92495,14 @@
     "sc": "Online"
   },
   {
+    "s": "Tine",
+    "d": "www.tine.no",
+    "t": "tine",
+    "u": "https://www.tine.no/sok?q={{{s}}}",
+    "c": "Research",
+    "sc": "Food"
+  },
+  {
     "s": "Tineye",
     "d": "www.tineye.com",
     "t": "tineye",


### PR DESCRIPTION
Adds `!tine` for recipes and articles from the Norwegian dairy product cooperative Tine (https://www.tine.no)