### PR TITLE
Do not URL encode GitHub repos

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -36867,7 +36867,8 @@
     "t": "ghrepo",
     "u": "https://github.com/{{{s}}}",
     "c": "Tech",
-    "sc": "Programming"
+    "sc": "Programming",
+    "fmt": ["open_base_path"]
   },
   {
     "s": "Github",


### PR DESCRIPTION
By default, the `/` in a GitHub repo path will be URL encoded, resulting in an incorrect URL.