### PR TITLE
Add Kagi Translate's dictionary

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -93146,6 +93146,14 @@
     "sc": "General"
   },
   {
+    "s": "Kagi Translate (Dictionary)",
+    "d": "translate.kagi.com",
+    "t": "kdic",
+    "u": "https://translate.kagi.com/dictionary?word={{{s}}}&from=auto",
+    "c": "Translation",
+    "sc": "General"
+  },
+  {
     "s": "Home Assistant Community",
     "d": "community.home-assistant.io",
     "t": "hac",


### PR DESCRIPTION
This PR allocates the `!kdic` bang to Kagi Translate's dictionary.