### PR TITLE
Fix `githubhelp` bang and add bang for `docs.github.com`

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -32290,6 +32290,17 @@
     "sc": "Programming"
   },
   {
+    "s": "GitHub Docs",
+    "d": "docs.github.com",
+    "t": "githubdocs",
+    "ts": [
+      "ghd"
+    ],
+    "u": "https://docs.github.com/search?query={{{s}}}",
+    "c": "Tech",
+    "sc": "Programming"
+  },
+  {
     "s": "GitHub Pages (Kagi Search)",
     "d": "kagi.com",
     "ad": "github.io",


### PR DESCRIPTION
This PR:

1. Fixes `!githubhelp`
    - Updates `help.github.com` to `support.github.com`
    - Adds `ghh`, `githubsupport`, `ghs` as additional triggers
2. Adds `!githubdocs` bang
    - Searches `docs.github.com`
    - Adds `ghd` as an additional trigger
