### PR TITLE
Add Chromium Review bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -16102,6 +16102,17 @@
     "sc": "Programming"
   },
   {
+    "s": "Chromium Review",
+    "d": "chromium-review.googlesource.com",
+    "t": "cge",
+    "ts": [
+      "cgerrit"
+    ],
+    "u": "https://chromium-review.googlesource.com/q/{{{s}}}",
+    "c": "Tech",
+    "sc": "Programming"
+  },
+  {
     "s": "Chain Reaction Cycles",
     "d": "www.chainreactioncycles.com",
     "t": "crc",


### PR DESCRIPTION
This PR adds `!cge` and `!cgerrit` bangs for [Chromium Review](https://chromium-review.googlesource.com/), something that'd be very handy for anyone working with Chromium