### PR TITLE
updated GeeksforGeeks bangs to use new search endpoint

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -31361,7 +31361,7 @@
     "s": "GeeksforGeeks",
     "d": "www.geeksforgeeks.org",
     "t": "geeks",
-    "u": "https://www.geeksforgeeks.org/?s={{{s}}}",
+    "u": "https://www.geeksforgeeks.org/search/?gq={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -31851,7 +31851,7 @@
     "s": "geeksforgeeks",
     "d": "www.geeksforgeeks.org",
     "t": "gfg",
-    "u": "https://www.geeksforgeeks.org/?q={{{s}}}",
+    "u": "https://www.geeksforgeeks.org/search/?gq={{{s}}}",
     "c": "Tech",
     "sc": "Programming"
   },


### PR DESCRIPTION
Updates the "geeks" and "gfg" bangs for GeeksforGeeks to point to their new search endpoint. 
previously, the queries routed to the root domain (`/?s={{{s}}}` and `/?q={{{s}}}`). This update ensures the queries are correctly formatted and routed to the dedicated search path "https://www.geeksforgeeks.org/search/?gq={{{s}}}".