### PR TITLE
Fix nu.nl URL template

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Adding new region bangs will be handled on a case-by-case basis.
 | ni      | National Instruments              | Tech            | Nicaragua                                    |
 | np      | The Noun Project                  | Multimedia      | Nepal                                        |
 | nr      | Nixpkgs Repository                | Tech            | Nauru                                        |
-| nu      | Nu.nl                             | News            | Niue                                         |
+| nu      | nu.nl                             | News            | The Netherlands                              |
 | pa      | Páginas Amarillas                 | Online Services | Panama                                       |
 | pe      | Dicionário Porto Editora          | Research        | Peru                                         |
 | pf      | PrintFriendly                     | Online Services | French Polynesia                             |

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -64734,12 +64734,12 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "Nu.nl",
+    "s": "nu.nl",
     "d": "www.nu.nl",
     "t": "nu",
-    "u": "https://www.nu.nl/zoeken/?q={{{s}}}",
+    "u": "https://www.nu.nl/zoeken?q={{{s}}}",
     "c": "News",
-    "sc": "Newspaper"
+    "sc": "Online"
   },
   {
     "s": "Nusagates Institute",


### PR DESCRIPTION
Removed the slash that was breaking the URL. Also fixed the metadata.