### PR TITLE
fix: tidal accepts a query param now

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -78034,9 +78034,9 @@
   },
   {
     "s": "Tidal",
-    "d": "listen.tidal.com",
+    "d": "tidal.com",
     "t": "tidal",
-    "u": "https://listen.tidal.com/search/{{{s}}}",
+    "u": "https://tidal.com/search/?q={{{s}}}",
     "c": "Multimedia",
     "sc": "Music"
   },


### PR DESCRIPTION
I was surprised there is a tidal bang, but it wasn't working as I expected, so here's a PR for a fix

previous tidal bang was stuck on the loading screen
<img width="1363" height="802" alt="before PR, stuck on the loading screen, nothing appears" src="https://github.com/user-attachments/assets/cf6224a8-abbf-4093-b692-e1fa9830a157" />

tidal now supports a semi-standard way of searching with `/search/?q=%s` string, so that's what I changed it to.
<img width="1446" height="667" alt="using query params redirects to a correct tidal search page" src="https://github.com/user-attachments/assets/3801a555-d0b3-447d-b78b-f5603e45c4ad" />
