### PR TITLE
Add AI Chatbots

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ This is a list of possible categories, with their corresponding subcategories.
 <details>
 <summary>Subcategories</summary>
 
+  - AI Chatbots
   - Events
   - Google
   - Jobs

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -14509,7 +14509,31 @@
     "t": "chatgpt",
     "u": "https://chatgpt.com/?q={{{s}}}",
     "c": "Online Services",
-    "sc": "Tools"
+    "sc": "AI Chatbots"
+  },
+  {
+    "s": "Claude",
+    "d": "claude.ai",
+    "t": "claude",
+    "u": "https://claude.ai/new?q={{{s}}}",
+    "c": "Online Services",
+    "sc": "AI Chatbots"
+  },
+  {
+    "s": "T3 Chat",
+    "d": "www.t3.chat",
+    "t": "t3",
+    "u": "https://www.t3.chat/new?q={{{s}}}",
+    "c": "Online Services",
+    "sc": "AI Chatbots"
+  },
+  {
+    "s": "Le Chat",
+    "d": "chat.mistral.ai",
+    "t": "lechat",
+    "u": "https://chat.mistral.ai/chat?q={{{s}}}",
+    "c": "Online Services",
+    "sc": "AI Chatbots"
   },
   {
     "s": "Chatters Salons",


### PR DESCRIPTION
Added `Claude`, `T3 Chat` and `Le Chat` AI chatbots, as well the `AI Chatbots` subcategory that now includes the aforementioned and `ChatGPT` (I didn't find any other).