### PR TITLE
Update Modrinth bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -57095,6 +57095,78 @@
     ]
   },
   {
+    "s": "Modrinth (Mods)",
+    "d": "modrinth.com",
+    "t": "mrmods",
+    "u": "https://modrinth.com/mods?q={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (Minecraft)",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Modrinth (Resource Packs)",
+    "d": "modrinth.com",
+    "t": "mrresourcepacks",
+    "u": "https://modrinth.com/resourcepacks?q={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (Minecraft)",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Modrinth (Datapacks)",
+    "d": "modrinth.com",
+    "t": "mrdatapacks",
+    "u": "https://modrinth.com/datapacks?q={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (Minecraft)",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Modrinth (Shaders)",
+    "d": "modrinth.com",
+    "t": "mrshaders",
+    "u": "https://modrinth.com/shaders?q={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (Minecraft)",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Modrinth (Modpacks)",
+    "d": "modrinth.com",
+    "t": "mrmodpacks",
+    "u": "https://modrinth.com/modpacks?q={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (Minecraft)",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Modrinth (Plugins)",
+    "d": "modrinth.com",
+    "t": "mrplugins",
+    "u": "https://modrinth.com/plugins?q={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (Minecraft)",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
     "s": "Minecraft Name History",
     "d": "namemc.com",
     "t": "mcname",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -57035,6 +57035,42 @@
     ]
   },
   {
+    "s": "Modrinth (Resource Packs)",
+    "d": "modrinth.com",
+    "t": "mdresourcepacks",
+    "u": "https://modrinth.com/resourcepacks?q={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (Minecraft)",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Modrinth (Datapacks)",
+    "d": "modrinth.com",
+    "t": "mddatapacks",
+    "u": "https://modrinth.com/datapacks?q={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (Minecraft)",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
+    "s": "Modrinth (Shaders)",
+    "d": "modrinth.com",
+    "t": "mdshaders",
+    "u": "https://modrinth.com/shaders?q={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (Minecraft)",
+    "fmt": [
+      "url_encode_placeholder",
+      "url_encode_space_to_plus"
+    ]
+  },
+  {
     "s": "Modrinth (Modpacks)",
     "d": "modrinth.com",
     "t": "mdmodpacks",


### PR DESCRIPTION
* Added !mdresourcepacks, !mddatapacks, and !mdshaders (now available from Modrinth)
* Ordered them in this list to match the order on the Modrinth website
* cfe959b: Added "mr" variants of the Modrinth bangs (they're more intuitive)

~~By the way: Is there a reason "md" was picked instead of "mr"? I also think there should be an alias system or fuzzy-search on the homepage, so you can use i.e. `!modrinth` to find these more easily...~~