### PR TITLE
Update GeeksforGeeks search endpoint and resolve duplicate templates

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -31361,7 +31361,7 @@
     "s": "GeeksforGeeks",
     "d": "www.geeksforgeeks.org",
     "t": "geeks",
-    "u": "https://www.geeksforgeeks.org/?s={{{s}}}",
+    "u": "https://www.geeksforgeeks.org/search/?gq={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -31851,7 +31851,7 @@
     "s": "geeksforgeeks",
     "d": "www.geeksforgeeks.org",
     "t": "gfg",
-    "u": "https://www.geeksforgeeks.org/?q={{{s}}}",
+    "u": "https://www.geeksforgeeks.org/search/?gq={{{s}}}",
     "c": "Tech",
     "sc": "Programming"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -31358,14 +31358,6 @@
     "sc": "Misc"
   },
   {
-    "s": "GeeksforGeeks",
-    "d": "www.geeksforgeeks.org",
-    "t": "geeks",
-    "u": "https://www.geeksforgeeks.org/search/?gq={{{s}}}",
-    "c": "Research",
-    "sc": "Learning"
-  },
-  {
     "s": "GeekSided",
     "d": "geeksided.com",
     "t": "geeksided",
@@ -31851,6 +31843,9 @@
     "s": "geeksforgeeks",
     "d": "www.geeksforgeeks.org",
     "t": "gfg",
+    "ts": [
+      "geeks"
+    ],
     "u": "https://www.geeksforgeeks.org/search/?gq={{{s}}}",
     "c": "Tech",
     "sc": "Programming"


### PR DESCRIPTION
Updates the GeeksforGeeks bangs to correctly route queries to their new dedicated `/search/` endpoint. To fix the CI `Duplicate template(s)` failure, the extra `geeks` entry was removed and added as an alias to the `gfg` entry under the `ts` property.