### PR TITLE
Add alternate domain for Yle

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -103560,8 +103560,9 @@
   {
     "s": "Yle",
     "d": "haku.yle.fi",
+    "ad": "yle.fi",
     "t": "yle",
-    "u": "https://haku.yle.fi/?language=fi&UILanguage=fi&q={{{s}}}",
+    "u": "https://haku.yle.fi/?query={{{s}}}",
     "c": "News",
     "sc": "Broadcast"
   },


### PR DESCRIPTION
Add an alternate domain for trigger `yle` that searches contents of domain yle.fi. haku.yle.fi domain only contains the search application for yle.fi ("<span lang="fi">haku</span>" means "search" in Finnish).

Also, update the query parameters to those currently in use.
