### PR TITLE
Add query.rs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -74347,6 +74347,14 @@
     "sc": "General"
   },
   {
+    "s": "Query.rs",
+    "d": "query.rs",
+    "t": "queryrs",
+    "u": "https://query.rs/?q={{{s}}}",
+    "c": "Tech",
+    "sc": "Languages (other)"
+  },
+  {
     "s": "QueryPosts",
     "d": "queryposts.com",
     "t": "queryposts",


### PR DESCRIPTION
[Query.rs](https://query.rs/) is a very convenient search engine for querying rust documentation. It has about 250 stars on [GitHub](https://github.com/huhu/query.rs).