### PR TITLE
Add new site: pds.ls

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -10829,6 +10829,14 @@
     "sc": "Social"
   },
   {
+    "s": "PDSls",
+    "d": "pds.ls",
+    "t": "pdsls",
+    "u": "https://pds.ls/?q={{{s}}}",
+    "c": "Online Services",
+    "sc": "Social"
+  },
+  {
     "s": "SignBSL",
     "d": "www.signbsl.com",
     "t": "bsl",
@@ -93165,13 +93173,5 @@
     "u": "https://tesaurus.kemendikdasmen.go.id/tematis/lema/{{{s}}}",
     "c": "Research",
     "sc": "Reference (words)"
-  },
-  {
-    "s": "PDSls",
-    "d": "pds.ls",
-    "t": "pdsls",
-    "u": "https://pds.ls/?q={{{s}}}",
-    "c": "Online Services",
-    "sc": "Social"
   }
 ]


### PR DESCRIPTION
PDSls (pds.ls) is a data inspector tool for the AT Protocol (Bluesky social network), hence why I've marked its category as `Online Services/Social`. I didn't know if another subcategory would be a better fit.

Someone would search `!pdsls [Bluesky handle]` and they could inspect that user's public data.