### PR TITLE
Add scoop

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -82302,12 +82302,12 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Scoop.it",
-    "d": "www.scoop.it",
+    "s": "Scoop",
+    "d": "scoop.sh",
     "t": "scoop",
-    "u": "https://www.scoop.it/search?q={{{s}}}",
-    "c": "Online Services",
-    "sc": "Social"
+    "u": "https://scoop.sh/#/apps?q={{{s}}}",
+    "c": "Tech",
+    "sc": "Downloads (software)"
   },
   {
     "s": "scope.dk",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -82302,6 +82302,14 @@
     "sc": "Reference (words intl)"
   },
   {
+    "s": "Scoop.it",
+    "d": "www.scoop.it",
+    "t": "scoop-it",
+    "u": "https://www.scoop.it/search?q={{{s}}}",
+    "c": "Online Services",
+    "sc": "Social"
+  },
+  {
     "s": "Scoop",
     "d": "scoop.sh",
     "t": "scoop",


### PR DESCRIPTION
Scoop is a popular command-line installer for Windows. This PR replaces the existing `!scoop` for `www.scoop.it` because the website appears to be low-traffic.