### PR TITLE
Remove Google Music

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -37108,14 +37108,6 @@
     "sc": "Google"
   },
   {
-    "s": "Google Music",
-    "d": "music.google.com",
-    "t": "gmusic",
-    "u": "https://music.google.com/music/listen?#{{{s}}}_sr",
-    "c": "Online Services",
-    "sc": "Google"
-  },
-  {
     "s": "Google",
     "d": "www.google.com.mx",
     "t": "gmx",


### PR DESCRIPTION
Google Music shutdown in 2020 (https://9to5google.com/2020/12/03/google-play-music-dead/), and the redirect to YouTube Music breaks the query as it simply redirects to the base URL