### PR TITLE
Add period to list of allowed chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Key   | Description  | Required | Notes
 `s`   | Website name | yes      |
 `d`   | Domain       | yes      |
 `ad`  | Alternate Domain | no   | Can be used to specify the domain of the results if the bang searches another website. See `hn` bang.
-`t`   | Trigger      | yes      | May contain letters, numbers, dashes (`-`), and underscores (`_`). No spaces or other special characters.
+`t`   | Trigger      | yes      | May contain letters, numbers, dashes (`-`), periods (`.`), and underscores (`_`). No spaces or other special characters.
 `ts`  | Additional triggers     | Additional triggers that invoke this bang
 `u`   | URL template | yes      | Use `{{{s}}}` for query placeholder.
 `x`   | Regex pattern | no      | Regex pattern that can be used for parsing the query for more complex bangs, allowing substition using `$1`, `$2`, etc.


### PR DESCRIPTION
Several bangs already use a period (`.`) in them (e.g. `a.es`), which the documentation seems to imply is not allowed.

Either the bangs or the docs need fixing, and I'd hope it's the latter.

