### PR TITLE
fix: adjust !kubernetes to move to /search instead of /docs/search

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -43555,14 +43555,6 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Kubernetes",
-    "d": "kubernetes.io",
-    "t": "kubernetes",
-    "u": "https://kubernetes.io/search/?q={{{s}}}",
-    "c": "Tech",
-    "sc": "Sysadmin"
-  },
-  {
     "s": "Kaartje2go",
     "d": "www.kaartje2go.nl",
     "t": "kaartje",


### PR DESCRIPTION
`/docs/search` seems to be deprecated in favor of `/search`. `/docs/search` gives back a 404

Moved `!kubernetes` next to `!k8s` in the json doc.