### PR TITLE
Clean up English Wikipedia bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -102727,6 +102727,14 @@
     "sc": "Academic"
   },
   {
+    "s": "Wikipedia",
+    "d": "en.wikipedia.org",
+    "t": "we",
+    "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
     "s": "Wikispecies",
     "d": "species.wikimedia.org",
     "t": "wikispecies",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -102652,7 +102652,7 @@
     "t": "wikispecies",
     "u": "https://species.wikimedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
-    "sc": "Learning"
+    "sc": "Academic"
   },
   {
     "s": "Wikipedia",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -102684,7 +102684,7 @@
     "t": "encyclopedia",
     "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
-    "sc": "Academic"
+    "sc": "Reference"
   },
   {
     "s": "Wikipedia",
@@ -102716,7 +102716,7 @@
     "t": "w.en",
     "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
-    "sc": "Learning"
+    "sc": "Reference"
   },
   {
     "s": "Wikipedia",
@@ -102732,7 +102732,7 @@
     "t": "wk",
     "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
-    "sc": "Academic"
+    "sc": "Reference"
   },
   {
     "s": "Wikipedia",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -102647,7 +102647,7 @@
     ]
   },
   {
-    "s": "English Wikipedia",
+    "s": "Wikipedia",
     "d": "en.wikipedia.org",
     "t": "wikipedia",
     "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
@@ -102655,7 +102655,7 @@
     "sc": "Reference"
   },
   {
-    "s": "English Wikipedia",
+    "s": "Wikipedia",
     "d": "en.wikipedia.org",
     "t": "wiki",
     "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
@@ -102663,7 +102663,7 @@
     "sc": "Reference"
   },
   {
-    "s": "English Wikipedia",
+    "s": "Wikipedia",
     "d": "en.wikipedia.org",
     "t": "w",
     "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
@@ -102671,7 +102671,7 @@
     "sc": "Reference"
   },
   {
-    "s": "English Wikipedia",
+    "s": "Wikipedia",
     "d": "en.wikipedia.org",
     "t": "wen",
     "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
@@ -102679,7 +102679,7 @@
     "sc": "Reference"
   },
   {
-    "s": "English Wikipedia",
+    "s": "Wikipedia",
     "d": "en.wikipedia.org",
     "t": "enwiki",
     "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
@@ -102687,7 +102687,7 @@
     "sc": "Reference"
   },
   {
-    "s": "English Wikipedia",
+    "s": "Wikipedia",
     "d": "en.wikipedia.org",
     "t": "wikien",
     "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -106361,14 +106361,6 @@
     "sc": "Learning"
   },
   {
-    "s": "Wikipedia in Spanish",
-    "d": "en.wikipedia.org",
-    "t": "w-es",
-    "u": "https://en.wikipedia.org/wiki/Special:Search?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
     "s": "Wikipedia Euskaraz (in Basque)",
     "d": "eu.wikipedia.org",
     "t": "weus",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -102759,6 +102759,14 @@
     "sc": "Reference"
   },
   {
+    "s": "Wikipedia Modules",
+    "d": "en.wikipedia.org",
+    "t": "wikimodule",
+    "u": "https://en.wikipedia.org/wiki/Module:{{{s}}}",
+    "c": "Research",
+    "sc": "Academic"
+  },
+  {
     "s": "Wikipedia Templates",
     "d": "en.wikipedia.org",
     "t": "wikitemplate",
@@ -106231,14 +106239,6 @@
     "u": "https://ja.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Reference"
-  },
-  {
-    "s": "Wikipedia",
-    "d": "en.wikipedia.org",
-    "t": "module",
-    "u": "https://en.wikipedia.org/wiki/Module:{{{s}}}",
-    "c": "Tech",
-    "sc": "Languages (lua)"
   },
   {
     "s": "Dutch Wikipedia",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -102695,6 +102695,14 @@
     "sc": "Reference"
   },
   {
+    "s": "Wikispecies",
+    "d": "species.wikimedia.org",
+    "t": "wikispecies",
+    "u": "https://species.wikimedia.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
     "s": "German Wikipedia",
     "d": "de.wikipedia.org",
     "t": "wde",
@@ -106453,14 +106461,6 @@
     "d": "pl.wikipedia.org",
     "t": "wiki.pl",
     "u": "https://pl.wikipedia.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Learning"
-  },
-  {
-    "s": "Wikispecies",
-    "d": "en.wikipedia.org",
-    "t": "wikispecies",
-    "u": "https://en.wikipedia.org/wiki/Special:Search?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -102647,6 +102647,14 @@
     ]
   },
   {
+    "s": "Wikispecies",
+    "d": "species.wikimedia.org",
+    "t": "wikispecies",
+    "u": "https://species.wikimedia.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
     "s": "Wikipedia",
     "d": "en.wikipedia.org",
     "t": "wikipedia",
@@ -102735,12 +102743,20 @@
     "sc": "Reference"
   },
   {
-    "s": "Wikispecies",
-    "d": "species.wikimedia.org",
-    "t": "wikispecies",
-    "u": "https://species.wikimedia.org/w/index.php?search={{{s}}}",
+    "s": "Wikipedia Random in Category",
+    "d": "en.wikipedia.org",
+    "t": "wrand",
+    "u": "https://en.wikipedia.org/wiki/Special:RandomInCategory/{{{s}}}",
     "c": "Research",
     "sc": "Learning"
+  },
+  {
+    "s": "Wikipedia Band Discography",
+    "d": "en.wikipedia.org",
+    "t": "wdg",
+    "u": "https://en.wikipedia.org/w/index.php?title=Special:Search&search={{{s}}}+discography",
+    "c": "Research",
+    "sc": "Reference"
   },
   {
     "s": "German Wikipedia",
@@ -106377,14 +106393,6 @@
     "sc": "Games (Pokemon)"
   },
   {
-    "s": "wikipedia.org Band Discography",
-    "d": "en.wikipedia.org",
-    "t": "wdg",
-    "u": "https://en.wikipedia.org/w/index.php?title=Special:Search&search={{{s}}}+discography",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
     "s": "Wikipedia (DK)",
     "d": "da.wikipedia.org",
     "t": "wdk",
@@ -106543,14 +106551,6 @@
     "u": "https://fr.wikipedia.org/wiki/{{{s}}}",
     "c": "Research",
     "sc": "Learning (intl)"
-  },
-  {
-    "s": "Wikipedia Random in Category",
-    "d": "en.wikipedia.org",
-    "t": "wrand",
-    "u": "https://en.wikipedia.org/wiki/Special:RandomInCategory/{{{s}}}",
-    "c": "Research",
-    "sc": "Learning"
   },
   {
     "s": "Russian Wikipedia",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -102673,6 +102673,14 @@
   {
     "s": "Wikipedia",
     "d": "en.wikipedia.org",
+    "t": "encyclopedia",
+    "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Academic"
+  },
+  {
+    "s": "Wikipedia",
+    "d": "en.wikipedia.org",
     "t": "wen",
     "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -102693,6 +102701,30 @@
     "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Reference"
+  },
+  {
+    "s": "Wikipedia",
+    "d": "en.wikipedia.org",
+    "t": "w.en",
+    "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Wikipedia",
+    "d": "en.wikipedia.org",
+    "t": "wi",
+    "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Wikipedia",
+    "d": "en.wikipedia.org",
+    "t": "wk",
+    "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Academic"
   },
   {
     "s": "Wikispecies",
@@ -106127,14 +106159,6 @@
     "sc": "Reference"
   },
   {
-    "s": "Wikipedia",
-    "d": "en.wikipedia.org",
-    "t": "encyclopedia",
-    "u": "https://en.wikipedia.org/wiki/Special:Search?search={{{s}}}",
-    "c": "Research",
-    "sc": "Academic"
-  },
-  {
     "s": "Google de.Wikipedia",
     "d": "www.google.de",
     "ad": "de.wikipedia.org",
@@ -106361,28 +106385,12 @@
     "sc": "Reference"
   },
   {
-    "s": "Wikipedia (English)",
-    "d": "en.wikipedia.org",
-    "t": "w.en",
-    "u": "https://en.wikipedia.org/wiki/Special:Search?search={{{s}}}",
-    "c": "Research",
-    "sc": "Learning"
-  },
-  {
     "s": "Wikipedia Euskaraz (in Basque)",
     "d": "eu.wikipedia.org",
     "t": "weus",
     "u": "https://eu.wikipedia.org/wiki/Special:Search?search={{{s}}}",
     "c": "Research",
     "sc": "Academic"
-  },
-  {
-    "s": "Wikipedia",
-    "d": "en.wikipedia.org",
-    "t": "we",
-    "u": "https://en.wikipedia.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
   },
   {
     "s": "fr.wikipedia.org",
@@ -106473,14 +106481,6 @@
     "sc": "Reference"
   },
   {
-    "s": "Wikipedia",
-    "d": "en.wikipedia.org",
-    "t": "wi",
-    "u": "https://en.wikipedia.org/wiki/Special:Search?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
     "s": "Wikipedia (Chinese)",
     "d": "zh.wikipedia.org",
     "t": "wizh",
@@ -106495,14 +106495,6 @@
     "u": "https://ja.wikipedia.org/wiki/{{{s}}}",
     "c": "Research",
     "sc": "Reference"
-  },
-  {
-    "s": "wikipedia",
-    "d": "en.wikipedia.org",
-    "t": "wk",
-    "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Academic"
   },
   {
     "s": "Wikipedia Deutsch Mobile",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -102759,6 +102759,14 @@
     "sc": "Reference"
   },
   {
+    "s": "Wikipedia Templates",
+    "d": "en.wikipedia.org",
+    "t": "wikitemplate",
+    "u": "https://en.wikipedia.org/wiki/Template:{{{s}}}",
+    "c": "Research",
+    "sc": "Academic"
+  },
+  {
     "s": "German Wikipedia",
     "d": "de.wikipedia.org",
     "t": "wde",
@@ -106287,14 +106295,6 @@
     "u": "https://ta.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning (intl)"
-  },
-  {
-    "s": "Wikipedia Templates",
-    "d": "en.wikipedia.org",
-    "t": "template",
-    "u": "https://en.wikipedia.org/wiki/Template:{{{s}}}",
-    "c": "Tech",
-    "sc": "Languages (lua)"
   },
   {
     "s": "Vicipaedia",


### PR DESCRIPTION
- unified the name for the english version: `English Wikipedia/Wikipedia (English)/Wikipedia` -> `Wikipedia`
- removed misleading bangs: `w-es` was actually english wikipedia despite being called `Wikipedia (in Spanish)`
- fixed wikispecies bang, as it previously linked to regular wikipedia instead
- updated all english wikipedia bang urls to be the same
- unified subcategories for regular wikipedia bangs
- `template` -> `wikitemplate` & `module` -> `wikimodule`, because common words aren't allowed to be bangs. also updated their titles
- grouped all english bangs together because previously they were spread all across the psuedo "wikipedia section" of the file

i'd also remove the "encyclopedia" bang if i was to strictly follow the common word rule, but i think it can have a pass because it's used for wikipedia, the world's most popular encyclopedia. just pointing it out in case this change is needed.