### PR TITLE
remove doai.io, add entry for engrxiv.org

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -24637,7 +24637,7 @@
     "ts": [
       "engrxiv"
     ],
-    "u": "https://engrxiv.org/search/search?query={{{s}}},
+    "u": "https://engrxiv.org/search/search?query={{{s}}}",
     "c": "Research",
     "sc": "Academic"
   },


### PR DESCRIPTION
doai.io does not resolve, attempts to redirect to malware site.