### PR TITLE
Add new alias to ChatGPT bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -13287,6 +13287,9 @@
     "s": "ChatGPT",
     "d": "chatgpt.com",
     "t": "chatgpt",
+    "ts": [
+      "cgpt"
+    ],
     "u": "https://chatgpt.com/?q={{{s}}}",
     "c": "Online Services",
     "sc": "AI Chatbots"


### PR DESCRIPTION
Hi! 👋

Many of us regularly use the custom site search for ChatGPT. The common shortcut would be gpt, but since that’s already mapped to Google Portugal, I’ve added a new alias: cgpt.

This should make it quicker and easier to search ChatGPT without conflicting with existing shortcuts.

It’s a small change, but it could be a nice quality-of-life improvement for those of us who use it often. If it makes sense to merge, that would be awesome! If not, no worries at all.

Thanks!