### PR TITLE
Update URL for namuwiki search

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -54637,7 +54637,7 @@
     "s": "namuwiki",
     "d": "namu.wiki",
     "t": "namu",
-    "u": "https://namu.wiki/Search?q={{{s}}}",
+    "u": "https://namu.wiki/Go?q={{{s}}}",
     "c": "Research",
     "sc": "Reference"
   },


### PR DESCRIPTION
Change from .../Search?q= to .../Go?q= which is namuwiki specific path redirecting to the most similar keyword.

Same format is automatically recommended by chromium browsers.
<img width="754" height="68" alt="Screenshot From 2025-12-08 12-53-58" src="https://github.com/user-attachments/assets/9466441f-f87c-4d0d-a6d5-b5b4433d43d9" />
