### PR TITLE
move !rb to ruby-lang.org

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -74415,9 +74415,9 @@
   },
   {
     "s": "RubyDoc.info",
-    "d": "rdoc.info",
+    "d": "rubydoc.info",
     "t": "rdoc",
-    "u": "http://rdoc.info/find/github?q={{{s}}}",
+    "u": "https://www.rubydoc.info/find/gems?q={{{s}}}",
     "c": "Tech",
     "sc": "Languages (ruby)"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -74094,9 +74094,10 @@
   },
   {
     "s": "Current ruby docs",
-    "d": "rubydocs.org",
+    "d": "www.google.com",
+    "ad": "docs.ruby-lang.org",
     "t": "rb",
-    "u": "https://rubydocs.org/d/ruby-latest/?q={{{s}}}",
+    "u": "https://www.google.com/cse?q={{{s}}}&cx=013598269713424429640:g5orptiw95w&ie=UTF-8",
     "c": "Tech",
     "sc": "Programming"
   },
@@ -77254,6 +77255,7 @@
   {
     "s": "Ruby-lang.org",
     "d": "www.google.com",
+    "ad": "docs.ruby-lang.org",
     "t": "ruby",
     "u": "https://www.google.com/cse?q={{{s}}}&cx=013598269713424429640:g5orptiw95w&ie=UTF-8",
     "c": "Tech",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -74415,7 +74415,7 @@
   },
   {
     "s": "RubyDoc.info",
-    "d": "rubydoc.info",
+    "d": "www.rubydoc.info",
     "t": "rdoc",
     "u": "https://www.rubydoc.info/find/gems?q={{{s}}}",
     "c": "Tech",


### PR DESCRIPTION
https://rubydocs.org has been brought offline. I now pointed !rb to !ruby which searches ruby-lang.org

I also updated !ruby to have a correct alternate domain set