### PR TITLE
Remove outdated gemini bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -32914,19 +32914,6 @@
     "sc": "Google"
   },
   {
-    "s": "Gemini",
-    "d": "gemini.google.com",
-    "t": "gemini",
-    "ts": [
-      "geminiai",
-      "gemai",
-      "gmai"
-    ],
-    "u": "https://gemini.google.com/?prompt_text={{{s}}}",
-    "c": "Online Services",
-    "sc": "AI Chatbots"
-  },
-  {
     "s": "GMail.com",
     "d": "mail.google.com",
     "t": "gmail",


### PR DESCRIPTION
Google has since removed URL queries, and recommends using chrome's omnibox feature.  