### PR TITLE
Update !dmde bang to use current DM.de search endpoint

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -20715,7 +20715,7 @@
     "s": "DM.DE",
     "d": "www.dm.de",
     "t": "dmde",
-    "u": "https://www.dm.de/search/468652.html?type=product&q={{{s}}}",
+    "u": "https://www.dm.de/search?query={{{s}}}",
     "c": "Shopping",
     "sc": "Online"
   },


### PR DESCRIPTION
This PR changes the search URL pattern for `!dmde` from `https://www.dm.de/search/468652.html?type=product&q={{{s}}}` to `https://www.dm.de/search?query={{{s}}}` as the previous one just redirected to the website's home page.

I noticed that the !dmde bang didn't work, so I submitted a test query and noted the working URL pattern. Opening the URL: `https://www.dm.de/search?query=Hello+World` works as expected and the space character parsed correctly by the website.

# AI use disclosure

The following prompt for GitHub Copilot Agent was used:

> Search !bangs are stored in /data/bangs.json, I want to fix the one for !dmde, it's currently:
> 
> ```json
>   {
>     "s": "DM.DE",
>     "d": "www.dm.de",
>     "t": "dmde",
>     "u": "https://www.dm.de/search/468652.html?type=product&q={{{s}}}",
>     "c": "Shopping",
>     "sc": "Online"
>   },
> ```
> 
> The url should be changed to "https://www.dm.de/search?query={{{s}}}".

**Edit:** The website adds the: `&searchProviderType=dm-products` parameter to the URL when searching. I intentionally omitted it as it is added automatically when it's missing, and this offers a bit more reliability should the default search target name or pattern change.

Other options are:

`&searchProviderType=pharmacy-products` and `&searchProviderType=content` - these can be manually selected in a tab menu after submitting a search query.