### PR TITLE
Fix !e926 bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -22532,7 +22532,7 @@
     "s": "e926",
     "d": "e926.net",
     "t": "e926",
-    "u": "https://e926.net/post/search?tags={{{s}}}",
+    "u": "https://e926.net/posts?tags={{{s}}}",
     "c": "Multimedia",
     "sc": "Images"
   },


### PR DESCRIPTION
`/post/search?tags={{{s}}}` is not a real page on this site, I have corrected it to be `/posts?tags={{{s}}}` which is the correct search URL.