### PR TITLE
change !posix from Issue 7 to Issue 8

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -70783,10 +70783,10 @@
     "sc": "Programming"
   },
   {
-    "s": "The Open Group",
+    "s": "The Open Group Base Specifications",
     "d": "pubs.opengroup.org",
     "t": "posix",
-    "u": "https://pubs.opengroup.org/cgi/kman4.cgi?value={{{s}}}",
+    "u": "https://pubs.opengroup.org/cgi/kman5.cgi?value={{{s}}}",
     "c": "Tech",
     "sc": "Sysadmin (man)"
   },


### PR DESCRIPTION
change !posix as [The Open Group Base Specifications, Issue 7, 2018 Edition](https://publications.opengroup.org/standards/unix/c181) = [IEEE Std 1003.1-2017](https://ieeexplore.ieee.org/document/8277153) is superseded by [The Open Group Base Specifications, Issue 8](https://publications.opengroup.org/standards/unix/c243) = [IEEE Std 1003.1-2024](https://ieeexplore.ieee.org/document/10555529)