### PR TITLE
Add Raycast, Icônes, and njt

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -44876,6 +44876,14 @@
     "sc": "Design"
   },
   {
+    "s": "Icônes",
+    "d": "icones.js.org",
+    "t": "icones",
+    "u": "https://icones.js.org/collection/all?s={{{s}}}",
+    "c": "Tech",
+    "sc": "Design"
+  },
+  {
     "s": "Icons8",
     "d": "icons8.com",
     "t": "icons8",
@@ -64398,6 +64406,14 @@
     "sc": "Languages (javascript)"
   },
   {
+    "s": "npm jump to",
+    "d": "njt.vercel.app",
+    "t": "njt",
+    "u": "https://njt.vercel.app/jump?to={{{s}}}",
+    "c": "Tech",
+    "sc": "Languages (javascript)"
+  },
+  {
     "s": "NPM Search",
     "d": "npmsearch.com",
     "t": "npms",
@@ -75071,6 +75087,14 @@
     "u": "https://rawg.io/search?query={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (general)"
+  },
+  {
+    "s": "Raycast Store",
+    "d": "raycast.com",
+    "t": "raycast",
+    "u": "https://www.raycast.com/search?q={{{s}}}",
+    "c": "Tech",
+    "sc": "Downloads (add-ons)"
   },
   {
     "s": "Raymond-nh",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -75090,7 +75090,7 @@
   },
   {
     "s": "Raycast Store",
-    "d": "raycast.com",
+    "d": "www.raycast.com",
     "t": "raycast",
     "u": "https://www.raycast.com/search?q={{{s}}}",
     "c": "Tech",


### PR DESCRIPTION
Adds JS-adjacent tech sites:

- [Raycast](https://www.raycast.com/store) - popular Mac Spotlight replacement
- [Icônes](https://icones.js.org/) - icon aggregator from a prolific JS maintainer
- [njt](https://njt.vercel.app/) - convenient proxy to popular npm tools

Tested in https://github.com/dmlls/yang ✅