### PR TITLE
Fix mistral bang's subcategory and name

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -14403,6 +14403,14 @@
     "sc": "AI Chatbots"
   },
   {
+    "s": "Le Chat",
+    "d": "chat.mistral.ai",
+    "t": "mistral",
+    "u": "https://chat.mistral.ai/chat?q={{{s}}}",
+    "c": "Online Services",
+    "sc": "AI Chatbots"
+  },
+  {
     "s": "OpenRouter",
     "d": "openrouter.ai",
     "t": "opr",
@@ -58186,14 +58194,6 @@
     "u": "https://mistborn.wikia.com/wiki/Special:Search?search={{{s}}}",
     "c": "Multimedia",
     "sc": "Books"
-  },
-  {
-    "s": "Mistral Chat",
-    "d": "chat.mistral.ai",
-    "t": "mistral",
-    "u": "https://chat.mistral.ai/chat?q={{{s}}}",
-    "c": "Online Services",
-    "sc": "Tools"
   },
   {
     "s": "Misumi USA",


### PR DESCRIPTION
identical alternative bang is named “Le Chat”, so i figured it makes sense to rename this one to be “Le Chat” too