### PR TITLE
Change Perplexity's subcategory to "AI Chatbots"

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -61297,7 +61297,7 @@
     ],
     "u": "https://perplexity.ai/?q={{{s}}}",
     "c": "Online Services",
-    "sc": "Tools"
+    "sc": "AI Chatbots"
   },
   {
     "s": "Personality Database",


### PR DESCRIPTION
Pretty sure Perplexity should be in the "AI Chatbots" category, since that's what it is.