### PR TITLE
Update bctag destination

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -7782,7 +7782,7 @@
     "s": "Bandcamp tags",
     "d": "bandcamp.com",
     "t": "bctag",
-    "u": "https://bandcamp.com/tag/{{{s}}}",
+    "u": "https://bandcamp.com/discover/{{{s}}}",
     "c": "Multimedia",
     "sc": "Music"
   },


### PR DESCRIPTION
`https://bandcamp.com/tag/<tag>` now returns a permanent redirect to `/discover/<tag>`

```shell
> curl -I https://bandcamp.com/tag/krautrock
HTTP/2 301
server: nginx
content-type: text/html; charset=UTF-8
location: /discover/krautrock
```