### PR TITLE
Update OpenStreetMap

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -58172,12 +58172,12 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Open Street Maps",
+    "s": "OpenStreetMap",
     "d": "www.openstreetmap.org",
-    "t": "omap",
+    "t": "osm",
     "ts": [
       "openmaps",
-      "osm",
+      "omap",
       "ost"
     ],
     "u": "https://www.openstreetmap.org/search?query={{{s}}}",


### PR DESCRIPTION
The project name was spelled incorrectly.

I also changed the default trigger to `osm` to match other OpenStreetMap related bangs. Moved `omap` to additional triggers for backwards compatibility.