### PR TITLE
Fix !avito's URL and subcategory

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -6568,9 +6568,9 @@
     "s": "Avito",
     "d": "www.avito.ru",
     "t": "avito",
-    "u": "https://www.avito.ru/rossiya?q={{{s}}}",
+    "u": "https://www.avito.ru/?q={{{s}}}",
     "c": "Shopping",
-    "sc": "Online (deals)"
+    "sc": "Online (marketplace)"
   },
   {
     "s": "avtoprom.org",


### PR DESCRIPTION
Removes the global scope, so that the search defaults to user's current/preferred region