### PR TITLE
Remove outdated & spammy CNET bangs, fix the URL for main one

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -23362,22 +23362,6 @@
     "sc": "Tools"
   },
   {
-    "s": "Cnet Downloads",
-    "d": "download.cnet.com",
-    "t": "downloadcnet",
-    "u": "https://download.cnet.com/1770-20_4-0.html?query={{{s}}}&platformSelect=&tag=srch&searchtype=downloads&filterName=platform=Windows,Mobile,Mac,Webware&filter=platform=Windows,Mobile,Mac,Webware",
-    "c": "Tech",
-    "sc": "Downloads (software)"
-  },
-  {
-    "s": "Download.com",
-    "d": "download.cnet.com",
-    "t": "download",
-    "u": "https://download.cnet.com/1770-20_4-0.html?searchtype=downloads&query={{{s}}}&tg=dl-20&search.x=0&search.y=0&search=+Go!",
-    "c": "Tech",
-    "sc": "Downloads (software)"
-  },
-  {
     "s": "Downpour",
     "d": "www.downpour.com",
     "t": "downpour",
@@ -81418,14 +81402,6 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Download.com",
-    "d": "download.cnet.com",
-    "t": "shareware",
-    "u": "https://download.cnet.com/1770-20_4-0.html?searchtype=downloads&query={{{s}}}&tg=dl-20&search.x=0&search.y=0&search=+Go!",
-    "c": "Tech",
-    "sc": "Downloads (software)"
-  },
-  {
     "s": "Shaw",
     "d": "www.shaw.ca",
     "t": "shaw",
@@ -83671,14 +83647,6 @@
     "d": "www.softpedia.com",
     "t": "softpedia",
     "u": "https://www.softpedia.com/dyn-search.php?search_term={{{s}}}&x=0&y=0",
-    "c": "Tech",
-    "sc": "Downloads (software)"
-  },
-  {
-    "s": "Download.com",
-    "d": "download.cnet.com",
-    "t": "software",
-    "u": "https://download.cnet.com/1770-20_4-0.html?searchtype=downloads&query={{{s}}}&tg=dl-20&search.x=0&search.y=0&search=+Go!",
     "c": "Tech",
     "sc": "Downloads (software)"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -15915,22 +15915,6 @@
     "sc": "Blogs"
   },
   {
-    "s": "CNET en español",
-    "d": "www.cnet.com",
-    "t": "cnete",
-    "u": "https://www.cnet.com/es/busqueda/?query={{{s}}}",
-    "c": "Tech",
-    "sc": "Blogs (intl)"
-  },
-  {
-    "s": "CNET UK",
-    "d": "www.cnet.com",
-    "t": "cnetuk",
-    "u": "https://www.cnet.com/search/?query={{{s}}}",
-    "c": "Tech",
-    "sc": "Blogs (intl)"
-  },
-  {
     "s": "Conservative Home",
     "d": "www.conservativehome.com",
     "t": "cnh",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -15910,7 +15910,7 @@
     "s": "CNET",
     "d": "www.cnet.com",
     "t": "cnet",
-    "u": "https://www.cnet.com/1770-5_1-0.html?query={{{s}}}&tag=srch&target=nw",
+    "u": "https://www.cnet.com/search/?searchQuery={{{s}}}",
     "c": "Tech",
     "sc": "Blogs"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -13667,14 +13667,6 @@
     "sc": "Business"
   },
   {
-    "s": "CNET",
-    "d": "www.cnet.com",
-    "t": "c",
-    "u": "https://www.cnet.com/1770-5_1-0.html?query={{{s}}}",
-    "c": "Tech",
-    "sc": "Downloads"
-  },
-  {
     "s": "Cheapies NZ",
     "d": "www.cheapies.nz",
     "t": "ccnz",


### PR DESCRIPTION
!download, !software, and !shareware bangs break the rule of not being common words, [as mentioned in the readme](https://github.com/kagisearch/bangs#:~:text=are%20not%20OK.-,The%20trigger,-must%20be%20specific). furthermore, none of them worked. download.cnet.com is also known to be spreading adware & malware (seriously, just open the page).

this PR also removes bangs for ES and UK version of cnet. ES version of CNET hasn't been active since 2017 and moved over to the [other domain with no search functionality](https://cnetenespanol.com/), while UK bang duplicates the search URL for the main website. neither of them worked, too.

cnet is not culturally important enough to claim the !c bang (especially if you compare it to websites like google or wikipedia), so i removed it also.

while cleaning up the other cnet mess, i fixed the !cnet bang to be actually functional :3

it feels like duckduckgo had a partnership with cnet back in the day, because otherwise i don't understand why they'd give them common words like "download" & "software".