### PR TITLE
Fix Lifeprint bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -52966,9 +52966,9 @@
   },
   {
     "s": "Lifeprint",
-    "d": "www.google.com",
+    "d": "cse.google.com",
     "t": "lifeprint",
-    "u": "https://www.google.com/cse?cx=partner-pub-2513564923850231:nzof3qz9abm&ie=ISO-8859-1&q=time#gsc.tab=0&gsc.q={{{s}}}&gsc.page=1",
+    "u": "https://cse.google.com/cse?cx=partner-pub-2513564923850231:nzof3qz9abm&ie=ISO-8859-1&q={{{s}}}&sa=Search",
     "c": "Research",
     "sc": "Learning (intl)"
   },


### PR DESCRIPTION
Previously, the bang always searched for “time” regardless of the query.

---

This is the URL that Lifeprint’s search form uses (https://www.lifeprint.com in the upper left). It looks like the `ie` and `sa` parameters are not needed, but I left them in since the web site uses them.