### PR TITLE
feat: add 7TV & BetterTTV 3rd-party Twitch emote providers

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -8341,6 +8341,14 @@
     "sc": "TV"
   },
   {
+    "s": "BetterTTV",
+    "d": "betterttv.com",
+    "t": "bttv",
+    "u": "https://betterttv.com/emotes/shared/search?query={{{s}}}",
+    "c": "Online Services",
+    "sc": "Tools"
+  },
+  {
     "s": "betterworldbooks.com",
     "d": "betterworldbooks.com",
     "t": "betterworldbooks",


### PR DESCRIPTION
This PR aims to add bangs for the following 3rd-party Twitch emote providers:
 - [BetterTTV/BTTV](https://betterttv.com/)
 - [7TV](https://7tv.app/)

FrankerFaceZ is already in the bangs list, so these two complete the current trio of popular emote providers.