### PR TITLE
Add bang for Semantic Scholar

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -93253,5 +93253,5 @@
     "c": "Research",
     "sc": "Academic", 
     "fmt": ["open_base_path"]
-  },
+  }
 ]


### PR DESCRIPTION
Semantic Scholar is a search engine for academic papers with the bangs `!semanticscholar` and `!sem`. 