### PR TITLE
Adding Podnews

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -62826,6 +62826,14 @@
     "sc": "Tools"
   },
   {
+    "s": "Podnews",
+    "d": "podnews.net",
+    "t": "podnews",
+    "u": "https://podnews.net/search?q={{{s}}}",
+    "c": "News",
+    "sc": "Business"
+  },
+  {
     "s": "Path of Exile Database",
     "d": "poedb.tw",
     "t": "poedb",


### PR DESCRIPTION
Podnews is both a podcast industry search engine and a podcast search engine.