### PR TITLE
Removed conflicting emojipedia bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -24236,14 +24236,6 @@
     "sc": "Search"
   },
   {
-    "s": "Emojipedia",
-    "d": "emojipedia.org",
-    "t": "emojipedia",
-    "u": "https://emojipedia.org/?s={{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
     "s": "emoney.ge",
     "d": "www.emoney.ge",
     "t": "emoneyge",


### PR DESCRIPTION
Emojipedia has a second bang listed that seems to use an unsupported query parameter. I wanted to remove it as it causes conflict with the correct Emojipedia bang.