### PR TITLE
Clean up a bunch of Google-related bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -38166,14 +38166,6 @@
     "sc": "Google"
   },
   {
-    "s": "Google with SSL",
-    "d": "google.com",
-    "t": "gssl",
-    "u": "https://google.com/search?q={{{s}}}",
-    "c": "Online Services",
-    "sc": "Google"
-  },
-  {
     "s": "Google Store",
     "d": "store.google.com",
     "t": "gstore",


### PR DESCRIPTION
- removed Google Plus & Google Play Music bangs, as they no longer work
- updated Google search bangs' URL to avoid a meaningless redirect from `google.com` to `www.google.com`
- updated miscapitalized and poorly phrased Google-related bang names
   - also renamed `!goog` from "unencrypted google search" to "Google"
- removed `!gssl`, since Google uses SSL by default