### PR TITLE
Add !stdict and !사전 for Standard Korean Language Dictionary

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -82152,6 +82152,22 @@
     "sc": "Tools"
   },
   {
+    "s": "Standard Korean Language Dictionary",
+    "d": "stdict.korean.go.kr",
+    "t": "stdict",
+    "u": "https://stdict.korean.go.kr/search/searchResult.do?searchKeyword={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Standard Korean Language Dictionary",
+    "d": "stdict.korean.go.kr",
+    "t": "사전",
+    "u": "https://stdict.korean.go.kr/search/searchResult.do?searchKeyword={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
     "s": "Skeptic's Dictionary (Kagi Search)",
     "d": "kagi.com",
     "t": "skepdic",


### PR DESCRIPTION
This PR adds two bangs `!stdict` `!사전`(dictionary in Korean[^1]) for Standard Korean Language Dictionary[^2][^3] maintained by the National Institute of Korean Language[^4].

[^1]: https://translate.kagi.com/?text=사전
[^2]: https://stdict.korean.go.kr
[^3]: https://en.wikipedia.org/wiki/Standard_Korean_Language_Dictionary
[^4]: https://korean.go.kr