### PR TITLE
Add JAX and FLAX docs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -48701,6 +48701,14 @@
     "sc": "Reference"
   },
   {
+    "s": "JAX Docs",
+    "d": "https://jax.readthedocs.io",
+    "t": "jax",
+    "u": "https://jax.readthedocs.io/en/latest/search.html?q={{{s}}}",
+    "c": "Tech",
+    "sc": "Languages (python)"
+  },
+  {
     "s": "Jaycar Electronics NZ",
     "d": "www.jaycar.co.nz",
     "t": "jaycar",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -31597,6 +31597,14 @@
     "sc": "Tools"
   },
   {
+    "s": "FLAX Docs",
+    "d": "https://flax.readthedocs.io/",
+    "t": "flax",
+    "u": "https://flax.readthedocs.io/en/latest/search.html?q={{{s}}}",
+    "c": "Tech",
+    "sc": "Languages (python)"
+  },
+  {
     "s": "Front Line Defenders",
     "d": "www.frontlinedefenders.org",
     "t": "fld",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -31598,7 +31598,7 @@
   },
   {
     "s": "FLAX Docs",
-    "d": "https://flax.readthedocs.io/",
+    "d": "flax.readthedocs.io/",
     "t": "flax",
     "u": "https://flax.readthedocs.io/en/latest/search.html?q={{{s}}}",
     "c": "Tech",
@@ -48710,7 +48710,7 @@
   },
   {
     "s": "JAX Docs",
-    "d": "https://jax.readthedocs.io",
+    "d": "jax.readthedocs.io",
     "t": "jax",
     "u": "https://jax.readthedocs.io/en/latest/search.html?q={{{s}}}",
     "c": "Tech",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -31598,7 +31598,7 @@
   },
   {
     "s": "FLAX Docs",
-    "d": "flax.readthedocs.io/",
+    "d": "flax.readthedocs.io",
     "t": "flax",
     "u": "https://flax.readthedocs.io/en/latest/search.html?q={{{s}}}",
     "c": "Tech",


### PR DESCRIPTION
JAX and FLAX are machine learning frameworks for Python made by Google, this searches their documentation.