### PR TITLE
Add "xuser" alias to Twitter user bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -80297,7 +80297,8 @@
     "d": "twitter.com",
     "t": "twitters",
     "ts": [
-      "twitteruser"
+      "twitteruser",
+      "xuser"
     ],
     "u": "https://twitter.com/{{{s}}}",
     "c": "Online Services",


### PR DESCRIPTION
Added a shorter alias for twitteruser, using the newer name X.

We might also want to update the URL to x.com/user, since twitter.com/user now redirects there. Let me know if you'd like me to include that change as well.