### PR TITLE
Add a bang for the official Predecessor wiki.

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -111323,5 +111323,13 @@
     "u": "https://ru.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Online Services",
     "sc": "Search"
+  },
+  {
+    "s": "Predecessor Official Wiki",
+    "d": "predecessor.wiki.gg",
+    "t": "pred",
+    "u": "https://predecessor.wiki.gg/index.php?search={{{s}}}&title=Special%3ASearch&go=Go",
+    "c": "Entertainment",
+    "sc": "Games (specific)"
   }
 ]


### PR DESCRIPTION
This adds a bang to search the official wiki for [Predecessor](https://www.predecessorgame.com/), a MOBA by Omeda.  The tag chosen, `!pred`, is a very common community abbreviation for the game's title.