### PR TITLE
Use docs.ruby-lang.org search directly

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -65825,13 +65825,12 @@
   },
   {
     "s": "Current ruby docs",
-    "d": "www.google.com",
-    "ad": "docs.ruby-lang.org",
+    "d": "docs.ruby-lang.org",
     "t": "rb",
     "ts": [
       "ruby"
     ],
-    "u": "https://www.google.com/cse?q={{{s}}}&cx=013598269713424429640:g5orptiw95w&ie=UTF-8",
+    "u": "https://docs.ruby-lang.org/en/master/?q={{{s}}}",
     "c": "Tech",
     "sc": "Programming"
   },


### PR DESCRIPTION
The latest version of RDoc, which Ruby's just upgraded to, has a built-in javascript powered search, similar to what !rails does. This should delivery better results than the google search.
https://github.com/ruby/rdoc/pull/1396

old: https://cse.google.com/cse?q=String%23gsub&cx=013598269713424429640:g5orptiw95w&ie=UTF-8
new: https://docs.ruby-lang.org/en/master/?q=String%23gsub


Refs: https://github.com/kagisearch/bangs/pull/195 https://github.com/ruby/rdoc/issues/1319