### PR TITLE
Add ARC Raiders Wiki

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -93110,5 +93110,14 @@
     "u": "https://libro.fm/search?utf8=%E2%9C%93&q={{{s}}}",
     "c": "Shopping",
     "sc": "Online"
+  },
+  {
+    "s": "ARC Raiders Wiki",
+    "d": "arcraiders.wiki",
+    "t": "arcwiki",
+    "ts": ["arcw"],
+    "u": "https://arcraiders.wiki/w/index.php?search={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (specific)"
   }
 ]


### PR DESCRIPTION
Adds ARC Raiders wiki as `arcwiki` or `arcw`