### PR TITLE
bangs: replace abe to amazon belgium

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -1273,10 +1273,10 @@
     "sc": "Games (offline)"
   },
   {
-    "s": "Abe's Market",
-    "d": "www.abesmarket.com",
+    "s": "Amazon Belgium",
+    "d": "www.amazon.com.be",
     "t": "abe",
-    "u": "https://www.abesmarket.com/catalogsearch/result/?cat=5&order=relevance&dir=desc&q={{{s}}}",
+    "u": "https://www.amazon.com.be/s?k={{{s}}}",
     "c": "Shopping",
     "sc": "Online"
   },


### PR DESCRIPTION
The previous search to Abe's Market was broken for months (seems to no longer exists and the domain was taken over).