### PR TITLE
fix broken !mario bang, making url same as !mariowiki

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -55570,7 +55570,7 @@
     "s": "Super Mario Wiki",
     "d": "www.mariowiki.com",
     "t": "mario",
-    "u": "https://www.mariowiki.com/{{{s}}}",
+    "u": "https://www.mariowiki.com/index.php?title=Special:Search&search={{{s}}}&go=Go",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },


### PR DESCRIPTION
the current url setup for the `!mario` bang does not work correctly. For instance, searching `!mario luigi's mansion` on Kagi brings the user to `https://www.mariowiki.com/Luigi%27s%2Bmansion`, a broken page. This PR makes the `!mario` bang target the same url as the correctly working `!mariowiki` bang.