### PR TITLE
Update RSpec tests to detect duplicate triggers in same file and fix duplicate triggers

### DIFF
--- a/data/assistant_bangs.json
+++ b/data/assistant_bangs.json
@@ -62,16 +62,6 @@
   {
     "s": "Kagi Assistant - Research",
     "d": "kagi.com",
-    "t": "research",
-    "u": "/assistant?q={{{s}}}&mode=7",
-    "fmt": [
-      "url_encode_placeholder",
-      "url_encode_space_to_plus"
-    ]
-  },
-  {
-    "s": "Kagi Assistant - Research",
-    "d": "kagi.com",
     "t": "asks",
     "u": "/assistant?q={{{s}}}&mode=7",
     "fmt": [

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -6442,14 +6442,6 @@
     "sc": "Newspaper (intl)"
   },
   {
-    "s": "Amazon Smile",
-    "d": "smile.amazon.com",
-    "t": "azs",
-    "u": "https://smile.amazon.com/s?url=search-alias%3Daps&field-keywords={{{s}}}",
-    "c": "Shopping",
-    "sc": "Online"
-  },
-  {
     "s": "Asana",
     "d": "app.asana.com",
     "t": "asana",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -65965,14 +65965,6 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "NixOS options",
-    "d": "search.nixos.org",
-    "t": "nixopt",
-    "u": "https://search.nixos.org/options?query={{{s}}}",
-    "c": "Tech",
-    "sc": "Sysadmin"
-  },
-  {
     "s": "NixOS Wiki",
     "d": "wiki.nixos.org",
     "t": "nix",
@@ -66003,14 +65995,6 @@
     "u": "https://nixos.org/nixos/packages.html?query={{{s}}}",
     "c": "Tech",
     "sc": "Downloads"
-  },
-  {
-    "s": "NixOS Packages",
-    "d": "nixos.org",
-    "t": "nixpkgs",
-    "u": "https://nixos.org/nixos/packages.html?query={{{s}}}",
-    "c": "Tech",
-    "sc": "Sysadmin"
   },
   {
     "s": "Nixtodon",
@@ -108642,7 +108626,7 @@
     "sc": "Books"
   },
   {
-    "s": "Nixpkgs Search",
+    "s": "NixOS Packages Search",
     "d": "search.nixos.org",
     "t": "nixpkgs",
     "u": "https://search.nixos.org/packages?query={{{s}}}",
@@ -108652,7 +108636,7 @@
   {
     "s": "NixOS Options Search",
     "d": "search.nixos.org",
-    "t": "nixos",
+    "t": "nixopt",
     "u": "https://search.nixos.org/options?query={{{s}}}",
     "c": "Tech",
     "sc": "Languages (nix)"

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -46727,14 +46727,6 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Idealo",
-    "d": "www.idealo.de",
-    "t": "idealo",
-    "u": "https://www.idealo.de/preisvergleich/MainSearchProductCategory.html?q={{{s}}}",
-    "c": "Shopping",
-    "sc": "Services"
-  },
-  {
     "s": "I Do Imaging",
     "d": "idoimaging.com",
     "t": "idi",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -16858,14 +16858,6 @@
     "sc": "Tools"
   },
   {
-    "s": "Search Code",
-    "d": "www.searchco.de",
-    "t": "sc",
-    "u": "http://www.searchco.de/?q={{{s}}}&cs=on",
-    "c": "Online Services",
-    "sc": "Search (non-US)"
-  },
-  {
     "s": "Codeweavers",
     "d": "www.codeweavers.com",
     "t": "codeweavers",

--- a/spec/bangs_spec.rb
+++ b/spec/bangs_spec.rb
@@ -12,8 +12,7 @@ assist_bangs_json = JSON.parse(File.read("data/assistant_bangs.json"))
 assistant_triggers = assist_bangs_json.map{|b| b["t"]}
 
 def find_dups(*arr)
-  arr.map{ |a| a.uniq }
-    .flatten
+  arr.flatten
     .group_by { |element| element }
     .select { |k, v| v.size > 1 }
     .keys


### PR DESCRIPTION
I noticed duplicate triggers in the same file while parsing the JSON for another purpose. This PR updates the RSpec tests to detect this scenario, and fixes up the duplicate triggers.

The change in 7e43d305ddbd371e42025201d44047b8af380945 assumes that this scenario should be invalid. The `uniq` caused it to deduplicate triggers in the same JSON file. It would only detect duplicate triggers if they appeared across JSON files.

The following commits are consolidating the duplicates as best as I could.