### PR TITLE
Fix Can I use… bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -13360,9 +13360,13 @@
     "s": "Can I use...",
     "d": "caniuse.com",
     "t": "caniuse",
-    "u": "https://caniuse.com/#search={{{s}}}",
+    "u": "https://caniuse.com/?search={{{s}}}",
     "c": "Tech",
-    "sc": "Languages (html)"
+    "sc": "Languages (html)",
+    "fmt": [
+      "open_base_path",
+      "url_encode_placeholder"
+    ]
   },
   {
     "s": "CanLII",


### PR DESCRIPTION
Fixes the `!caniuse` bang to use query strings for the search parameters (e.g. https://caniuse.com/?search=grid instead of https://caniuse.com/#search=grid), which is how the site now operates by default. The old hash links still work but are legacy and rewritten to the new format.

Also fixes space-encoding as Can I Use… natively uses %20-encoding for spaces rather than pluses.