### PR TITLE
Updated bang for Kakaku.com

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -43464,7 +43464,7 @@
     "d": "search.kakaku.com",
     "ad": "kakaku.com",
     "t": "kakaku",
-    "u": "/{{{s}}}/",
+    "u": "https://search.kakaku.com/{{{s}}}/",
     "c": "Shopping",
     "sc": "Online",
     "fmt": [


### PR DESCRIPTION
# Problem
The current `kakaku.com` bang fails to properly handle Japanese characters due to an outdated(?) URL structure that corrupts encoding during redirects. This is an issue since the site is mainly Japanese focused.

# Example

**Current:** https://kakaku.com/search_results/テスト
**Current Result:** https://search.kakaku.com/繝・せ繝・/ (corrupted Japanese with the wrong encoding)
**Fixed:** https://search.kakaku.com/テスト/


# Changes
- Updated URL to current search endpoint
- Updated name to match official branding per [corporate site](https://corporate.kakaku.com/en/service)
