### PR TITLE
Add codeberg.org search

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -16794,6 +16794,14 @@
     "sc": "Companies"
   },
   {
+    "s": "Codeberg",
+    "d": "codeberg.org",
+    "t": "codeberg",
+    "u": "https://codeberg.org/explore/repos?q={{{s}}}",
+    "c": "Tech",
+    "sc": "Programming"
+  },
+  {
     "s": "CodeBottle",
     "d": "codebottle.io",
     "t": "codebottle",


### PR DESCRIPTION
Codeberg.org is a FOSS alternative to GitHub, hosting over 125,000 open source projects.

This PR adds a `!codeberg` bang to search through all public repositories hosted on codeberg.org.