### PR TITLE
update domains

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -43738,9 +43738,9 @@
   },
   {
     "s": "Kamus Besar Bahasa Indonesia",
-    "d": "kbbi.kemdikbud.go.id",
+    "d": "kbbi.kemendikdasmen.go.id",
     "t": "kbbi",
-    "u": "https://kbbi.kemdikbud.go.id/entri/{{{s}}}",
+    "u": "https://kbbi.kemendikdasmen.go.id/entri/{{{s}}}",
     "c": "Research",
     "sc": "Reference"
   },


### PR DESCRIPTION
update https://kbbi.kemdikbud.go.id/ to https://kbbi.kemendikdasmen.go.id/ (government agency name changed)

update https://kateglo.com/ to kateglo.lostfocus.org/ (main kateglo website is no longer active and someone maintained an updated clone to this new domain)