### PR TITLE
fix: Websters 1913 site name

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -84843,7 +84843,7 @@
     "sc": "Weather"
   },
   {
-    "s": "Webster's Dictionary (1913) !websters Webster's Dictionary 1828 - Online Edition !owd Merriam-Webster Dictionary !mw Merriam-Webster Pronunciation !say Merriam-Webster's Learner's Dictionary !mwl Webster's Revised Unabridged Dictionary (1913)",
+    "s": "Webster's Dictionary (1913)",
     "d": "www.websters1913.com",
     "t": "web1913",
     "u": "https://www.websters1913.com/words/{{{s}}}",


### PR DESCRIPTION
It looks as though other bangs and their site names were concatted on to the name for this entry.

This issue currently exists in the duckduckgo bangs database too, where I've submitted an update request.