### PR TITLE
Add SeriesGraph bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -70692,6 +70692,15 @@
     "sc": "TV"
   },
   {
+    "s": "SeriesGraph",
+    "d": "seriesgraph.com",
+    "t": "sgr",
+    "ts": ["seriesgraph"],
+    "u": "https://seriesgraph.com/show/search/{{{s}}}",
+    "c": "Entertainment",
+    "sc": "TV"
+  },
+  {
     "s": "servershop24",
     "d": "www.servershop24.de",
     "t": "server24",


### PR DESCRIPTION
This PR adds a couple of bangs for the [SeriesGraph](https://seriesgraph.com/) website. Bangs are `!sgr` and `!seriesgraph`

I categorized it under Entertainment > TV since the main purpose of the page is to quickly visualize TV show episode ratings by season