### PR TITLE
fix ghr

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -35408,12 +35408,15 @@
     ]
   },
   {
-    "s": "Github",
+    "s": "Github Repo",
     "d": "github.com",
     "t": "ghr",
     "u": "https://github.com/{{{s}}}",
     "c": "Tech",
-    "sc": "Programming"
+    "sc": "Programming",
+    "fmt": [
+      "open_base_path"
+    ]
   },
   {
     "s": "Github - Trending",


### PR DESCRIPTION
Fix the `!ghr` bang so that it doesn't use percent encoding like `!ghrepo`, otherwise, you can't use `/` to go to a repo.