### PR TITLE
Update Warframe related bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -95881,11 +95881,11 @@
   },
   {
     "s": "Warframe",
-    "d": "warframe.wikia.com",
+    "d": "wiki.warframe.com",
     "t": "warframe",
-    "u": "https://warframe.wikia.com/wiki/Special:Search?search={{{s}}}&fulltext=Search&ns0=1&ns14=1",
-    "c": "Online Services",
-    "sc": "Search"
+    "u": "https://wiki.warframe.com/?search={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (specific)"
   },
   {
     "s": "Total war Warhammer Wiki",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -96885,9 +96885,9 @@
   },
   {
     "s": "WARFRAME Wiki",
-    "d": "warframe.wikia.com",
+    "d": "wiki.warframe.com",
     "t": "wfen",
-    "u": "https://warframe.wikia.com/wiki/Special:Search?query={{{s}}}",
+    "u": "https://wiki.warframe.com/?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },
@@ -96925,11 +96925,11 @@
   },
   {
     "s": "Warframe",
-    "d": "warframe.wikia.com",
+    "d": "wiki.warframe.com",
     "t": "wframe",
-    "u": "https://warframe.wikia.com/wiki/Special:Search?search={{{s}}}&fulltext=Search&ns0=1&ns14=1",
-    "c": "Online Services",
-    "sc": "Search"
+    "u": "https://wiki.warframe.com/?search={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (specific)"
   },
   {
     "s": "Wordreference",
@@ -96949,17 +96949,17 @@
   },
   {
     "s": "WARFRAME Wiki",
-    "d": "warframe.wikia.com",
+    "d": "wiki.warframe.com",
     "t": "wfwiki",
-    "u": "https://warframe.wikia.com/wiki/Special:Search?search={{{s}}}",
+    "u": "https://wiki.warframe.com/?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },
   {
     "s": "WARFRAME Wiki",
-    "d": "warframe.wikia.com",
+    "d": "wiki.warframe.com",
     "t": "wfw",
-    "u": "https://warframe.wikia.com/wiki/Special:WikiaSearch?search={{{s}}}&fulltext=Search",
+    "u": "https://wiki.warframe.com/?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },


### PR DESCRIPTION
The official wiki for Warframe has moved, so update all the associated bangs. The DE Warframe wikia bang has been left as there is no German equivalent of the new wiki. Also updated the categories to better reflect these are video game related bangs. Official announcement of the Wiki's move is [here](https://www.warframe.com/news/devstream-184-overview).