### PR TITLE
Update URL template for UNC-CH library search

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -96046,7 +96046,7 @@
     "s": "University of North Carolina at Chapel Hill Library",
     "d": "library.unc.edu",
     "t": "unclib",
-    "u": "https://library.unc.edu/find/combinedresults/?Ntt={{{s}}}&Ntk=Keyword",
+    "u": "https://library.unc.edu/find/?q={{{s}}}",
     "c": "Research",
     "sc": "Academic"
   },


### PR DESCRIPTION
The University of North Carolina at Chapel Hill Library recently updated its website, breaking the existing `!unclib` bang. This PR fixes it.