### PR TITLE
Fix broken !baseball, make same as !bbref

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -11392,7 +11392,7 @@
     "s": "Baseball-Reference",
     "d": "www.baseball-reference.com",
     "t": "baseball",
-    "u": "https://www.baseball-reference.com/pl/player_search.cgi?search={{{s}}}",
+    "u": "https://www.baseball-reference.com/search/search.fcgi?hint=&search={{{s}}}",
     "c": "Research",
     "sc": "Reference"
   },


### PR DESCRIPTION
[`player_search.cgi`](https://www.baseball-reference.com/pl/player_search.cgi) seems to no longer exist