### PR TITLE
Update Chrome Web Store bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -13747,7 +13747,7 @@
   },
   {
     "s": "Chrome Web Store",
-    "d": "chrome.google.com",
+    "d": "chromewebstore.google.com",
     "t": "chrome",
     "ts": [
       "chromestore",


### PR DESCRIPTION
The URL of the Chrome Web Store has been updated from https://chrome.google.com/webstore to https://chromewebstore.google.com/.

This PR includes this update, plus the merging of the bang `crx`, which also pointed to the outdated URL (and contained a no longer valid query parameter).