### PR TITLE
Fix Real Time Trains URL

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -68527,7 +68527,7 @@
     "s": "Real Time Trains",
     "d": "www.realtimetrains.co.uk",
     "t": "rtt",
-    "u": "https://www.realtimetrains.co.uk/search/handler?type=basic&qs=true&search={{{s}}}",
+    "u": "https://www.realtimetrains.co.uk/search/handler?type=basic&qsearch={{{s}}}",
     "c": "Online Services",
     "sc": "Tracking"
   },


### PR DESCRIPTION
URL for the current Real Time Trains bang fails with no search actually being done ("You have left the location blank.")

This URL change uses the current pattern used by RTT for quick searches.