### PR TITLE
Add Translink NI timetable search

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -90602,6 +90602,14 @@
     "sc": "Tools"
   },
   {
+    "s": "Translink NI",
+    "d": "www.translink.co.uk",
+    "t": "tlni",
+    "u": "https://www.translink.co.uk/timetables?Name={{{s}}}",
+    "c": "Online Services",
+    "sc": "Tools"
+  },
+  {
     "s": "Thorlabs",
     "d": "www.thorlabs.com",
     "t": "tls",


### PR DESCRIPTION
(The main public transport operator in Northern Ireland)
Supports searching bus timetables by route number, eg https://www.translink.co.uk/timetables?Name=238 - Unfortunately can't cover searching by destination/stop, as those use an internal ID where the name parameter does nothing, eg. https://www.translink.co.uk/timetables?LocationId=10000055&Name=The+moon

The same could also be added for train timetables, but given that it requires the exact full line name (eg `?Name=Bangor+line&TransportMode=Train` is required instead of `?Name=Bangor&TransportMode=Train`), and that the rail network barely exists here, I've left it out for now.