### PR TITLE
Fix some broken Norwegian URLs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -55844,7 +55844,7 @@
     "s": "MatPrat",
     "d": "www.matprat.no",
     "t": "matprat",
-    "u": "https://www.matprat.no/sok?searchFor=fisk",
+    "u": "https://www.matprat.no/sok?searchFor={{{s}}}",
     "c": "Research",
     "sc": "Food"
   },


### PR DESCRIPTION
Fix broken URLs for: alesund, deic, matprat, nb, norid, posten and vartoslo