### PR TITLE
corrected search query for UVa Catalog

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -82314,7 +82314,7 @@
     "ts": [
       "uvalib"
     ],
-    "u": "https://search.lib.virginia.edu/catalog?q={{{s}}}",
+    "u": "https://search.lib.virginia.edu/search?q=keyword:+{{{{s}}}}&pool=uva_library&sort=SortRelevance_desc",
     "c": "Research",
     "sc": "Academic"
   },


### PR DESCRIPTION
The API for the University of Virginia Library catalog changed. This query works now.

Respectfully submitted,