### PR TITLE
Search Kagi bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -7852,17 +7852,17 @@
   },
   {
     "s": "Search all !bangs",
-    "d": "duckduckgo.com",
+    "d": "kbe.smaertness.net",
     "t": "bang",
-    "u": "https://duckduckgo.com/bang?q={{{s}}}",
+    "u": "https://kbe.smaertness.net/search?q={{{s}}}",
     "c": "Tech",
     "sc": "Search (DDG)"
   },
   {
     "s": "Search all !bangs",
-    "d": "duckduckgo.com",
+    "d": "kbe.smaertness.net",
     "t": "bangs",
-    "u": "https://duckduckgo.com/bang?q={{{s}}}",
+    "u": "https://kbe.smaertness.net/search?q={{{s}}}",
     "c": "Online Services",
     "sc": "Search (DDG)"
   },


### PR DESCRIPTION
The `!bang` and `!bangs` meta-bangs still leads to a search of DuckDuckGo's bangs, which the Kagi bangs are slowly diverging from. This PR replaces that with the unofficial (but [referenced in the Kagi docs](https://help.kagi.com/kagi/features/bangs.html)) [community bang explorer](https://kbe.smaertness.net).