### PR TITLE
Add huggingface search bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -109863,5 +109863,21 @@
     "fmt": [
       "open_base_path"
     ]
+  },
+  {
+    "s": "Hugging Face Datasets",
+    "d": "huggingface.co",
+    "t": "hfd",
+    "u": "https://huggingface.co/datasets?search={{{s}}}",
+    "c": "Tech",
+    "sc": "Libraries/Frameworks"
+  },
+  {
+    "s": "Hugging Face Models",
+    "d": "huggingface.co",
+    "t": "hfm",
+    "u": "https://huggingface.co/models?search={{{s}}}",
+    "c": "Tech",
+    "sc": "Libraries/Frameworks"
   }
 ]


### PR DESCRIPTION
This PR introduces two additional bangs `!hfd` and `!hfd` for searching [huggingface hub](https://huggingface.co/) for datasets and models (there's no unified search). The website is really popular in the AI sphere which I believe justifies the bangs being upstreamed.