### PR TITLE
Remove bangs for jet.com

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -48159,14 +48159,6 @@
     "sc": "Companies"
   },
   {
-    "s": "Jet.com",
-    "d": "jet.com",
-    "t": "jet",
-    "u": "https://jet.com/search?term={{{s}}}",
-    "c": "Shopping",
-    "sc": "Online"
-  },
-  {
     "s": "The Happy Jetlagger",
     "d": "thehappyjetlagger.com",
     "t": "jetlag",
@@ -48329,14 +48321,6 @@
     "u": "https://www.jouwictvacature.nl/vacatures?s={{{s}}}",
     "c": "Online Services",
     "sc": "Jobs"
-  },
-  {
-    "s": "Jet.com",
-    "d": "jet.com",
-    "t": "j",
-    "u": "https://jet.com/search?term={{{s}}}",
-    "c": "Shopping",
-    "sc": "Online (marketplace)"
   },
   {
     "s": "Jinja",


### PR DESCRIPTION
it's been [shut down since 2020](https://www.theverge.com/2020/5/19/21263584/walmart-jet-shutdown-amazon-online-shopping-3-billion-2016), bangs redirect to walmart.com with no search term actually used

*(discovered it when going through one-letter bang list in alphabetical order)*