### PR TITLE
Add kde, osm, proton bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -49352,7 +49352,7 @@
   },
   {
     "s": "KDE Bugtracking System",
-    "d": "https://bugs.kde.org/",
+    "d": "bugs.kde.org",
     "t": "kdebugs",
     "u": "https://bugs.kde.org/buglist.cgi?quicksearch={{{s}}}",
     "c": "Tech",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -72987,13 +72987,29 @@
     "sc": "Games (general)"
   },
   {
-    "s": "ProtonMail",
-    "d": "mail.protonmail.com",
-    "t": "protonmail",
-    "u": "https://mail.protonmail.com/search?keyword={{{s}}}",
+    "s": "Proton Calendar",
+    "d": "calendar.proton.me",
+    "t": "protoncalendar",
+    "u": "https://calendar.proton.me/search#keyword={{{s}}}",
     "c": "Online Services",
-    "sc": "Search"
+    "sc": "Tools"
   },
+  {
+    "s": "Proton Drive",
+    "d": "drive.proton.me",
+    "t": "protondrive",
+    "u": "https://drive.proton.me/search#q={{{s}}}",
+    "c": "Online Services",
+    "sc": "Tools"
+  },
+  {
+    "s": "Proton Mail",
+    "d": "mail.proton.me",
+    "t": "protonmail",
+    "u": "https://mail.proton.me/#keyword={{{s}}}",
+    "c": "Online Services",
+    "sc": "Tools"
+  },  
   {
     "s": "Provigo Grocery Store",
     "d": "www.provigo.ca",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -49351,6 +49351,14 @@
     "sc": "Libraries/Frameworks (KDE)"
   },
   {
+    "s": "KDE Bugtracking System",
+    "d": "https://bugs.kde.org/",
+    "t": "kdebugs",
+    "u": "https://bugs.kde.org/buglist.cgi?quicksearch={{{s}}}",
+    "c": "Tech",
+    "sc": "Tools"
+  },
+  {
     "s": "Khan Academy (Profile Page)",
     "d": "www.khanacademy.org",
     "t": "kaprof",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -87551,6 +87551,22 @@
     "sc": "Tools"
   },
   {
+    "s": "OSM Community",
+    "d": "community.openstreetmap.org",
+    "t": "osmcommunity",
+    "u": "https://community.openstreetmap.org/search?q={{{s}}}",
+    "c": "Online Services",
+    "sc": "Tools"
+  },
+  {
+    "s": "OSM Com",
+    "d": "community.openstreetmap.org",
+    "t": "osmcom",
+    "u": "https://community.openstreetmap.org/search?q={{{s}}}",
+    "c": "Online Services",
+    "sc": "Tools"
+  }, 
+  {
     "s": "OpenStreetMap Taginfo",
     "d": "taginfo.openstreetmap.org",
     "t": "taginfo",


### PR DESCRIPTION
I changed protonmail to tools instead of search, is that ok or should it be search or maybe search private? I don't really get those categories yet

There doesn't seem to be much consitentcy for email services.

Tuta mail is 'social'. gmail is it's own category (fair enough), outlook is also search, fastmail is tools, yahoo mail is "Search (Private)"