### PR TITLE
Updated mouser bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -53044,7 +53044,7 @@
     "s": "Mouser Electronics",
     "d": "www.mouser.com",
     "t": "mouser",
-    "u": "https://www.mouser.com/Search/Refine.aspx?Keyword={{{s}}}",
+    "u": "https://www.mouser.com/c/?q={{{s}}}",
     "c": "Shopping",
     "sc": "Tech"
   },


### PR DESCRIPTION
mouser bang used outdated url for search, updated it: https://kagifeedback.org/d/9864-mouser-bang-no-longer-working