### PR TITLE
added Royal Society Collection Catalogues

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -76813,6 +76813,30 @@
     "sc": "Tech"
   },
   {
+    "s": "Royal Society Collections Catalogues, archives",
+    "d": "https://catalogues.royalsociety.org/CalmView/default.aspx",
+    "t": "rsca",
+    "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.Catalog&r=((((text)=%27{{{s}}}%27)))",
+    "c": "Research",
+    "sc": "Academic"
+  },
+  {
+    "s": "Royal Society Collections Catalogues, printed works",
+    "d": "https://catalogues.royalsociety.org/CalmView/default.aspx",
+    "t": "rscp",
+    "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.CatalogL&r=((((text)=%27{{{s}}}%27)))",
+    "c": "Research",
+    "sc": "Academic"
+  },
+  {
+    "s": "Royal Society Collections Catalogues, past Fellows by surname",
+    "d": "https://catalogues.royalsociety.org/CalmView/default.aspx",
+    "t": "rscf",
+    "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.Persons&r=(((Surname=%27{{{s}}}%27)))",
+    "c": "Research",
+    "sc": "Academic"
+  },
+  {
     "s": "RS Components (DE)",
     "d": "de.rs-online.com",
     "t": "rsde",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -76814,25 +76814,25 @@
   },
   {
     "s": "Royal Society Collections Catalogues, archives",
-    "d": "catalogues.royalsociety.org/CalmView",
+    "d": "catalogues.royalsociety.org",
     "t": "rsca",
-    "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.Catalog&r=((((text)=%27{{{s}}}%27)))",
+    "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.Catalog&r=((((text)='{{{s}}}')))",
     "c": "Research",
     "sc": "Academic"
   },
   {
     "s": "Royal Society Collections Catalogues, printed works",
-    "d": "catalogues.royalsociety.org/CalmView",
+    "d": "catalogues.royalsociety.org",
     "t": "rscp",
-    "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.CatalogL&r=((((text)=%27{{{s}}}%27)))",
+    "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.CatalogL&r=((((text)='{{{s}}}')))",
     "c": "Research",
     "sc": "Academic"
   },
   {
     "s": "Royal Society Collections Catalogues, past Fellows by surname",
-    "d": "catalogues.royalsociety.org/CalmView",
+    "d": "catalogues.royalsociety.org",
     "t": "rscf",
-    "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.Persons&r=(((Surname=%27{{{s}}}%27)))",
+    "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.Persons&r=(((Surname='{{{s}}}')))",
     "c": "Research",
     "sc": "Academic"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -76814,7 +76814,7 @@
   },
   {
     "s": "Royal Society Collections Catalogues, archives",
-    "d": "https://catalogues.royalsociety.org/CalmView/default.aspx",
+    "d": "catalogues.royalsociety.org/CalmView",
     "t": "rsca",
     "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.Catalog&r=((((text)=%27{{{s}}}%27)))",
     "c": "Research",
@@ -76822,7 +76822,7 @@
   },
   {
     "s": "Royal Society Collections Catalogues, printed works",
-    "d": "https://catalogues.royalsociety.org/CalmView/default.aspx",
+    "d": "catalogues.royalsociety.org/CalmView",
     "t": "rscp",
     "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.CatalogL&r=((((text)=%27{{{s}}}%27)))",
     "c": "Research",
@@ -76830,7 +76830,7 @@
   },
   {
     "s": "Royal Society Collections Catalogues, past Fellows by surname",
-    "d": "https://catalogues.royalsociety.org/CalmView/default.aspx",
+    "d": "catalogues.royalsociety.org/CalmView",
     "t": "rscf",
     "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.Persons&r=(((Surname=%27{{{s}}}%27)))",
     "c": "Research",


### PR DESCRIPTION
I'm following the pattern for library catalogues, but the RS has three separate ones. The first two are normal keyword searches. The Fellow search is by surname.

Searching the Fellows by text is possible, but not very useful. If you need the search for Fellows to follow the keyword model, change `Surname` to `(text)` as in the previous queries.

Respectfully submitted,