### PR TITLE
Use Yle Areena's on-site search

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -5816,7 +5816,7 @@
     "s": "Yle Areena",
     "d": "areena.yle.fi",
     "t": "areena",
-    "u": "https://areena.yle.fi/haku?q={{{s}}}",
+    "u": "https://areena.yle.fi/hae?q={{{s}}}&service=tv",
     "c": "Multimedia",
     "sc": "Video"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -5813,10 +5813,10 @@
     "sc": "Reference"
   },
   {
-    "s": "YLE Areena",
-    "d": "haku.yle.fi",
+    "s": "Yle Areena",
+    "d": "areena.yle.fi",
     "t": "areena",
-    "u": "https://haku.yle.fi/?q={{{s}}}&category=Areena",
+    "u": "https://areena.yle.fi/haku?q={{{s}}}",
     "c": "Multimedia",
     "sc": "Video"
   },


### PR DESCRIPTION
Switch to use Yle Areena's new in-app search. The old search still works, but the new one is preferred as it's more up-to-date and offers easier navigation to the rest of the app.

Also fix title casing for Yle Areena (see document title on [areena.yle.fi](https://areena.yle.fi/tv)).

I'm Yle employee working on Yle Areena web app.
