### PR TITLE
update sklearn bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -72033,9 +72033,9 @@
   {
     "s": "Scikit-Learn (Kagi Search)",
     "d": "kagi.com",
-    "ad": "scikit-learn.org/stable/modules/generated/",
+    "ad": "scikit-learn.org/stable/",
     "t": "sklearn",
-    "u": "/search?q={{{s}}}+site:http://scikit-learn.org/stable/modules/generated/",
+    "u": "/search?q={{{s}}}+site:https://scikit-learn.org/stable/",
     "c": "Research",
     "sc": "Academic (math/cs)"
   },


### PR DESCRIPTION
https://scikit-learn.org/stable/modules/generated/ is 404, so I updated the operator and bang.ad