### PR TITLE
Adding listennotes.com

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -53239,6 +53239,14 @@
     "sc": "Programming"
   },
   {
+    "s": "Listen Notes",
+    "d": "www.listennotes.com",
+    "t": "lns",
+    "u": "https://www.listennotes.com/search/?q={{{s}}}",
+    "c": "Entertainment",
+    "s": "Audio"
+  },
+  {
     "s": "Love2D Wiki",
     "d": "www.love2d.org",
     "t": "l2d",


### PR DESCRIPTION
Adding a bang search for https://www.listennotes.com/, a full text podcast search engine.