### PR TITLE
use more general search url for !arin

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -5884,7 +5884,7 @@
     "s": "ARIN Whois",
     "d": "whois.arin.net",
     "t": "arin",
-    "u": "https://whois.arin.net/rest/nets;q={{{s}}}?showDetails=true&showARIN=false&ext=netref2",
+    "u": "https://whois.arin.net/ui/query.do?queryinput={{{s}}}",
     "c": "Tech",
     "sc": "Sysadmin (network)"
   },


### PR DESCRIPTION
The current URL for ARIN only returns result for IP searches. This change makes it so that you can search different stuff and still get a relevant result (e.g. AS36459).