### PR TITLE
fix waitrose to use new search url

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -84299,7 +84299,7 @@
     "s": "Waitrose",
     "d": "www.waitrose.com",
     "t": "waitrose",
-    "u": "https://www.waitrose.com/shop/HeaderSearchCmd?searchTerm={{{s}}}",
+    "u": "https://www.waitrose.com/ecom/shop/search?searchTerm={{{s}}}",
     "c": "Shopping",
     "sc": "Online (marketplace)"
   },


### PR DESCRIPTION
The !waitrose bang now returns `410 Gone` - the search URL appears to have changed from
`https://www.waitrose.com/shop/HeaderSearchCmd?searchTerm={{{s}}}`
to
`https://www.waitrose.com/ecom/shop/search?searchTerm={{{s}}}`