### PR TITLE
Add all Kagi News regions as bangs

### DIFF
--- a/data/kagi_bangs.json
+++ b/data/kagi_bangs.json
@@ -891,5 +891,2318 @@
       "open_base_path",
       "url_encode_placeholder"
     ]
+  },
+  {
+    "s": "News in International",
+    "d": "kagi.com",
+    "t": "knint",
+    "u": "/news?q={{s}}&r=no_region",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Albania (AL)",
+    "d": "kagi.com",
+    "t": "knal",
+    "u": "/news?q={{s}}&r=al",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Afghanistan (AF)",
+    "d": "kagi.com",
+    "t": "knaf",
+    "u": "/news?q={{s}}&r=af",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Algeria (DZ)",
+    "d": "kagi.com",
+    "t": "kndz",
+    "u": "/news?q={{s}}&r=dz",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in American Samoa (AS)",
+    "d": "kagi.com",
+    "t": "knas",
+    "u": "/news?q={{s}}&r=as",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Andorra (AD)",
+    "d": "kagi.com",
+    "t": "knad",
+    "u": "/news?q={{s}}&r=ad",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Angola (AO)",
+    "d": "kagi.com",
+    "t": "knao",
+    "u": "/news?q={{s}}&r=ao",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Anguilla (AI)",
+    "d": "kagi.com",
+    "t": "knai",
+    "u": "/news?q={{s}}&r=ai",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Antarctica (AQ)",
+    "d": "kagi.com",
+    "t": "knaq",
+    "u": "/news?q={{s}}&r=aq",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Antigua and Barbuda (AG)",
+    "d": "kagi.com",
+    "t": "knag",
+    "u": "/news?q={{s}}&r=ag",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Argentina (AR)",
+    "d": "kagi.com",
+    "t": "knar",
+    "u": "/news?q={{s}}&r=ar",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Armenia (AM)",
+    "d": "kagi.com",
+    "t": "knam",
+    "u": "/news?q={{s}}&r=am",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Aruba (AW)",
+    "d": "kagi.com",
+    "t": "knaw",
+    "u": "/news?q={{s}}&r=aw",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Ascension Island (AC)",
+    "d": "kagi.com",
+    "t": "knac",
+    "u": "/news?q={{s}}&r=ac",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Australia (AU)",
+    "d": "kagi.com",
+    "t": "knau",
+    "u": "/news?q={{s}}&r=au",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Austria (AT)",
+    "d": "kagi.com",
+    "t": "knat",
+    "u": "/news?q={{s}}&r=at",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Azerbaijan (AZ)",
+    "d": "kagi.com",
+    "t": "knaz",
+    "u": "/news?q={{s}}&r=az",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Bahamas (BS)",
+    "d": "kagi.com",
+    "t": "knbs",
+    "u": "/news?q={{s}}&r=bs",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Bahrain (BH)",
+    "d": "kagi.com",
+    "t": "knbh",
+    "u": "/news?q={{s}}&r=bh",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Bangladesh (BD)",
+    "d": "kagi.com",
+    "t": "knbd",
+    "u": "/news?q={{s}}&r=bd",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Barbados (BB)",
+    "d": "kagi.com",
+    "t": "knbb",
+    "u": "/news?q={{s}}&r=bb",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Belarus (BY)",
+    "d": "kagi.com",
+    "t": "knby",
+    "u": "/news?q={{s}}&r=by",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Belgium (BE - nl)",
+    "d": "kagi.com",
+    "t": "knbe",
+    "u": "/news?q={{s}}&r=be",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Belgium (BE - fr)",
+    "d": "kagi.com",
+    "t": "knbe_fr",
+    "u": "/news?q={{s}}&r=be_fr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Belize (BZ)",
+    "d": "kagi.com",
+    "t": "knbz",
+    "u": "/news?q={{s}}&r=bz",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Benin (BJ)",
+    "d": "kagi.com",
+    "t": "knbj",
+    "u": "/news?q={{s}}&r=bj",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Bermuda (BM)",
+    "d": "kagi.com",
+    "t": "knbm",
+    "u": "/news?q={{s}}&r=bm",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Bhutan (BT)",
+    "d": "kagi.com",
+    "t": "knbt",
+    "u": "/news?q={{s}}&r=bt",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Bolivia (BO)",
+    "d": "kagi.com",
+    "t": "knbo",
+    "u": "/news?q={{s}}&r=bo",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Bonaire, Sint Eustatius and Saba (BQ)",
+    "d": "kagi.com",
+    "t": "knbq",
+    "u": "/news?q={{s}}&r=bq",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Bosnia and Herzegovina (BA)",
+    "d": "kagi.com",
+    "t": "knba",
+    "u": "/news?q={{s}}&r=ba",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Botswana (BW)",
+    "d": "kagi.com",
+    "t": "knbw",
+    "u": "/news?q={{s}}&r=bw",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Bouvet Island (BV)",
+    "d": "kagi.com",
+    "t": "knbv",
+    "u": "/news?q={{s}}&r=bv",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Brazil (BR)",
+    "d": "kagi.com",
+    "t": "knbr",
+    "u": "/news?q={{s}}&r=br",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in British Indian Ocean Territory (IO)",
+    "d": "kagi.com",
+    "t": "knio",
+    "u": "/news?q={{s}}&r=io",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in British Virgin Islands (VG)",
+    "d": "kagi.com",
+    "t": "knvg",
+    "u": "/news?q={{s}}&r=vg",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Brunei (BN)",
+    "d": "kagi.com",
+    "t": "knbn",
+    "u": "/news?q={{s}}&r=bn",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Bulgaria (BG)",
+    "d": "kagi.com",
+    "t": "knbg",
+    "u": "/news?q={{s}}&r=bg",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Burkina Faso (BF)",
+    "d": "kagi.com",
+    "t": "knbf",
+    "u": "/news?q={{s}}&r=bf",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Burundi (BI)",
+    "d": "kagi.com",
+    "t": "knbi",
+    "u": "/news?q={{s}}&r=bi",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Cabo Verde (CV)",
+    "d": "kagi.com",
+    "t": "kncv",
+    "u": "/news?q={{s}}&r=cv",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Cambodia (KH)",
+    "d": "kagi.com",
+    "t": "knkh",
+    "u": "/news?q={{s}}&r=kh",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Cameroon (CM)",
+    "d": "kagi.com",
+    "t": "kncm",
+    "u": "/news?q={{s}}&r=cm",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Canada (CA - en)",
+    "d": "kagi.com",
+    "t": "knca",
+    "u": "/news?q={{s}}&r=ca",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Canada (CA - fr)",
+    "d": "kagi.com",
+    "t": "knca_fr",
+    "u": "/news?q={{s}}&r=ca_fr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Cayman Islands (KY)",
+    "d": "kagi.com",
+    "t": "knky",
+    "u": "/news?q={{s}}&r=ky",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Central African Republic (CF)",
+    "d": "kagi.com",
+    "t": "kncf",
+    "u": "/news?q={{s}}&r=cf",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Chad (TD)",
+    "d": "kagi.com",
+    "t": "kntd",
+    "u": "/news?q={{s}}&r=td",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Chile (CL)",
+    "d": "kagi.com",
+    "t": "kncl",
+    "u": "/news?q={{s}}&r=cl",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in China (CN)",
+    "d": "kagi.com",
+    "t": "kncn",
+    "u": "/news?q={{s}}&r=cn",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Christmas Island (CX)",
+    "d": "kagi.com",
+    "t": "kncx",
+    "u": "/news?q={{s}}&r=cx",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Cocos (Keeling) Islands (CC)",
+    "d": "kagi.com",
+    "t": "kncc",
+    "u": "/news?q={{s}}&r=cc",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Colombia (CO)",
+    "d": "kagi.com",
+    "t": "knco",
+    "u": "/news?q={{s}}&r=co",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Comoros (KM)",
+    "d": "kagi.com",
+    "t": "knkm",
+    "u": "/news?q={{s}}&r=km",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Congo (CG)",
+    "d": "kagi.com",
+    "t": "kncg",
+    "u": "/news?q={{s}}&r=cg",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Congo, Democratic Republic of the (CD)",
+    "d": "kagi.com",
+    "t": "kncd",
+    "u": "/news?q={{s}}&r=cd",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Cook Islands (CK)",
+    "d": "kagi.com",
+    "t": "knck",
+    "u": "/news?q={{s}}&r=ck",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Costa Rica (CR)",
+    "d": "kagi.com",
+    "t": "kncr",
+    "u": "/news?q={{s}}&r=cr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Croatia (HR)",
+    "d": "kagi.com",
+    "t": "knhr",
+    "u": "/news?q={{s}}&r=hr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Cuba (CU)",
+    "d": "kagi.com",
+    "t": "kncu",
+    "u": "/news?q={{s}}&r=cu",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Curaçao (CW)",
+    "d": "kagi.com",
+    "t": "kncw",
+    "u": "/news?q={{s}}&r=cw",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Cyprus (CY)",
+    "d": "kagi.com",
+    "t": "kncy",
+    "u": "/news?q={{s}}&r=cy",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Czechia (CZ)",
+    "d": "kagi.com",
+    "t": "kncz",
+    "u": "/news?q={{s}}&r=cz",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Côte d'Ivoire (CI)",
+    "d": "kagi.com",
+    "t": "knci",
+    "u": "/news?q={{s}}&r=ci",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Denmark (DK)",
+    "d": "kagi.com",
+    "t": "kndk",
+    "u": "/news?q={{s}}&r=dk",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Djibouti (DJ)",
+    "d": "kagi.com",
+    "t": "kndj",
+    "u": "/news?q={{s}}&r=dj",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Dominica (DM)",
+    "d": "kagi.com",
+    "t": "kndm",
+    "u": "/news?q={{s}}&r=dm",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Dominican Republic (DO)",
+    "d": "kagi.com",
+    "t": "kndo",
+    "u": "/news?q={{s}}&r=do",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Ecuador (EC)",
+    "d": "kagi.com",
+    "t": "knec",
+    "u": "/news?q={{s}}&r=ec",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Egypt (EG)",
+    "d": "kagi.com",
+    "t": "kneg",
+    "u": "/news?q={{s}}&r=eg",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in El Salvador (SV)",
+    "d": "kagi.com",
+    "t": "knsv",
+    "u": "/news?q={{s}}&r=sv",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Equatorial Guinea (GQ)",
+    "d": "kagi.com",
+    "t": "kngq",
+    "u": "/news?q={{s}}&r=gq",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Eritrea (ER)",
+    "d": "kagi.com",
+    "t": "kner",
+    "u": "/news?q={{s}}&r=er",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Estonia (EE)",
+    "d": "kagi.com",
+    "t": "knee",
+    "u": "/news?q={{s}}&r=ee",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Eswatini (SZ)",
+    "d": "kagi.com",
+    "t": "knsz",
+    "u": "/news?q={{s}}&r=sz",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Ethiopia (ET)",
+    "d": "kagi.com",
+    "t": "knet",
+    "u": "/news?q={{s}}&r=et",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Falkland Islands (FK)",
+    "d": "kagi.com",
+    "t": "knfk",
+    "u": "/news?q={{s}}&r=fk",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Faroe Islands (FO)",
+    "d": "kagi.com",
+    "t": "knfo",
+    "u": "/news?q={{s}}&r=fo",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Fiji (FJ)",
+    "d": "kagi.com",
+    "t": "knfj",
+    "u": "/news?q={{s}}&r=fj",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Finland (FI)",
+    "d": "kagi.com",
+    "t": "knfi",
+    "u": "/news?q={{s}}&r=fi",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in France (FR)",
+    "d": "kagi.com",
+    "t": "knfr",
+    "u": "/news?q={{s}}&r=fr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in French Guiana (GF)",
+    "d": "kagi.com",
+    "t": "kngf",
+    "u": "/news?q={{s}}&r=gf",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in French Polynesia (PF)",
+    "d": "kagi.com",
+    "t": "knpf",
+    "u": "/news?q={{s}}&r=pf",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in French Southern Territories (TF)",
+    "d": "kagi.com",
+    "t": "kntf",
+    "u": "/news?q={{s}}&r=tf",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Gabon (GA)",
+    "d": "kagi.com",
+    "t": "knga",
+    "u": "/news?q={{s}}&r=ga",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Gambia (GM)",
+    "d": "kagi.com",
+    "t": "kngm",
+    "u": "/news?q={{s}}&r=gm",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Georgia (GE)",
+    "d": "kagi.com",
+    "t": "knge",
+    "u": "/news?q={{s}}&r=ge",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Germany (DE)",
+    "d": "kagi.com",
+    "t": "knde",
+    "u": "/news?q={{s}}&r=de",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Ghana (GH)",
+    "d": "kagi.com",
+    "t": "kngh",
+    "u": "/news?q={{s}}&r=gh",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Gibraltar (GI)",
+    "d": "kagi.com",
+    "t": "kngi",
+    "u": "/news?q={{s}}&r=gi",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Greece (GR)",
+    "d": "kagi.com",
+    "t": "kngr",
+    "u": "/news?q={{s}}&r=gr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Greenland (GL)",
+    "d": "kagi.com",
+    "t": "kngl",
+    "u": "/news?q={{s}}&r=gl",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Grenada (GD)",
+    "d": "kagi.com",
+    "t": "kngd",
+    "u": "/news?q={{s}}&r=gd",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Guadeloupe (GP)",
+    "d": "kagi.com",
+    "t": "kngp",
+    "u": "/news?q={{s}}&r=gp",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Guam (GU)",
+    "d": "kagi.com",
+    "t": "kngu",
+    "u": "/news?q={{s}}&r=gu",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Guatemala (GT)",
+    "d": "kagi.com",
+    "t": "kngt",
+    "u": "/news?q={{s}}&r=gt",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Guernsey (GG)",
+    "d": "kagi.com",
+    "t": "kngg",
+    "u": "/news?q={{s}}&r=gg",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Guinea (GN)",
+    "d": "kagi.com",
+    "t": "kngn",
+    "u": "/news?q={{s}}&r=gn",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Guinea-Bissau (GW)",
+    "d": "kagi.com",
+    "t": "kngw",
+    "u": "/news?q={{s}}&r=gw",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Guyana (GY)",
+    "d": "kagi.com",
+    "t": "kngy",
+    "u": "/news?q={{s}}&r=gy",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Haiti (HT)",
+    "d": "kagi.com",
+    "t": "knht",
+    "u": "/news?q={{s}}&r=ht",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Heard Island and McDonald Islands (HM)",
+    "d": "kagi.com",
+    "t": "knhm",
+    "u": "/news?q={{s}}&r=hm",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Honduras (HN)",
+    "d": "kagi.com",
+    "t": "knhn",
+    "u": "/news?q={{s}}&r=hn",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Hong Kong (HK)",
+    "d": "kagi.com",
+    "t": "knhk",
+    "u": "/news?q={{s}}&r=hk",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Hungary (HU)",
+    "d": "kagi.com",
+    "t": "knhu",
+    "u": "/news?q={{s}}&r=hu",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Iceland (IS)",
+    "d": "kagi.com",
+    "t": "knis",
+    "u": "/news?q={{s}}&r=is",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in India (IN)",
+    "d": "kagi.com",
+    "t": "knin",
+    "u": "/news?q={{s}}&r=in",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Indonesia (ID)",
+    "d": "kagi.com",
+    "t": "knid",
+    "u": "/news?q={{s}}&r=id",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Iran (IR)",
+    "d": "kagi.com",
+    "t": "knir",
+    "u": "/news?q={{s}}&r=ir",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Iraq (IQ)",
+    "d": "kagi.com",
+    "t": "kniq",
+    "u": "/news?q={{s}}&r=iq",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Ireland (IE)",
+    "d": "kagi.com",
+    "t": "knie",
+    "u": "/news?q={{s}}&r=ie",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Isle of Man (IM)",
+    "d": "kagi.com",
+    "t": "knim",
+    "u": "/news?q={{s}}&r=im",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Israel (IL)",
+    "d": "kagi.com",
+    "t": "knil",
+    "u": "/news?q={{s}}&r=il",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Italy (IT)",
+    "d": "kagi.com",
+    "t": "knit",
+    "u": "/news?q={{s}}&r=it",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Jamaica (JM)",
+    "d": "kagi.com",
+    "t": "knjm",
+    "u": "/news?q={{s}}&r=jm",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Japan (JP)",
+    "d": "kagi.com",
+    "t": "knjp",
+    "u": "/news?q={{s}}&r=jp",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Jersey (JE)",
+    "d": "kagi.com",
+    "t": "knje",
+    "u": "/news?q={{s}}&r=je",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Jordan (JO)",
+    "d": "kagi.com",
+    "t": "knjo",
+    "u": "/news?q={{s}}&r=jo",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Kazakhstan (KZ)",
+    "d": "kagi.com",
+    "t": "knkz",
+    "u": "/news?q={{s}}&r=kz",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Kenya (KE)",
+    "d": "kagi.com",
+    "t": "knke",
+    "u": "/news?q={{s}}&r=ke",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Kiribati (KI)",
+    "d": "kagi.com",
+    "t": "knki",
+    "u": "/news?q={{s}}&r=ki",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Kosovo (XK)",
+    "d": "kagi.com",
+    "t": "knxk",
+    "u": "/news?q={{s}}&r=xk",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Kuwait (KW)",
+    "d": "kagi.com",
+    "t": "knkw",
+    "u": "/news?q={{s}}&r=kw",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Kyrgyzstan (KG)",
+    "d": "kagi.com",
+    "t": "knkg",
+    "u": "/news?q={{s}}&r=kg",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Laos (LA)",
+    "d": "kagi.com",
+    "t": "knla",
+    "u": "/news?q={{s}}&r=la",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Latvia (LV)",
+    "d": "kagi.com",
+    "t": "knlv",
+    "u": "/news?q={{s}}&r=lv",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Lebanon (LB)",
+    "d": "kagi.com",
+    "t": "knlb",
+    "u": "/news?q={{s}}&r=lb",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Lesotho (LS)",
+    "d": "kagi.com",
+    "t": "knls",
+    "u": "/news?q={{s}}&r=ls",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Liberia (LR)",
+    "d": "kagi.com",
+    "t": "knlr",
+    "u": "/news?q={{s}}&r=lr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Libya (LY)",
+    "d": "kagi.com",
+    "t": "knly",
+    "u": "/news?q={{s}}&r=ly",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Liechtenstein (LI)",
+    "d": "kagi.com",
+    "t": "knli",
+    "u": "/news?q={{s}}&r=li",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Lithuania (LT)",
+    "d": "kagi.com",
+    "t": "knlt",
+    "u": "/news?q={{s}}&r=lt",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Luxembourg (LU)",
+    "d": "kagi.com",
+    "t": "knlu",
+    "u": "/news?q={{s}}&r=lu",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Macao (MO)",
+    "d": "kagi.com",
+    "t": "knmo",
+    "u": "/news?q={{s}}&r=mo",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Madagascar (MG)",
+    "d": "kagi.com",
+    "t": "knmg",
+    "u": "/news?q={{s}}&r=mg",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Malawi (MW)",
+    "d": "kagi.com",
+    "t": "knmw",
+    "u": "/news?q={{s}}&r=mw",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Malaysia (MY)",
+    "d": "kagi.com",
+    "t": "knmy",
+    "u": "/news?q={{s}}&r=my",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Maldives (MV)",
+    "d": "kagi.com",
+    "t": "knmv",
+    "u": "/news?q={{s}}&r=mv",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Mali (ML)",
+    "d": "kagi.com",
+    "t": "knml",
+    "u": "/news?q={{s}}&r=ml",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Malta (MT)",
+    "d": "kagi.com",
+    "t": "knmt",
+    "u": "/news?q={{s}}&r=mt",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Marshall Islands (MH)",
+    "d": "kagi.com",
+    "t": "knmh",
+    "u": "/news?q={{s}}&r=mh",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Martinique (MQ)",
+    "d": "kagi.com",
+    "t": "knmq",
+    "u": "/news?q={{s}}&r=mq",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Mauritania (MR)",
+    "d": "kagi.com",
+    "t": "knmr",
+    "u": "/news?q={{s}}&r=mr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Mauritius (MU)",
+    "d": "kagi.com",
+    "t": "knmu",
+    "u": "/news?q={{s}}&r=mu",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Mayotte (YT)",
+    "d": "kagi.com",
+    "t": "knyt",
+    "u": "/news?q={{s}}&r=yt",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Mexico (MX)",
+    "d": "kagi.com",
+    "t": "knmx",
+    "u": "/news?q={{s}}&r=mx",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Micronesia (Federated States of) (FM)",
+    "d": "kagi.com",
+    "t": "knfm",
+    "u": "/news?q={{s}}&r=fm",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Moldova (MD)",
+    "d": "kagi.com",
+    "t": "knmd",
+    "u": "/news?q={{s}}&r=md",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Monaco (MC)",
+    "d": "kagi.com",
+    "t": "knmc",
+    "u": "/news?q={{s}}&r=mc",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Mongolia (MN)",
+    "d": "kagi.com",
+    "t": "knmn",
+    "u": "/news?q={{s}}&r=mn",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Montenegro (ME)",
+    "d": "kagi.com",
+    "t": "knme",
+    "u": "/news?q={{s}}&r=me",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Montserrat (MS)",
+    "d": "kagi.com",
+    "t": "knms",
+    "u": "/news?q={{s}}&r=ms",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Morocco (MA)",
+    "d": "kagi.com",
+    "t": "knma",
+    "u": "/news?q={{s}}&r=ma",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Mozambique (MZ)",
+    "d": "kagi.com",
+    "t": "knmz",
+    "u": "/news?q={{s}}&r=mz",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Myanmar (MM)",
+    "d": "kagi.com",
+    "t": "knmm",
+    "u": "/news?q={{s}}&r=mm",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Namibia (NA)",
+    "d": "kagi.com",
+    "t": "knna",
+    "u": "/news?q={{s}}&r=na",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Nauru (NR)",
+    "d": "kagi.com",
+    "t": "knnr",
+    "u": "/news?q={{s}}&r=nr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Nepal (NP)",
+    "d": "kagi.com",
+    "t": "knnp",
+    "u": "/news?q={{s}}&r=np",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Netherlands (NL)",
+    "d": "kagi.com",
+    "t": "knnl",
+    "u": "/news?q={{s}}&r=nl",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in New Caledonia (NC)",
+    "d": "kagi.com",
+    "t": "knnc",
+    "u": "/news?q={{s}}&r=nc",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in New Zealand (NZ)",
+    "d": "kagi.com",
+    "t": "knnz",
+    "u": "/news?q={{s}}&r=nz",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Nicaragua (NI)",
+    "d": "kagi.com",
+    "t": "knni",
+    "u": "/news?q={{s}}&r=ni",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Niger (NE)",
+    "d": "kagi.com",
+    "t": "knne",
+    "u": "/news?q={{s}}&r=ne",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Nigeria (NG)",
+    "d": "kagi.com",
+    "t": "knng",
+    "u": "/news?q={{s}}&r=ng",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Niue (NU)",
+    "d": "kagi.com",
+    "t": "knnu",
+    "u": "/news?q={{s}}&r=nu",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Norfolk Island (NF)",
+    "d": "kagi.com",
+    "t": "knnf",
+    "u": "/news?q={{s}}&r=nf",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in North Korea (KP)",
+    "d": "kagi.com",
+    "t": "knkp",
+    "u": "/news?q={{s}}&r=kp",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in North Macedonia (MK)",
+    "d": "kagi.com",
+    "t": "knmk",
+    "u": "/news?q={{s}}&r=mk",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Northern Mariana Islands (MP)",
+    "d": "kagi.com",
+    "t": "knmp",
+    "u": "/news?q={{s}}&r=mp",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Norway (NO)",
+    "d": "kagi.com",
+    "t": "knno",
+    "u": "/news?q={{s}}&r=no",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Oman (OM)",
+    "d": "kagi.com",
+    "t": "knom",
+    "u": "/news?q={{s}}&r=om",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Pakistan (PK)",
+    "d": "kagi.com",
+    "t": "knpk",
+    "u": "/news?q={{s}}&r=pk",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Palau (PW)",
+    "d": "kagi.com",
+    "t": "knpw",
+    "u": "/news?q={{s}}&r=pw",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Palestine (PS)",
+    "d": "kagi.com",
+    "t": "knps",
+    "u": "/news?q={{s}}&r=ps",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Panama (PA)",
+    "d": "kagi.com",
+    "t": "knpa",
+    "u": "/news?q={{s}}&r=pa",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Papua New Guinea (PG)",
+    "d": "kagi.com",
+    "t": "knpg",
+    "u": "/news?q={{s}}&r=pg",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Paraguay (PY)",
+    "d": "kagi.com",
+    "t": "knpy",
+    "u": "/news?q={{s}}&r=py",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Peru (PE)",
+    "d": "kagi.com",
+    "t": "knpe",
+    "u": "/news?q={{s}}&r=pe",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Philippines (PH)",
+    "d": "kagi.com",
+    "t": "knph",
+    "u": "/news?q={{s}}&r=ph",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Pitcairn (PN)",
+    "d": "kagi.com",
+    "t": "knpn",
+    "u": "/news?q={{s}}&r=pn",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Poland (PL)",
+    "d": "kagi.com",
+    "t": "knpl",
+    "u": "/news?q={{s}}&r=pl",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Portugal (PT)",
+    "d": "kagi.com",
+    "t": "knpt",
+    "u": "/news?q={{s}}&r=pt",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Puerto Rico (PR)",
+    "d": "kagi.com",
+    "t": "knpr",
+    "u": "/news?q={{s}}&r=pr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Qatar (QA)",
+    "d": "kagi.com",
+    "t": "knqa",
+    "u": "/news?q={{s}}&r=qa",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Romania (RO)",
+    "d": "kagi.com",
+    "t": "knro",
+    "u": "/news?q={{s}}&r=ro",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Russia (RU)",
+    "d": "kagi.com",
+    "t": "knru",
+    "u": "/news?q={{s}}&r=ru",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Rwanda (RW)",
+    "d": "kagi.com",
+    "t": "knrw",
+    "u": "/news?q={{s}}&r=rw",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Réunion (RE)",
+    "d": "kagi.com",
+    "t": "knre",
+    "u": "/news?q={{s}}&r=re",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Saint Barthélemy (BL)",
+    "d": "kagi.com",
+    "t": "knbl",
+    "u": "/news?q={{s}}&r=bl",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Saint Helena, Ascension and Tristan da Cunha (SH)",
+    "d": "kagi.com",
+    "t": "knsh",
+    "u": "/news?q={{s}}&r=sh",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Saint Kitts and Nevis (KN)",
+    "d": "kagi.com",
+    "t": "knkn",
+    "u": "/news?q={{s}}&r=kn",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Saint Lucia (LC)",
+    "d": "kagi.com",
+    "t": "knlc",
+    "u": "/news?q={{s}}&r=lc",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Saint Martin (MF)",
+    "d": "kagi.com",
+    "t": "knmf",
+    "u": "/news?q={{s}}&r=mf",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Saint Pierre and Miquelon (PM)",
+    "d": "kagi.com",
+    "t": "knpm",
+    "u": "/news?q={{s}}&r=pm",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Saint Vincent and the Grenadines (VC)",
+    "d": "kagi.com",
+    "t": "knvc",
+    "u": "/news?q={{s}}&r=vc",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Samoa (WS)",
+    "d": "kagi.com",
+    "t": "knws",
+    "u": "/news?q={{s}}&r=ws",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in San Marino (SM)",
+    "d": "kagi.com",
+    "t": "knsm",
+    "u": "/news?q={{s}}&r=sm",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Sao Tome and Principe (ST)",
+    "d": "kagi.com",
+    "t": "knst",
+    "u": "/news?q={{s}}&r=st",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Saudi Arabia (SA)",
+    "d": "kagi.com",
+    "t": "knsa",
+    "u": "/news?q={{s}}&r=sa",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Senegal (SN)",
+    "d": "kagi.com",
+    "t": "knsn",
+    "u": "/news?q={{s}}&r=sn",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Serbia (RS)",
+    "d": "kagi.com",
+    "t": "knrs",
+    "u": "/news?q={{s}}&r=rs",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Seychelles (SC)",
+    "d": "kagi.com",
+    "t": "knsc",
+    "u": "/news?q={{s}}&r=sc",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Sierra Leone (SL)",
+    "d": "kagi.com",
+    "t": "knsl",
+    "u": "/news?q={{s}}&r=sl",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Singapore (SG)",
+    "d": "kagi.com",
+    "t": "knsg",
+    "u": "/news?q={{s}}&r=sg",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Sint Maarten (SX)",
+    "d": "kagi.com",
+    "t": "knsx",
+    "u": "/news?q={{s}}&r=sx",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Slovakia (SK)",
+    "d": "kagi.com",
+    "t": "knsk",
+    "u": "/news?q={{s}}&r=sk",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Slovenia (SI)",
+    "d": "kagi.com",
+    "t": "knsi",
+    "u": "/news?q={{s}}&r=si",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Solomon Islands (SB)",
+    "d": "kagi.com",
+    "t": "knsb",
+    "u": "/news?q={{s}}&r=sb",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Somalia (SO)",
+    "d": "kagi.com",
+    "t": "knso",
+    "u": "/news?q={{s}}&r=so",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in South Africa (ZA)",
+    "d": "kagi.com",
+    "t": "knza",
+    "u": "/news?q={{s}}&r=za",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in South Georgia and the South Sandwich Islands (GS)",
+    "d": "kagi.com",
+    "t": "kngs",
+    "u": "/news?q={{s}}&r=gs",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in South Korea (KR)",
+    "d": "kagi.com",
+    "t": "knkr",
+    "u": "/news?q={{s}}&r=kr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in South Sudan (SS)",
+    "d": "kagi.com",
+    "t": "knss",
+    "u": "/news?q={{s}}&r=ss",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Spain (ES - ca)",
+    "d": "kagi.com",
+    "t": "knes_ca",
+    "u": "/news?q={{s}}&r=es_ca",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Spain (ES - es)",
+    "d": "kagi.com",
+    "t": "knes",
+    "u": "/news?q={{s}}&r=es",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Sri Lanka (LK)",
+    "d": "kagi.com",
+    "t": "knlk",
+    "u": "/news?q={{s}}&r=lk",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Sudan (SD)",
+    "d": "kagi.com",
+    "t": "knsd",
+    "u": "/news?q={{s}}&r=sd",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Suriname (SR)",
+    "d": "kagi.com",
+    "t": "knsr",
+    "u": "/news?q={{s}}&r=sr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Svalbard and Jan Mayen (SJ)",
+    "d": "kagi.com",
+    "t": "knsj",
+    "u": "/news?q={{s}}&r=sj",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Sweden (SE)",
+    "d": "kagi.com",
+    "t": "knse",
+    "u": "/news?q={{s}}&r=se",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Switzerland (CH - de)",
+    "d": "kagi.com",
+    "t": "knch",
+    "u": "/news?q={{s}}&r=ch",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Switzerland (CH - fr)",
+    "d": "kagi.com",
+    "t": "knch_fr",
+    "u": "/news?q={{s}}&r=ch_fr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Syria (SY)",
+    "d": "kagi.com",
+    "t": "knsy",
+    "u": "/news?q={{s}}&r=sy",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Taiwan (TW)",
+    "d": "kagi.com",
+    "t": "kntw",
+    "u": "/news?q={{s}}&r=tw",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Tajikistan (TJ)",
+    "d": "kagi.com",
+    "t": "kntj",
+    "u": "/news?q={{s}}&r=tj",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Tanzania (TZ)",
+    "d": "kagi.com",
+    "t": "kntz",
+    "u": "/news?q={{s}}&r=tz",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Thailand (TH)",
+    "d": "kagi.com",
+    "t": "knth",
+    "u": "/news?q={{s}}&r=th",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Timor-Leste (TL)",
+    "d": "kagi.com",
+    "t": "kntl",
+    "u": "/news?q={{s}}&r=tl",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Togo (TG)",
+    "d": "kagi.com",
+    "t": "kntg",
+    "u": "/news?q={{s}}&r=tg",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Tokelau (TK)",
+    "d": "kagi.com",
+    "t": "kntk",
+    "u": "/news?q={{s}}&r=tk",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Tonga (TO)",
+    "d": "kagi.com",
+    "t": "knto",
+    "u": "/news?q={{s}}&r=to",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Trinidad and Tobago (TT)",
+    "d": "kagi.com",
+    "t": "kntt",
+    "u": "/news?q={{s}}&r=tt",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Tristan da Cunha (TA)",
+    "d": "kagi.com",
+    "t": "knta",
+    "u": "/news?q={{s}}&r=ta",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Tunisia (TN)",
+    "d": "kagi.com",
+    "t": "kntn",
+    "u": "/news?q={{s}}&r=tn",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Turkey (TR)",
+    "d": "kagi.com",
+    "t": "kntr",
+    "u": "/news?q={{s}}&r=tr",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Turkmenistan (TM)",
+    "d": "kagi.com",
+    "t": "kntm",
+    "u": "/news?q={{s}}&r=tm",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Turks and Caicos Islands (TC)",
+    "d": "kagi.com",
+    "t": "kntc",
+    "u": "/news?q={{s}}&r=tc",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Tuvalu (TV)",
+    "d": "kagi.com",
+    "t": "kntv",
+    "u": "/news?q={{s}}&r=tv",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Uganda (UG)",
+    "d": "kagi.com",
+    "t": "knug",
+    "u": "/news?q={{s}}&r=ug",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Ukraine (UA)",
+    "d": "kagi.com",
+    "t": "knua",
+    "u": "/news?q={{s}}&r=ua",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in United Arab Emirates (AE)",
+    "d": "kagi.com",
+    "t": "knae",
+    "u": "/news?q={{s}}&r=ae",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in United Kingdom (GB)",
+    "d": "kagi.com",
+    "t": "kngb",
+    "u": "/news?q={{s}}&r=gb",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in United States (US)",
+    "d": "kagi.com",
+    "t": "knus",
+    "u": "/news?q={{s}}&r=us",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in United States Minor Outlying Islands (UM)",
+    "d": "kagi.com",
+    "t": "knum",
+    "u": "/news?q={{s}}&r=um",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in United States Virgin Islands (VI)",
+    "d": "kagi.com",
+    "t": "knvi",
+    "u": "/news?q={{s}}&r=vi",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Uruguay (UY)",
+    "d": "kagi.com",
+    "t": "knuy",
+    "u": "/news?q={{s}}&r=uy",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Uzbekistan (UZ)",
+    "d": "kagi.com",
+    "t": "knuz",
+    "u": "/news?q={{s}}&r=uz",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Vanuatu (VU)",
+    "d": "kagi.com",
+    "t": "knvu",
+    "u": "/news?q={{s}}&r=vu",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Vatican City (VA)",
+    "d": "kagi.com",
+    "t": "knva",
+    "u": "/news?q={{s}}&r=va",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Venezuela (VE)",
+    "d": "kagi.com",
+    "t": "knve",
+    "u": "/news?q={{s}}&r=ve",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Vietnam (VN)",
+    "d": "kagi.com",
+    "t": "knvn",
+    "u": "/news?q={{s}}&r=vn",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Wallis and Futuna (WF)",
+    "d": "kagi.com",
+    "t": "knwf",
+    "u": "/news?q={{s}}&r=wf",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Western Sahara (EH)",
+    "d": "kagi.com",
+    "t": "kneh",
+    "u": "/news?q={{s}}&r=eh",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Yemen (YE)",
+    "d": "kagi.com",
+    "t": "knye",
+    "u": "/news?q={{s}}&r=ye",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Zambia (ZM)",
+    "d": "kagi.com",
+    "t": "knzm",
+    "u": "/news?q={{s}}&r=zm",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Zimbabwe (ZW)",
+    "d": "kagi.com",
+    "t": "knzw",
+    "u": "/news?q={{s}}&r=zw",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
+  },
+  {
+    "s": "News in Åland Islands (AX)",
+    "d": "kagi.com",
+    "t": "knax",
+    "u": "/news?q={{s}}&r=ax",
+    "fmt": [
+      "url_encode_placeholder"
+    ]
   }
 ]


### PR DESCRIPTION
I know it's A LOT of bangs, but I also noticed that google has bangs like !gnbe which searches google news for belgium.
So figured it would be nice if Kagi had the same.

So had everything single region that is listed in Kagi News converted to bangs.

Also I checked, none of these bangs conflict with any of the existing bangs in kagi_bangs.json, bangs.json or assistant_bangs.json

(do I need to create kagifeedback's for these and just ask them to be marked as done? I'm not sure if the kagi changelog relies on kagifeedback's or if this would be manually added?)