### PR TITLE
Restore abe shortcut for amazon.com.be

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -1274,6 +1274,7 @@
     "s": "Amazon Belgium",
     "d": "www.amazon.com.be",
     "t": "amazonbe",
+    "ts": ["abe"],
     "u": "https://www.amazon.com.be/s?k={{{s}}}",
     "c": "Shopping",
     "sc": "Online"


### PR DESCRIPTION
Was removed at 695934d0e8b but other amazons are available through afr, aes, ade,…

cc @thibaultmol 