### PR TITLE
update VIAF search url

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -93842,7 +93842,7 @@
     "s": "VIAF (Virtual Internet Authority File)",
     "d": "viaf.org",
     "t": "viaf",
-    "u": "https://viaf.org/viaf/search?query=local.names+all+\"{{{s}}}\"&stylesheet=/viaf/xsl/results.xsl&sortKeys=holdingscount&maximumRecords=100",
+    "u": "https://viaf.org/en/viaf/search?field=local%2Cnames&index=VIAF&searchTerms={{{s}}}",
     "c": "Research",
     "sc": "Reference"
   },


### PR DESCRIPTION
VIAF changed its formatting a while ago, making `!viaf` useless. This updates the URL to make it work again. Let me know if I am doing this right!