### PR TITLE
Add Open Critic and KProfiles

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -51825,6 +51825,14 @@
     "sc": "Reference (words intl)"
   },
   {
+    "s": "KProfiles",
+    "d": "kprofiles.com",
+    "t": "kprofiles",
+    "u": "https://kprofiles.com/?s={{{s}}}",
+    "c": "Multimedia",
+    "sc": "Music"
+  },
+  {
     "s": "Kreativ Font",
     "d": "www.kreativfont.com",
     "t": "kreativfont",
@@ -67469,6 +67477,14 @@
     "u": "https://openclipart.org/search/?query={{{s}}}",
     "c": "Multimedia",
     "sc": "Images"
+  },
+  {
+    "s": "OpenCritic",
+    "d": "kagi.com",
+    "t": "opencritic",
+    "u": "/search?q={{{s}}}+site%3Aopencritic.com",
+    "c": "Online Services",
+    "sc": "Search"
   },
   {
     "s": "OpenCompanies",


### PR DESCRIPTION
Adding 2 websites:
OpenCritic, it's like MetaCritic, but specifically for games. They don't have a search inside the site, so i'm adding it as a site filter bang. (www.opencritic.com)

KProfiles, it's a K-Pop site with group profiles (www.kprofiles.com).