### PR TITLE
Remove !z bang for zalando

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -105062,14 +105062,6 @@
     "sc": "Music"
   },
   {
-    "s": "www.zalando.de",
-    "d": "www.zalando.de",
-    "t": "z",
-    "u": "https://www.zalando.de/katalog/?q={{{s}}}",
-    "c": "Shopping",
-    "sc": "Online"
-  },
-  {
     "s": "Zephyr Cross Reference",
     "d": "elixir.bootlin.com",
     "t": "zxr",


### PR DESCRIPTION
zalando doesn't seem to be culturally important enough to have a single letter bang, since it's a EU-only clothing reseller