### PR TITLE
fix(bangs): update `!cve` to use new website

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -18409,9 +18409,9 @@
   },
   {
     "s": "Common Vulnerabilities and Exposures (CVE)",
-    "d": "cve.mitre.org",
+    "d": "www.cve.org",
     "t": "cve",
-    "u": "https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword={{{s}}}",
+    "u": "https://www.cve.org/CVERecord/SearchResults?query={{{s}}}",
     "c": "Tech",
     "sc": "Libraries/Frameworks"
   },


### PR DESCRIPTION
Hi,

tl;dr: This is a simple maintenance update.

The website for CVEs is being renovated and migrated to a new domain. Migrating the bang to the new domain will prevent breaking the bang when the previous site goes down.

Please let me know if fixes should be applied.