### PR TITLE
catalogue for the National Library of Wales

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -63174,6 +63174,14 @@
     "sc": "Reference"
   },
   {
+    "s": "Llyfrgell Genedlaethol Cymru = The National Library of Wales",
+    "d": "discover.library.wales",
+    "t": "nlow",
+    "u": "https://discover.library.wales/discovery/search?query=any,contains,{{{s}}}&tab=In_The_Library&search_scope=In_The_Library&vid=44WHELF_NLW:44WHELF_NLW_NUI&offset=0",
+    "c": "Research",
+    "sc": "Academic"
+  },
+  {
     "s": "Naver Map",
     "d": "map.naver.com",
     "t": "nmap",


### PR DESCRIPTION
Catalogue search for the National Library of Wales, also known as Llyfrgell Genedlaethol Cymru in Welsh. They seem to use the Welsh name first in branding.

(FWIW, I'd prefer this to have been !nlw, but a wiki of television shows has it. It might be worth thinking about who gets short tags. Deciding whether the NLW or Nolife-wiki has better claim to a shorter tag might be a complicated question of international politics if it weren't first-come first-served."