### PR TITLE
Fix Pexels URL encoding

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -71818,7 +71818,10 @@
     "t": "pexels",
     "u": "http://www.pexels.com/search/{{{s}}}/",
     "c": "Multimedia",
-    "sc": "Images"
+    "sc": "Images",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
   },
   {
     "s": "Poinformowani",


### PR DESCRIPTION
Pexels uses `%20`-encoded spaces (e.g. https://www.pexels.com/search/search%20engine/ instead of https://www.pexels.com/search/search+engine/).