### PR TITLE
Clean up Yandex bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -42024,15 +42024,15 @@
     "sc": "Blogs"
   },
   {
-    "s": "Yandex Images",
+    "s": "Yandex Images (en)",
     "d": "yandex.com",
-    "t": "iya",
+    "t": "ymg",
     "ts": [
-      "ymg"
+      "iya"
     ],
     "u": "https://yandex.com/images/search?text={{{s}}}",
-    "c": "Multimedia",
-    "sc": "Images"
+    "c": "Online Services",
+    "sc": "Search (non-US)"
   },
   {
     "s": "izneo",
@@ -54290,11 +54290,12 @@
     "sc": "Search"
   },
   {
-    "s": "market.yandex.ru",
+    "s": "Yandex Market",
     "d": "market.yandex.ru",
     "t": "mya",
     "ts": [
-      "yama"
+      "yama",
+      "yandexm"
     ],
     "u": "https://market.yandex.ru/search?text={{{s}}}",
     "c": "Shopping",
@@ -72336,14 +72337,6 @@
     "sc": "Learning"
   },
   {
-    "s": "Yandex.Slovari",
-    "d": "slovari.yandex.ru",
-    "t": "slov",
-    "u": "https://slovari.yandex.ru/search.xml?text={{{s}}}",
-    "c": "Research",
-    "sc": "Learning (intl)"
-  },
-  {
     "s": "Sololearn Discuss",
     "d": "www.sololearn.com",
     "t": "slqa",
@@ -88795,23 +88788,16 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Yandex Dictionaries",
-    "d": "slovari.yandex.ru",
-    "t": "yad",
-    "u": "https://slovari.yandex.ru/{{{s}}}/",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
     "s": "Yandex (en)",
     "d": "yandex.com",
-    "t": "yaen",
+    "t": "yan",
     "ts": [
+      "yaen",
       "yandexen"
     ],
-    "u": "https://yandex.com/yandsearch?text={{{s}}}",
+    "u": "https://yandex.com/search?text={{{s}}}",
     "c": "Online Services",
-    "sc": "Search (non-US)"
+    "sc": "Search"
   },
   {
     "s": "Yahoo Finance Australia",
@@ -88849,11 +88835,12 @@
     "sc": "Video"
   },
   {
-    "s": "Yandex Music (ru)",
+    "s": "Yandex Music",
     "d": "music.yandex.ru",
     "t": "yamusic",
     "ts": [
-      "yamu"
+      "yamu",
+      "яму"
     ],
     "u": "https://music.yandex.ru/search?text={{{s}}}",
     "c": "Multimedia",
@@ -88881,44 +88868,12 @@
     "sc": "Maps"
   },
   {
-    "s": "Yandex Market",
-    "d": "market.yandex.ru",
-    "t": "yandexm",
-    "u": "https://market.yandex.ru/search.xml?text={{{s}}}",
-    "c": "Online Services",
-    "sc": "Search (non-US)"
-  },
-  {
-    "s": "yandex.ru/pogoda/",
-    "d": "yandex.ru",
-    "t": "yandexw",
-    "u": "https://yandex.ru/pogoda/{{{s}}}",
-    "c": "News",
-    "sc": "Weather"
-  },
-  {
-    "s": "Yandex.Ru",
-    "d": "www.yandex.ru",
-    "t": "yandex",
-    "u": "https://www.yandex.ru/yandsearch?text={{{s}}}",
-    "c": "Online Services",
-    "sc": "Search (non-US)"
-  },
-  {
     "s": "Yahoo! Answers",
     "d": "answers.yahoo.com",
     "t": "yanswers",
     "u": "http://answers.yahoo.com/search/search_result;_ylt=AnPnri0ekBBFsWt64sNbHmvj1KIX;_ylv=3?p={{{s}}}&submit-go=Search+Y!+Answers",
     "c": "Online Services",
     "sc": "Social"
-  },
-  {
-    "s": "yandex.com",
-    "d": "www.yandex.com",
-    "t": "yan",
-    "u": "https://www.yandex.com/?q={{{s}}}",
-    "c": "Online Services",
-    "sc": "Search (Private)"
   },
   {
     "s": "Yarn",
@@ -88930,17 +88885,6 @@
     "u": "https://yarnpkg.com/en/packages?q={{{s}}}",
     "c": "Tech",
     "sc": "Languages (javascript)"
-  },
-  {
-    "s": "Yandex Slovari",
-    "d": "slovari.yandex.ru",
-    "t": "yaslovari",
-    "ts": [
-      "ys"
-    ],
-    "u": "https://slovari.yandex.ru/{{{s}}}",
-    "c": "Online Services",
-    "sc": "Search"
   },
   {
     "s": "Yandex Turkey",
@@ -88959,7 +88903,7 @@
     "sc": "Video"
   },
   {
-    "s": "Yandex Translate",
+    "s": "Yandex Translate (en)",
     "d": "translate.yandex.com",
     "t": "yat",
     "ts": [
@@ -88967,7 +88911,7 @@
     ],
     "u": "https://translate.yandex.com/?text={{{s}}}",
     "c": "Online Services",
-    "sc": "Search"
+    "sc": "Tools"
   },
   {
     "s": "Yandex Video",
@@ -88978,18 +88922,14 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Yandex Weather",
-    "d": "yandex.ru",
-    "t": "yaw",
-    "u": "https://yandex.ru/pogoda/search?request={{{s}}}",
-    "c": "News",
-    "sc": "Weather"
-  },
-  {
     "s": "Yandex",
     "d": "yandex.ru",
     "t": "ya",
-    "u": "https://yandex.ru/search/?text={{{s}}}",
+    "ts": [
+      "yandex",
+      "я"
+    ],
+    "u": "https://yandex.ru/search?text={{{s}}}",
     "c": "Online Services",
     "sc": "Search (non-US)"
   },
@@ -89711,9 +89651,15 @@
     "sc": "Programming"
   },
   {
-    "s": "Yandex.Translate",
+    "s": "Yandex Translate",
     "d": "translate.yandex.ru",
     "t": "ytr",
+    "ts": [
+      "ys",
+      "yad",
+      "slov",
+      "yaslovari"
+    ],
     "u": "https://translate.yandex.ru/?text={{{s}}}",
     "c": "Online Services",
     "sc": "Tools"
@@ -90513,28 +90459,16 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Yandex.ru",
+    "s": "Yandex Images",
     "d": "yandex.ru",
-    "t": "я",
-    "u": "https://yandex.ru/yandsearch?text={{{s}}}",
-    "c": "Online Services",
-    "sc": "Search (non-US)"
-  },
-  {
-    "s": "Yandex images (Яндекс картинки)",
-    "d": "yandex.ru",
-    "t": "як",
+    "t": "yai",
+    "ts": [
+      "yak",
+      "як"
+    ],
     "u": "https://yandex.ru/images/search?text={{{s}}}",
     "c": "Online Services",
-    "sc": "Search"
-  },
-  {
-    "s": "Yandex Music",
-    "d": "music.yandex.com",
-    "t": "яму",
-    "u": "https://music.yandex.com/search?text={{{s}}}",
-    "c": "Multimedia",
-    "sc": "Music"
+    "sc": "Search (non-US)"
   },
   {
     "s": "Nayiri",


### PR DESCRIPTION
Yandex Maps:
- Updated the URL to prevent an extra redirect.
- Added !yamaps.
- Replaced "карты" (generic word) with "якарты".
- Removed "ям", because it's called "Яндекс Карты" in Russian, not "Яндекс Мапс". If anything, it should be "як", but that's already taken.

Other Yandex services:
- Merged Yandex Market bangs & updated site name
- Merged Yandex Music bangs & fixed URL
- Moved all Yandex Slovari bangs to Yandex Translate, as that's where the dictionary moved to
- Updated English Yandex URL & subcategory, merged several bangs into one
- Merged several Russian Yandex bangs into one & updated URL
- Removed broken Yandex Weather bangs, as it no longer offers linkable search
- Added !yai and !yak bangs to Russian Yandex Images
- Fixed subcategory of English Yandex Translate
- Fixed category and title of English Yandex Images