### PR TITLE
Add Nixpkgs, NixOS Options, and Noogle bangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ No corresponding subcategories.
   - Languages (scala)
   - Languages (scheme)
   - Languages (vala)
+  - Languages (nix)
   - Libraries/Frameworks
   - Libraries/Frameworks (KDE)
   - Libraries/Frameworks (wordpress)

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -108588,5 +108588,29 @@
     "u": "https://app.thestorygraph.com/browse?search_term={{{s}}}",
     "c": "Multimedia",
     "sc": "Books"
+  },
+  {
+    "s": "Nixpkgs Search",
+    "d": "search.nixos.org",
+    "t": "nixpkgs",
+    "u": "https://search.nixos.org/packages?query={{{s}}}",
+    "c": "Tech",
+    "sc": "Languages (nix)"
+  },
+  {
+    "s": "NixOS Options Search",
+    "d": "search.nixos.org",
+    "t": "nixos",
+    "u": "https://search.nixos.org/options?query={{{s}}}",
+    "c": "Tech",
+    "sc": "Languages (nix)"
+  },
+  {
+    "s": "Noogle Nix Function Search",
+    "d": "noogle.dev",
+    "t": "noogle",
+    "u": "https://noogle.dev/q?term={{{s}}}",
+    "c": "Tech",
+    "sc": "Languages (nix)"
   }
 ]


### PR DESCRIPTION
Adds bangs for:

- [Nixpkgs Search](https://search.nixos.org/packages)
- [NixOS Options Search](https://search.nixos.org/options)
- [Noogle (Nix Function Search)](https://noogle.dev)