### PR TITLE
fix(php): use www.php.net instead of secure.php.net

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -61759,13 +61759,13 @@
   },
   {
     "s": "PHP.net",
-    "d": "secure.php.net",
+    "d": "www.php.net",
     "ad": "php.net",
     "t": "phpnet",
     "ts": [
       "php"
     ],
-    "u": "https://secure.php.net/manual-lookup.php?pattern={{{s}}}",
+    "u": "https://www.php.net/manual-lookup.php?pattern={{{s}}}",
     "c": "Tech",
     "sc": "Languages (php)"
   },


### PR DESCRIPTION
secure.php.net nowadays just redirects to www.php.net and as per https://github.com/php/web-php/issues/1684#issuecomment-3626277253, they'd (understandably) prefers others to _not_ use the secure.php.net redirect. 

Ref: https://github.com/php/web-php/issues/1684