### PR TITLE
fix: update outdated apple bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -1859,9 +1859,9 @@
   },
   {
     "s": "Apple dev form",
-    "d": "forums.developer.apple.com",
+    "d": "developer.apple.com",
     "t": "adf",
-    "u": "https://forums.developer.apple.com/search.jspa?q={{{s}}}",
+    "u": "https://developer.apple.com/forums/search?q={{{s}}}",
     "c": "Tech",
     "sc": "Programming"
   },
@@ -4635,7 +4635,7 @@
     "s": "Apple",
     "d": "www.apple.com",
     "t": "apple",
-    "u": "https://www.apple.com/search/?q={{{s}}}",
+    "u": "https://www.apple.com/search/{{{s}}}",
     "c": "Shopping",
     "sc": "Tech"
   },
@@ -4667,7 +4667,7 @@
     "s": "Apple Discussions",
     "d": "discussions.apple.com",
     "t": "applediscuss",
-    "u": "https://discussions.apple.com/search.jspa?peopleEnabled=true&userID=&containerType=&container=&spotlight=true&q={{{s}}}",
+    "u": "https://discussions.apple.com/search?source=aml&origin=asc_serp&q={{{s}}}",
     "c": "Tech",
     "sc": "Companies"
   },
@@ -68933,9 +68933,9 @@
   },
   {
     "s": "Safari Extensions Gallery",
-    "d": "safari-extensions.apple.com",
+    "d": "apps.apple.com",
     "t": "safariext",
-    "u": "https://safari-extensions.apple.com/?q={{{s}}}",
+    "u": "https://apps.apple.com/us/mac/search?term={{{s}}}",
     "c": "Tech",
     "sc": "Downloads (add-ons)"
   },


### PR DESCRIPTION
I have fixed a few Apple search bangs as their routes have been changed recently.

As the Safari Extensions Gallery is no longer available, I have changed it to search the Mac App Store (where extensions are now supposed to be downloaded).