### PR TITLE
Standardize bang names based on new naming spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,193 @@
+# AGENTS.md
+
+Coding agent guidelines for the Kagi Bangs repository.
+
+## Project Overview
+
+This repository contains bang definitions for [Kagi Search](https://kagi.com). Bangs are search shortcuts (e.g., `!gh` for GitHub) that redirect queries to specific websites.
+
+- **Primary data files**: `data/bangs.json` (community bangs), `data/kagi_bangs.json` (internal Kagi bangs)
+- **Schema**: `data/bangs.schema.json`
+- **Language**: Ruby for scripts/tests, JSON for data
+
+## Build/Test Commands
+
+```bash
+# Install dependencies
+make install
+# or: bundle install
+
+# Run all tests
+make test
+# or: bundle exec rspec
+
+# Run specific test by line number
+bundle exec rspec spec/bangs_spec.rb:127
+
+# Run specific test by description pattern
+bundle exec rspec -e "doesn't have duplicate bang triggers"
+
+# Health check all bang URLs (slow)
+ruby scripts/health_check.rb
+
+# Other utilities
+ruby scripts/generate_alt_domains.rb
+ruby scripts/taken_region_codes.rb
+ruby scripts/deduplicate_bangs.rb
+```
+
+## Code Style
+
+### General (EditorConfig)
+
+- **Charset**: UTF-8
+- **Line endings**: LF (`\n`)
+- **Indent**: 2 spaces (no tabs)
+- **Final newline**: Required
+- **Trim trailing whitespace**: Yes
+
+### Ruby Style
+
+```ruby
+# Require statements at top
+require "json"
+require "rspec"
+
+# Double quotes for strings
+bangs_json = JSON.parse(File.read("data/bangs.json"))
+
+# Method definitions with snake_case
+def find_dups(*arr)
+  arr.flatten
+    .group_by { |element| element }
+    .select { |k, v| v.size > 1 }
+    .keys
+end
+
+# Guard clauses for early returns
+return if bang["u"].start_with?("/")
+
+# Conditional assignment
+bang["ts"] ||= []
+
+# String interpolation
+puts "#{bang["s"]} (#{bang["t"]})"
+
+# Exception handling
+rescue => e
+  mutex.synchronize { errored << [bang, e] }
+```
+
+### JSON Bang Object Style
+
+Key order: `s`, `d`, `ad`, `t`, `ts`, `u`, `x`, `c`, `sc`, `skip_tests`, `fmt`
+
+Website names in `s` must follow `WEBSITE_NAMING_SPEC.md`. In short: preserve official brand styling for the base site name, and use `Site Name (Qualifier)` for variants such as filters, sections, scoped entities, users, region variants, and translation pairs.
+
+```json
+{
+  "s": "Site Name",
+  "d": "example.com",
+  "ad": "alt-domain.com",
+  "t": "trigger",
+  "ts": ["alias1", "alias2"],
+  "u": "https://example.com/search?q={{{s}}}",
+  "x": "^pattern$",
+  "c": "Category",
+  "sc": "Subcategory",
+  "skip_tests": false,
+  "fmt": ["url_encode_placeholder"]
+}
+```
+
+#### Required Fields
+
+| Key | Description |
+|-----|-------------|
+| `s` | Website name (display name, following `WEBSITE_NAMING_SPEC.md`) |
+| `d` | Domain (must match URL host) |
+| `t` | Trigger (lowercase, letters/numbers/dashes/periods/underscores only) |
+| `u` | URL template with `{{{s}}}` placeholder |
+
+#### Optional Fields
+
+| Key | Description |
+|-----|-------------|
+| `ad` | Alternative/snap domain |
+| `ts` | Array of additional trigger aliases |
+| `x` | Regex pattern for complex query parsing |
+| `c` | Category (see README for valid values) |
+| `sc` | Subcategory |
+| `skip_tests` | Boolean to skip spec tests |
+| `fmt` | Array of format flags (exhaustive): `open_base_path`, `open_snap_domain`, `url_encode_placeholder`, `url_encode_space_to_plus` |
+
+### RSpec Test Patterns
+
+```ruby
+describe "bangs.json" do
+  it "doesn't have duplicate bang triggers" do
+    dups = find_dups(bang_triggers)
+    expect(dups).to be_empty, "Duplicate triggers(s) found: #{dups.join(", ")}"
+  end
+
+  bangs_json.each do |bang|
+    it "trigger should be lowercase (#{bang["s"]})" do
+      expect(bang["t"]).to eq(bang["t"].downcase)
+    end
+  end
+end
+```
+
+## Data Validation Rules
+
+Tests enforce (see `spec/bangs_spec.rb`):
+
+- No duplicate triggers across `bangs.json` and `kagi_bangs.json`
+- No duplicate templates or sites
+- Triggers must be lowercase
+- Templates must contain exactly one `{{{s}}}` placeholder
+- Templates must be HTTPS URLs or paths starting with `/`
+- Domains must match the URL template host
+- Domains must not be URI-encoded
+- Alternative domains (`ad`) must not contain protocol, commas, or spaces
+- Regex patterns (`x`) must be valid regex
+- Bangs with path-only URLs (`/search`) must have an `ad` field and `d: "kagi.com"`
+
+## File Structure
+
+```
+bangs/
+├── data/
+│   ├── bangs.json          # Community bangs (edit this)
+│   ├── kagi_bangs.json     # Internal Kagi bangs
+│   └── bangs.schema.json   # JSON Schema
+├── spec/
+│   └── bangs_spec.rb       # RSpec tests
+├── scripts/                # Utility scripts
+├── Gemfile                 # Ruby dependencies
+├── Makefile                # Build commands
+└── .editorconfig           # Formatting rules
+```
+
+## Common Tasks
+
+### Adding a New Bang
+
+1. Add entry to `data/bangs.json` (alphabetical by trigger)
+2. Set `s` according to `WEBSITE_NAMING_SPEC.md`
+3. Run `bundle exec rspec` to validate
+4. Verify the URL works with a test query
+
+### Adding Additional Triggers
+
+Add to the `ts` array instead of creating duplicate entries:
+
+```json
+{
+  "s": "GitHub",
+  "d": "github.com",
+  "t": "gh",
+  "ts": ["github", "git"],
+  "u": "https://github.com/search?q={{{s}}}"
+}
+```

--- a/WEBSITE_NAMING_SPEC.md
+++ b/WEBSITE_NAMING_SPEC.md
@@ -1,0 +1,139 @@
+# Website Name (`s` field) Specification
+
+This document defines the naming convention for the `s` (Website Name) field in bang definitions.
+
+## Core Principles
+
+1. **Preserve official brand styling**: Keep the site's own capitalization and spelling where known, such as `eBay`, `iFixit`, `npm`, `dev.to`, `WordReference`, or names in native script
+2. **Use Title Case for generic qualifiers**: Capitalize descriptive qualifiers inside parentheses, such as `History`, `Creative Commons`, `Past Day`, or `Orders`
+3. **Site name first**: Never lead with qualifier, filter, or feature
+4. **Parentheses for variants**: Use `()` consistently for qualifiers, variants, scopes, and filters; do not use dashes or bare suffixes
+5. **No redundant "Search"**: Omit "Search" from names unless it is part of the official product name
+6. **Prefer user-facing meaning**: Name the bang for what users understand it does, not for raw URL parameters or implementation details
+
+## Format Patterns
+
+| Category | Format | Examples |
+|----------|--------|----------|
+| **Default** | `Site Name` | `"GitHub"`, `"YouTube"`, `"Amazon"` |
+| **Feature/Section** | `Site Name (Feature)` | `"GitHub (Stars)"`, `"GitHub (Notifications)"`, `"YouTube (History)"` |
+| **Content Filter** | `Site Name (Filter)` | `"YouTube (Creative Commons)"`, `"YouTube (Past Day)"`, `"YouTube (Long)"` |
+| **Item Type** | `Site Name (Type)` | `"YouTube (Video)"`, `"GitHub (Repo)"`, `"Amazon (ASIN)"` |
+| **User/Profile** | `Site Name (User)` | `"Reddit (User)"`, `"GitHub (User)"` |
+| **Scoped Entity** | `Site Name (Entity)` | `"YouTube (Game Grumps)"`, `"GitHub (NixOS/nixpkgs)"` |
+| **Sub-site Community** | `Site Name (/r/name)` | `"Reddit (/r/AskReddit)"`, `"Reddit (/r/ProgrammerHumor)"` |
+| **Market/Region Variant** | `Site Name (Region)` | `"Amazon (UK)"`, `"eBay (Germany)"` |
+| **Translation Pair** | `Site Name (xx-yy)` | `"Google Translate (de-en)"`, `"DeepL (en-fr)"`, `"DeepL (pt-en)"` |
+| **Auto-Detect Translation** | `Site Name (auto-yy)` | `"Google Translate (auto-en)"`, `"DeepL (auto-de)"` |
+| **Kagi-Routed** | `Site Name (Kagi)` | `"4chan (Kagi)"`, `"Ada 2005 Manual (Kagi)"` |
+
+## Language and Region Rules
+
+- **Translation codes**: Use lowercase language codes in source-target form: `xx-yy`
+- **Auto-detect source**: Use `auto-yy` for automatic source language detection
+- **Script or regional language variants**: Keep the canonical code when needed, such as `zh-CN` or `pt-BR`
+- **Normalize legacy codes**: Prefer modern standard codes in names, such as `he` instead of `iw`
+- **Do not spell out language names**: Use `de-en`, not `German to English`
+- **Region or market variants**: Use a stable, human-readable region label such as `US`, `UK`, `Germany`, or `Japan`; do not mix region codes and country names within the same site family
+
+## Variant Model
+
+Use this simple model whenever possible:
+
+- Base bang: `Site`
+- Variant bang: `Site (Qualifier)`
+- Scoped entity bang: `Site (Entity)` or `Site (/r/Entity)` when the slash form is meaningful to users
+
+Prefer a single qualifier over stacked qualifiers. If multiple qualifiers could apply, create separate bangs instead of combining them.
+
+If combining is truly necessary, order qualifiers as follows:
+
+1. Scope or entity
+2. Feature or section
+3. Filter or type
+4. Region or locale
+
+## Common Mistakes to Avoid
+
+| Don't | Do Instead |
+|-------|------------|
+| `"YouTube - long"` | `"YouTube (Long)"` |
+| `"Google Translate da-en"` | `"Google Translate (da-en)"` |
+| `"Translate English to Danish"` | `"Google Translate (en-da)"` |
+| `"deepl.com"` | `"DeepL (fr-en)"` |
+| `"reddit.com/r/GlobalOffensive"` | `"Reddit (/r/GlobalOffensive)"` |
+| `"GitHub Code Search"` | `"GitHub (Code)"` |
+| `"Amazon.com order history"` | `"Amazon (Orders)"` |
+| `"101 Domain"` and `"101domain"` | Pick one: `"101 Domain"` |
+| `"/r/AskReddit"` | `"Reddit (/r/AskReddit)"` |
+| `"r/ADHD"` | `"Reddit (/r/ADHD)"` |
+| `"GitHub User"` | `"GitHub (User)"` |
+| `"YouTube Video"` | `"YouTube (Video)"` |
+| `"Google Translate (de2fr)"` | `"Google Translate (de-fr)"` |
+| `"Google Translate (to Arabic)"` | `"Google Translate (auto-ar)"` |
+
+## Examples by Site
+
+### GitHub
+```json
+{ "s": "GitHub" }
+{ "s": "GitHub (Code)" }
+{ "s": "GitHub (Stars)" }
+{ "s": "GitHub (Notifications)" }
+{ "s": "GitHub (Trending)" }
+{ "s": "GitHub (Topic)" }
+{ "s": "GitHub (User)" }
+{ "s": "GitHub (Repo)" }
+{ "s": "GitHub (Private)" }
+{ "s": "GitHub (JavaScript)" }
+{ "s": "GitHub (NixOS/nixpkgs)" }
+```
+
+### YouTube
+```json
+{ "s": "YouTube" }
+{ "s": "YouTube (Video)" }
+{ "s": "YouTube (Playlists)" }
+{ "s": "YouTube (Creative Commons)" }
+{ "s": "YouTube (Past Day)" }
+{ "s": "YouTube (Long)" }
+{ "s": "YouTube (DE)" }
+{ "s": "YouTube (US)" }
+{ "s": "YouTube (Channel)" }
+{ "s": "YouTube (History)" }
+{ "s": "YouTube (Game Grumps)" }
+```
+
+### Reddit
+```json
+{ "s": "Reddit" }
+{ "s": "Reddit (User)" }
+{ "s": "Reddit (/r/AskReddit)" }
+{ "s": "Reddit (/r/ProgrammerHumor)" }
+{ "s": "Reddit (/r/GlobalOffensive)" }
+{ "s": "Reddit (Subreddits)" }
+```
+
+### Translation Services
+```json
+{ "s": "Google Translate (de-en)" }
+{ "s": "Google Translate (en-ja)" }
+{ "s": "Google Translate (fr-en)" }
+{ "s": "Google Translate (auto-ar)" }
+{ "s": "Google Translate (zh-CN-en)" }
+{ "s": "DeepL (en-de)" }
+{ "s": "DeepL (en-fr)" }
+{ "s": "DeepL (pt-en)" }
+```
+
+### Amazon
+```json
+{ "s": "Amazon" }
+{ "s": "Amazon (ASIN)" }
+{ "s": "Amazon (Books)" }
+{ "s": "Amazon (Kindle)" }
+{ "s": "Amazon (Prime Video)" }
+{ "s": "Amazon (Orders)" }
+{ "s": "Amazon (Fresh)" }
+{ "s": "Amazon (Automotive)" }
+```

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -76,7 +76,7 @@
     "sc": "Search"
   },
   {
-    "s": "1177 Vårdguiden",
+    "s": "1177",
     "d": "www.1177.se",
     "t": "1177",
     "u": "https://www.1177.se/Sok/?q={{{s}}}",
@@ -100,7 +100,7 @@
     "sc": "Sports"
   },
   {
-    "s": "11번가",
+    "s": "11st",
     "d": "search.11st.co.kr",
     "t": "11st",
     "u": "https://search.11st.co.kr/SearchPrdAction.tmall?method=getTotalSearchSeller&kwd={{{s}}}",
@@ -116,7 +116,7 @@
     "sc": "General"
   },
   {
-    "s": "14-tage-wettervorhersage.de",
+    "s": "14-Tage Wettervorhersage",
     "d": "14-tage-wettervorhersage.de",
     "t": "14",
     "u": "https://14-tage-wettervorhersage.de/suche/?q={{{s}}}&lg=de",
@@ -156,7 +156,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "180.no",
+    "s": "180",
     "d": "www.180.no",
     "t": "180",
     "u": "https://www.180.no/Search/All?w={{{s}}}",
@@ -164,7 +164,7 @@
     "sc": "Tools"
   },
   {
-    "s": "1881.no",
+    "s": "1881",
     "d": "www.1881.no",
     "t": "1881",
     "u": "https://www.1881.no/?query={{{s}}}",
@@ -220,7 +220,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "24au.ru",
+    "s": "24au",
     "d": "krsk.au.ru",
     "t": "24au",
     "u": "https://krsk.au.ru/nextauction/?search={{{s}}}",
@@ -272,7 +272,7 @@
     "sc": "Forum"
   },
   {
-    "s": "2dehands.be",
+    "s": "2dehands",
     "d": "www.2dehands.be",
     "t": "2dehands",
     "u": "https://www.2dehands.be/markt?qq={{{s}}}",
@@ -320,7 +320,7 @@
     "sc": "Online"
   },
   {
-    "s": "2player.com",
+    "s": "2Player",
     "d": "2player.com",
     "t": "2pl",
     "u": "https://2player.com/search/?search={{{s}}}",
@@ -328,7 +328,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "34travel.me",
+    "s": "34travel",
     "d": "34travel.me",
     "t": "34travel",
     "u": "https://34travel.me/search?text={{{s}}}",
@@ -392,7 +392,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "3Druck.com",
+    "s": "3Druck",
     "d": "3druck.com",
     "t": "3druck",
     "u": "https://3druck.com/?s={{{s}}}",
@@ -443,7 +443,7 @@
     "sc": "Online"
   },
   {
-    "s": "TriTrans (Engelsk)",
+    "s": "TriTrans (en-no)",
     "d": "www.tritrans.net",
     "t": "3t",
     "u": "https://www.tritrans.net/cgibin/translate.cgi?spraak=Engelsk&Fra={{{s}}}&button=Translate!",
@@ -475,7 +475,7 @@
     "sc": "Newspaper (intl)"
   },
   {
-    "s": "4chan /b/",
+    "s": "4chan (/b/)",
     "d": "boards.4chan.org",
     "t": "4_b",
     "ts": [
@@ -494,7 +494,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "4chan Board",
+    "s": "4chan (Board)",
     "d": "4chan.org",
     "t": "4ch",
     "u": "https://4chan.org/{{{s}}}",
@@ -502,7 +502,7 @@
     "sc": "Forum"
   },
   {
-    "s": "4chan /a/ board",
+    "s": "4chan (/a/)",
     "d": "boards.4chan.org",
     "t": "4cha",
     "u": "https://boards.4chan.org/a/catalog#s={{{s}}}",
@@ -510,7 +510,7 @@
     "sc": "Forum"
   },
   {
-    "s": "4chan (Kagi Search)",
+    "s": "4chan (Kagi)",
     "d": "kagi.com",
     "ad": "4chan.org",
     "t": "4chan",
@@ -519,7 +519,7 @@
     "sc": "Images"
   },
   {
-    "s": "4chan Boards",
+    "s": "4chan (/b)",
     "d": "4chan.org",
     "t": "4chanb",
     "u": "https://4chan.org/b/{{{s}}}",
@@ -527,7 +527,7 @@
     "sc": "Misc"
   },
   {
-    "s": "4chan Catalog",
+    "s": "4chan (Catalog)",
     "d": "boards.4chan.org",
     "t": "4chc",
     "u": "https://boards.4chan.org/{{{s}}}/catalog",
@@ -535,7 +535,7 @@
     "sc": "Social"
   },
   {
-    "s": "4chan fashion board",
+    "s": "4chan (/fa/)",
     "d": "boards.4chan.org",
     "t": "4chfa",
     "u": "https://boards.4chan.org/fa/catalog#s={{{s}}}",
@@ -543,7 +543,7 @@
     "sc": "Misc"
   },
   {
-    "s": "4chan technology board",
+    "s": "4chan (/g/)",
     "d": "boards.4chan.org",
     "t": "4chg",
     "u": "https://boards.4chan.org/g/catalog#s={{{s}}}",
@@ -551,7 +551,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "4chan international board",
+    "s": "4chan (/int/)",
     "d": "boards.4chan.org",
     "t": "4chint",
     "u": "https://boards.4chan.org/int/catalog#s={{{s}}}",
@@ -559,7 +559,7 @@
     "sc": "Forum"
   },
   {
-    "s": "4chan music board",
+    "s": "4chan (/mu/)",
     "d": "boards.4chan.org",
     "t": "4chmu",
     "u": "https://boards.4chan.org/mu/catalog#s={{{s}}}",
@@ -567,7 +567,7 @@
     "sc": "Music"
   },
   {
-    "s": "4chan's /news/ board",
+    "s": "4chan (/news/)",
     "d": "boards.4chan.org",
     "t": "4chnews",
     "u": "https://boards.4chan.org/news/catalog#s={{{s}}}",
@@ -575,7 +575,7 @@
     "sc": "International"
   },
   {
-    "s": "4chan robot board",
+    "s": "4chan (/r9k/)",
     "d": "boards.4chan.org",
     "t": "4chr9k",
     "u": "https://boards.4chan.org/r9k/catalog#s={{{s}}}",
@@ -591,7 +591,7 @@
     "sc": "Forum"
   },
   {
-    "s": "4chan video games board",
+    "s": "4chan (/v/)",
     "d": "boards.4chan.org",
     "t": "4chv",
     "u": "https://boards.4chan.org/v/catalog#s={{{s}}}",
@@ -599,7 +599,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "4chan, /vg/",
+    "s": "4chan (/vg/)",
     "d": "boards.4chan.org",
     "t": "4cvg",
     "u": "https://boards.4chan.org/vg/catalog#s={{{s}}}",
@@ -607,7 +607,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "4chan - /g/ - Technology",
+    "s": "4chan (/g)",
     "d": "4chan.org",
     "t": "4g",
     "u": "https://4chan.org/g/{{{s}}}",
@@ -712,7 +712,7 @@
     "sc": "Food"
   },
   {
-    "s": "fivethirtyeight.com",
+    "s": "FiveThirtyEight",
     "d": "fivethirtyeight.com",
     "t": "538",
     "u": "https://fivethirtyeight.com/?s={{{s}}}",
@@ -760,7 +760,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "6pm.com",
+    "s": "6pm",
     "d": "www.6pm.com",
     "t": "6pm",
     "u": "https://www.6pm.com/search?term={{{s}}}",
@@ -808,7 +808,7 @@
     "sc": "Tools"
   },
   {
-    "s": "800notes.com",
+    "s": "800notes",
     "d": "800notes.com",
     "t": "800",
     "u": "https://800notes.com/Phone.aspx/{{{s}}}",
@@ -856,7 +856,7 @@
     "sc": "Music"
   },
   {
-    "s": "911tabs",
+    "s": "911Tabs",
     "d": "www.911tabs.com",
     "t": "911",
     "u": "https://www.911tabs.com/search.php?search={{{s}}}&type=band",
@@ -864,7 +864,7 @@
     "sc": "Music"
   },
   {
-    "s": "911 Tabs (Songs)",
+    "s": "911Tabs (Songs)",
     "d": "www.911tabs.com",
     "t": "911s",
     "u": "https://www.911tabs.com/search.php?search={{{s}}}&type=song",
@@ -920,7 +920,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "990 Search (Foundation Center)",
+    "s": "990 Finder",
     "d": "990finder.foundationcenter.org",
     "t": "990",
     "u": "https://990finder.foundationcenter.org/990results.aspx?990_type=&fn={{{s}}}&st=&zp=&ei=&fy=&action=Search",
@@ -947,7 +947,7 @@
     "sc": "Comics"
   },
   {
-    "s": "AlternativeTo.net",
+    "s": "AlternativeTo",
     "d": "alternativeto.net",
     "t": "alto",
     "ts": [
@@ -963,7 +963,7 @@
     "sc": "Downloads (software)"
   },
   {
-    "s": "Angular.io v5",
+    "s": "Angular (v5)",
     "d": "v5.angular.io",
     "t": "a5",
     "u": "https://v5.angular.io/api?query={{{s}}}",
@@ -971,7 +971,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Angular.io v6",
+    "s": "Angular (v6)",
     "d": "v6.angular.io",
     "t": "a6",
     "u": "https://v6.angular.io/api?query={{{s}}}",
@@ -979,7 +979,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Angular.io v7",
+    "s": "Angular (v7)",
     "d": "v7.angular.io",
     "t": "a7",
     "u": "https://v7.angular.io/api?query={{{s}}}",
@@ -1003,7 +1003,7 @@
     "sc": "Online"
   },
   {
-    "s": "Amazon Automotive",
+    "s": "Amazon (Automotive)",
     "d": "www.amazon.com",
     "t": "aa",
     "u": "https://www.amazon.com/s/&url=search-alias=automotive&field-keywords={{{s}}}",
@@ -1056,7 +1056,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "Amazon.com",
+    "s": "Amazon",
     "d": "www.amazon.com",
     "t": "a",
     "ts": [
@@ -1097,7 +1097,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Estonian - English - Estonian Dictionary",
+    "s": "Aare (et-en-et)",
     "d": "aare.edu.ee",
     "t": "aare",
     "u": "https://aare.edu.ee/dictionary.html?query={{{s}}}&lang=ee",
@@ -1105,7 +1105,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Amazon Germany / Austria",
+    "s": "Amazon (Germany)",
     "d": "www.amazon.de",
     "t": "amazonde",
     "ts": [
@@ -1153,7 +1153,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Abadis English to Persian dictionary",
+    "s": "Abadis (en-fa)",
     "d": "dictionary.abadis.ir",
     "t": "abadise",
     "u": "https://dictionary.abadis.ir/?LnType=entofa&Word={{{s}}}",
@@ -1161,7 +1161,7 @@
     "sc": "General"
   },
   {
-    "s": "Abadis Persian to English dictionary",
+    "s": "Abadis (fa-en)",
     "d": "dictionary.abadis.ir",
     "t": "abadisf",
     "u": "https://dictionary.abadis.ir/?lntype=fatoen&word={{{s}}}",
@@ -1196,7 +1196,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "Abbreviations.com",
+    "s": "Abbreviations",
     "d": "www.abbreviations.com",
     "t": "abbr",
     "ts": [
@@ -1287,7 +1287,7 @@
     "sc": "Learning"
   },
   {
-    "s": "AbeBooks.de",
+    "s": "AbeBooks (Germany)",
     "d": "www.abebooks.de",
     "t": "abebooksde",
     "u": "https://www.abebooks.de/servlet/SearchResults?kn={{{s}}}&sts=t&x=0&y=0",
@@ -1295,7 +1295,7 @@
     "sc": "Online"
   },
   {
-    "s": "Abbyy Dictionary En-Ru",
+    "s": "Lingvo Live (en-ru)",
     "d": "www.lingvolive.com",
     "t": "ab-er",
     "u": "https://www.lingvolive.com/en/translate/en-ru/{{{s}}}",
@@ -1415,7 +1415,7 @@
     "sc": "Online"
   },
   {
-    "s": "Amazon.ca",
+    "s": "Amazon (Canada)",
     "d": "www.amazon.ca",
     "t": "aca",
     "ts": [
@@ -1569,7 +1569,7 @@
     "sc": "Law"
   },
   {
-    "s": "ACM Guide",
+    "s": "ACM (Guide)",
     "d": "dl.acm.org",
     "t": "acm",
     "u": "https://dl.acm.org/results.cfm?dlr=GUIDE&query={{{s}}}",
@@ -1577,7 +1577,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "ACM Digital Library",
+    "s": "ACM (Digital Library)",
     "d": "dl.acm.org",
     "t": "acmdl",
     "u": "https://dl.acm.org/results.cfm?query={{{s}}}",
@@ -1585,7 +1585,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Amazon.cn",
+    "s": "Amazon (China)",
     "d": "www.amazon.cn",
     "t": "acn",
     "ts": [
@@ -1597,7 +1597,7 @@
     "sc": "Online (intl)"
   },
   {
-    "s": "Acne.org",
+    "s": "Acne",
     "d": "www.acne.org",
     "t": "acne",
     "u": "https://www.acne.org/search.php?i=&q={{{s}}}",
@@ -1667,7 +1667,7 @@
     "sc": "Academic"
   },
   {
-    "s": "ActiveState.com",
+    "s": "ActiveState",
     "d": "www.activestate.com",
     "t": "activestate",
     "u": "https://www.activestate.com/search/index.html?q={{{s}}}#1013",
@@ -1831,7 +1831,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "Amazon.de Fremdsprachige Bücher",
+    "s": "Amazon (English Books, Germany)",
     "d": "www.amazon.de",
     "t": "adefb",
     "u": "https://www.amazon.de/s?k={{{s}}}&i=english-books",
@@ -1839,7 +1839,7 @@
     "sc": "Online"
   },
   {
-    "s": "Adelung: Grammatisch-Kritisches Wörterbuch der Hochdeutschen Mundart",
+    "s": "Wörterbuchnetz (Adelung)",
     "d": "woerterbuchnetz.de",
     "t": "adelung",
     "u": "https://woerterbuchnetz.de/Adelung/?lemma={{{s}}}",
@@ -1858,7 +1858,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Apple dev form",
+    "s": "Apple Developer (Forums)",
     "d": "developer.apple.com",
     "t": "adf",
     "u": "https://developer.apple.com/forums/search?q={{{s}}}",
@@ -1902,7 +1902,7 @@
     "sc": "Online"
   },
   {
-    "s": "Adlibris FI",
+    "s": "Adlibris (Finland)",
     "d": "www.adlibris.com",
     "t": "adlibrisfi",
     "u": "https://www.adlibris.com/fi/haku?q={{{s}}}",
@@ -1910,7 +1910,7 @@
     "sc": "Online"
   },
   {
-    "s": "Adlibris NO",
+    "s": "Adlibris (Norway)",
     "d": "www.adlibris.com",
     "t": "adlibrisno",
     "u": "https://www.adlibris.com/no/sok?q={{{s}}}",
@@ -1918,7 +1918,7 @@
     "sc": "Online"
   },
   {
-    "s": "Adme.ru",
+    "s": "AdMe",
     "d": "www.adme.ru",
     "t": "adme",
     "u": "https://www.adme.ru/search/?q={{{s}}}",
@@ -1950,7 +1950,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Ansible Docs",
+    "s": "Ansible (Docs)",
     "d": "docs.ansible.com",
     "t": "adoc",
     "ts": [
@@ -1985,7 +1985,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "SAO/NASA Astrophysics Data System",
+    "s": "NASA ADS",
     "d": "adsabs.harvard.edu",
     "t": "adsabs",
     "u": "https://adsabs.harvard.edu//cgi-bin/basic_connect?qsearch={{{s}}}",
@@ -2028,7 +2028,7 @@
     "sc": "Music"
   },
   {
-    "s": "NASA ADS Bibliographical reference search",
+    "s": "NASA ADS (References)",
     "d": "adsabs.harvard.edu",
     "t": "adsref",
     "u": "https://adsabs.harvard.edu/cgi-bin/nph-abs_connect?db_key=ALL&bibcode={{{s}}}",
@@ -2044,7 +2044,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "Adventure Rider Forum (Kagi Search)",
+    "s": "Adventure Rider Forum (Kagi)",
     "d": "kagi.com",
     "ad": "advrider.com",
     "t": "adv",
@@ -2130,7 +2130,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Aeris Blog (Kagi Search)",
+    "s": "Aeris Blog (Kagi)",
     "d": "kagi.com",
     "ad": "imirhil.fr",
     "t": "aeris",
@@ -2177,7 +2177,7 @@
     "sc": "Online"
   },
   {
-    "s": "Android Code Search",
+    "s": "Android (Code)",
     "d": "cs.android.com",
     "t": "androidcs",
     "ts": [
@@ -2239,7 +2239,7 @@
     "sc": "Government"
   },
   {
-    "s": "Amazon.fr",
+    "s": "Amazon (France)",
     "d": "www.amazon.fr",
     "t": "afr",
     "ts": [
@@ -2260,7 +2260,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "aftvhacks",
+    "s": "Aftvhacks",
     "d": "aftvhacks.de",
     "t": "aftvhacks",
     "u": "https://aftvhacks.de/?s={{{s}}}",
@@ -2292,7 +2292,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Grateful Dead Lyrics (Kagi Search)",
+    "s": "Grateful Dead Lyrics (Kagi)",
     "d": "kagi.com",
     "ad": "artsites.ucsc.edu/GDead/agdl/",
     "t": "agdl",
@@ -2320,7 +2320,7 @@
     "sc": "Blogs (intl)"
   },
   {
-    "s": "Agora.co.il",
+    "s": "Agora",
     "d": "agora.co.il",
     "t": "agorail",
     "u": "https://agora.co.il/toGet.asp?iseek={{{s}}}",
@@ -2388,7 +2388,7 @@
     "sc": "Programming"
   },
   {
-    "s": "AutoHotkey v2 Docs",
+    "s": "AutoHotkey (v2 Docs)",
     "d": "www.autohotkey.com",
     "t": "ahkd",
     "u": "https://www.autohotkey.com/docs/v2/search.htm?q={{{s}}}",
@@ -2407,7 +2407,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Ahmia.fi",
+    "s": "Ahmia",
     "d": "ahmia.fi",
     "t": "ahmia",
     "u": "https://ahmia.fi/search/?q={{{s}}}",
@@ -2415,7 +2415,7 @@
     "sc": "Domains"
   },
   {
-    "s": "ahrefs",
+    "s": "Ahrefs",
     "d": "ahrefs.com",
     "t": "ahrefs",
     "u": "https://ahrefs.com/site-explorer/overview/v2/subdomains/recent?target={{{s}}}",
@@ -2518,7 +2518,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "aip.org",
+    "s": "AIP Scitation",
     "d": "scitation.aip.org",
     "t": "aip",
     "u": "https://scitation.aip.org/search?value1={{{s}}}&option1=fulltext",
@@ -2566,7 +2566,7 @@
     "sc": "Online"
   },
   {
-    "s": "Airliners.net",
+    "s": "Airliners",
     "d": "www.airliners.net",
     "t": "airliners",
     "u": "https://www.airliners.net/search?keywords={{{s}}}",
@@ -2601,7 +2601,7 @@
     "sc": "Search"
   },
   {
-    "s": "archive.is",
+    "s": "Archive.today",
     "d": "archive.is",
     "t": "ais",
     "ts": [
@@ -2628,7 +2628,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Amazon.it",
+    "s": "Amazon (Italy)",
     "d": "www.amazon.it",
     "t": "ait",
     "ts": [
@@ -2666,7 +2666,7 @@
     "sc": "Online"
   },
   {
-    "s": "アマゾン (Amazon Japan)",
+    "s": "Amazon (Japan)",
     "d": "www.amazon.co.jp",
     "t": "aj",
     "ts": [
@@ -2728,7 +2728,7 @@
     "sc": "Newspaper (intl)"
   },
   {
-    "s": "alaMaula",
+    "s": "AlaMaula",
     "d": "www.alamaula.com",
     "t": "ala",
     "u": "https://www.alamaula.com/q/{{{s}}}/S0",
@@ -2744,7 +2744,7 @@
     "sc": "Search"
   },
   {
-    "s": "aladin",
+    "s": "Aladin",
     "d": "www.aladin.co.kr",
     "t": "aladin",
     "u": "https://www.aladin.co.kr/search/wsearchresult.aspx?SearchTarget=All&SearchWord={{{s}}}",
@@ -2803,7 +2803,7 @@
     "sc": "Government"
   },
   {
-    "s": "AllMusic Albums",
+    "s": "AllMusic (Albums)",
     "d": "www.allmusic.com",
     "t": "album",
     "ts": [
@@ -2814,7 +2814,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Albumart (Music)",
+    "s": "Album Art (Music)",
     "d": "www.albumart.org",
     "t": "albumartcd",
     "u": "https://www.albumart.org/index.php?skey={{{s}}}&itempage=1&newsearch=1&searchindex=Music",
@@ -2822,7 +2822,7 @@
     "sc": "Music"
   },
   {
-    "s": "Albumart (DVD)",
+    "s": "Album Art (DVD)",
     "d": "www.albumart.org",
     "t": "albumartdvd",
     "u": "https://www.albumart.org/index.php?skey={{{s}}}&itempage=1&newsearch=1&searchindex=DVD",
@@ -2956,7 +2956,7 @@
     "sc": "Local"
   },
   {
-    "s": "alibris",
+    "s": "Alibris",
     "d": "www.alibris.com",
     "t": "alibris",
     "u": "https://www.alibris.com/booksearch?keyword={{{s}}}",
@@ -3020,7 +3020,7 @@
     "sc": "Tools"
   },
   {
-    "s": "allaboutcircuits",
+    "s": "All About Circuits",
     "d": "www.allaboutcircuits.com",
     "t": "allaboutcircuits",
     "u": "https://www.allaboutcircuits.com/scripts/search.html?q={{{s}}}",
@@ -3079,7 +3079,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Allerhande",
+    "s": "Albert Heijn (Allerhande)",
     "d": "www.ah.nl",
     "t": "allerhande",
     "u": "https://www.ah.nl/allerhande/recepten-zoeken?Ntt={{{s}}}",
@@ -3087,7 +3087,7 @@
     "sc": "Food"
   },
   {
-    "s": "Allerstorfer.at",
+    "s": "Allerstorfer",
     "d": "www.allerstorfer.at",
     "t": "allerstorfer",
     "u": "https://www.allerstorfer.at/?s={{{s}}}",
@@ -3130,7 +3130,7 @@
     "sc": "Movies"
   },
   {
-    "s": "All Music",
+    "s": "AllMusic",
     "d": "www.allmusic.com",
     "t": "allmus",
     "ts": [
@@ -3181,7 +3181,7 @@
     "sc": "Music"
   },
   {
-    "s": "almaany",
+    "s": "Almaany (ar-ar)",
     "d": "www.almaany.com",
     "t": "almaanyar",
     "ts": [
@@ -3203,7 +3203,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Almaany persian",
+    "s": "Almaany (ar-fa)",
     "d": "www.almaany.com",
     "t": "almaanyfa",
     "u": "https://www.almaany.com/ar/dict/ar-fa/{{{s}}}/",
@@ -3278,7 +3278,7 @@
     "sc": "Sysadmin (packages)"
   },
   {
-    "s": "Alternate België",
+    "s": "Alternate (Belgium)",
     "d": "www.alternate.be",
     "t": "altbe",
     "u": "https://www.alternate.be/html/search.html?query={{{s}}}",
@@ -3374,7 +3374,7 @@
     "sc": "Online"
   },
   {
-    "s": "Amazon.de",
+    "s": "Amazon (Digital Music, Germany)",
     "d": "www.amazon.de",
     "t": "amademp3",
     "u": "https://www.amazon.de/s?k={{{s}}}&i=digital-music",
@@ -3382,7 +3382,7 @@
     "sc": "Music"
   },
   {
-    "s": "Amazon Alexa Skills Search Page",
+    "s": "Amazon (Alexa Skills)",
     "d": "www.amazon.com",
     "t": "amalexa",
     "u": "https://www.amazon.com/s?k={{{s}}}&i=alexa-skills",
@@ -3410,7 +3410,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Amazon MP3 Store",
+    "s": "Amazon (MP3)",
     "d": "www.amazon.com",
     "t": "amazonmp3",
     "ts": [
@@ -3421,7 +3421,7 @@
     "sc": "Online (intl)"
   },
   {
-    "s": "Amazon México",
+    "s": "Amazon (Mexico)",
     "d": "www.amazon.com.mx",
     "t": "amazonmx",
     "ts": [
@@ -3440,7 +3440,7 @@
     "sc": "Online"
   },
   {
-    "s": "Amazon.com order history",
+    "s": "Amazon (Orders)",
     "d": "www.amazon.com",
     "t": "amazonorders",
     "ts": [
@@ -3451,7 +3451,7 @@
     "sc": "Online"
   },
   {
-    "s": "Amazon.com.tr",
+    "s": "Amazon (Turkey)",
     "d": "www.amazon.com.tr",
     "t": "amazontr",
     "u": "https://www.amazon.com.tr/s?k={{{s}}}",
@@ -3459,7 +3459,7 @@
     "sc": "Online"
   },
   {
-    "s": "Amazon.co.uk",
+    "s": "Amazon (UK)",
     "d": "www.amazon.co.uk",
     "t": "amazonuk",
     "ts": [
@@ -3473,7 +3473,7 @@
     "sc": "Online (intl)"
   },
   {
-    "s": "Amazon Cloud",
+    "s": "Amazon (Cloud)",
     "d": "www.amazon.com",
     "t": "amcloud",
     "u": "https://www.amazon.com/clouddrive/#G=0&path={{{s}}}",
@@ -3537,7 +3537,7 @@
     "sc": "Topical"
   },
   {
-    "s": "Amazon (GLOBAL)",
+    "s": "Amazon (Global)",
     "d": "www.amazon.com",
     "t": "amglobal",
     "u": "https://www.amazon.com/s?k={{{s}}}&i=us-worldwide-shipping-aps",
@@ -3616,7 +3616,7 @@
     "sc": "Music"
   },
   {
-    "s": "Firefox Add-ons",
+    "s": "Firefox (Add-ons)",
     "d": "addons.mozilla.org",
     "t": "amo",
     "ts": [
@@ -3632,7 +3632,7 @@
     "sc": "Downloads (add-ons)"
   },
   {
-    "s": "Auto-Medienportal.Net",
+    "s": "Auto-Medienportal",
     "d": "www.auto-medienportal.net",
     "t": "ampnet",
     "u": "https://www.auto-medienportal.net/artikel/quicksearch/?searchterm={{{s}}}",
@@ -3640,7 +3640,7 @@
     "sc": "Magazine (car)"
   },
   {
-    "s": "Ampparit.com",
+    "s": "Ampparit",
     "d": "www.ampparit.com",
     "t": "ampparit",
     "u": "https://www.ampparit.com/haku?q={{{s}}}",
@@ -3659,7 +3659,7 @@
     "sc": "Design"
   },
   {
-    "s": "Amazon.co.uk MP3",
+    "s": "Amazon (MP3, UK)",
     "d": "www.amazon.co.uk",
     "t": "amukmp3",
     "u": "https://www.amazon.co.uk/s?k={{{s}}}&i=digital-music",
@@ -3683,7 +3683,7 @@
     "sc": "General"
   },
   {
-    "s": "Amazon Instant Video",
+    "s": "Amazon (Instant Video)",
     "d": "www.amazon.com",
     "t": "amvid",
     "u": "https://www.amazon.com/s/url=search-alias=instant-video&field-keywords={{{s}}}",
@@ -3691,7 +3691,7 @@
     "sc": "Online"
   },
   {
-    "s": "Amazon.de Instant Video",
+    "s": "Amazon (Prime Video, Germany)",
     "d": "www.amazon.de",
     "t": "amvidde",
     "ts": [
@@ -3702,7 +3702,7 @@
     "sc": "Video"
   },
   {
-    "s": "Amway.com",
+    "s": "Amway",
     "d": "www.amway.com",
     "t": "amway",
     "u": "https://www.amway.com/Shop/Search/SearchResults.aspx?searchkeyword={{{s}}}",
@@ -3710,7 +3710,7 @@
     "sc": "Online"
   },
   {
-    "s": "Amazon Books",
+    "s": "Amazon (Books)",
     "d": "www.amazon.com",
     "t": "amzbks",
     "ts": [
@@ -3756,7 +3756,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "R Analysis (Kagi Search)",
+    "s": "R Analysis (Kagi)",
     "d": "kagi.com",
     "ad": "larmarange.github.io/analyse-R",
     "t": "analyser",
@@ -3878,7 +3878,7 @@
     "sc": "Online"
   },
   {
-    "s": "Angular (Kagi Search)",
+    "s": "Angular (Kagi)",
     "d": "kagi.com",
     "ad": "angular.io",
     "t": "ang",
@@ -3911,7 +3911,7 @@
     "sc": "Startups"
   },
   {
-    "s": "anghami",
+    "s": "Anghami",
     "d": "www.anghami.com",
     "t": "anghami",
     "u": "https://www.anghami.com/search/{{{s}}}",
@@ -3919,7 +3919,7 @@
     "sc": "Music"
   },
   {
-    "s": "Angular.io",
+    "s": "Angular",
     "d": "angular.io",
     "t": "angular",
     "ts": [
@@ -4068,7 +4068,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Apertium (Dutch to Afrikaans)",
+    "s": "Apertium (nld-afr)",
     "d": "www.apertium.org",
     "t": "anlaf",
     "u": "https://www.apertium.org/index.eng.html?dir=nld-afr&q={{{s}}}"
@@ -4098,7 +4098,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "anobii",
+    "s": "Anobii",
     "d": "www.anobii.com",
     "t": "anobii",
     "u": "https://www.anobii.com/search?s=1&keyword={{{s}}}",
@@ -4144,7 +4144,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Ansible Module Documentation",
+    "s": "Ansible (Modules)",
     "d": "docs.ansible.com",
     "t": "ansiblemod",
     "u": "https://docs.ansible.com/ansible/latest/collections/ansible/builtin/{{{s}}}_module.html",
@@ -4152,7 +4152,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Splunk Answers",
+    "s": "Splunk (Answers)",
     "d": "answers.splunk.com",
     "t": "ans.splunk",
     "u": "https://answers.splunk.com/search.html?q={{{s}}}",
@@ -4160,7 +4160,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Answers.com",
+    "s": "Answers",
     "d": "www.answers.com",
     "t": "answers",
     "u": "https://www.answers.com/{{{s}}}",
@@ -4200,7 +4200,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Antônimos.com.br",
+    "s": "Antônimos",
     "d": "www.antonimos.com.br",
     "t": "antonimos",
     "u": "https://www.antonimos.com.br/busca.php?q={{{s}}}",
@@ -4208,7 +4208,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Synonyms.net",
+    "s": "Synonyms.net (Antonyms)",
     "d": "www.synonyms.net",
     "t": "antonym",
     "u": "https://www.synonyms.net/antonyms/{{{s}}}",
@@ -4248,7 +4248,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Archive of our Own",
+    "s": "Archive of Our Own",
     "d": "archiveofourown.org",
     "t": "ao3",
     "u": "https://archiveofourown.org/works/search?utf8=%E2%9C%93&work_search[query]={{{s}}}",
@@ -4256,7 +4256,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Archive of Our Own (Tag Search)",
+    "s": "Archive of Our Own (Tags)",
     "d": "archiveofourown.org",
     "t": "ao3tags",
     "u": "https://archiveofourown.org/tags/search?query[name]={{{s}}}",
@@ -4264,7 +4264,7 @@
     "sc": "Misc"
   },
   {
-    "s": "AOE 2 Reddit Page",
+    "s": "Reddit (/r/aoe2)",
     "d": "www.reddit.com",
     "t": "aoe2r",
     "u": "https://www.reddit.com/r/aoe2/search?q={{{s}}}&restrict_sr=1",
@@ -4296,7 +4296,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Art of Problem Solving [Wiki]",
+    "s": "Art of Problem Solving (Wiki)",
     "d": "artofproblemsolving.com",
     "t": "aops",
     "u": "https://artofproblemsolving.com/wiki/index.php?title=Special:Search&fulltext=Search&search={{{s}}}",
@@ -4304,7 +4304,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "Art Of Problem Solving Community",
+    "s": "Art of Problem Solving (Community)",
     "d": "artofproblemsolving.com",
     "t": "aopscomm",
     "u": "https://artofproblemsolving.com/community/search/{{{s}}}",
@@ -4378,7 +4378,7 @@
     "sc": "Video"
   },
   {
-    "s": "Australia Post Postcode Lookup",
+    "s": "Australia Post (Postcode)",
     "d": "auspost.com.au",
     "t": "apc",
     "u": "https://auspost.com.au/search?q={{{s}}}",
@@ -4394,7 +4394,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Apertium (English to Spanish)",
+    "s": "Apertium (eng-spa)",
     "d": "www.apertium.org",
     "t": "apert-en-es",
     "u": "https://www.apertium.org/index.spa.html?dir=eng-spa&q={{{s}}}#translation",
@@ -4416,7 +4416,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "APIDock - Rails",
+    "s": "APIDock (Rails Quick)",
     "d": "apidock.com",
     "t": "apidockrails",
     "u": "https://apidock.com/rails/search/quick?query={{{s}}}",
@@ -4424,7 +4424,7 @@
     "sc": "Languages (ruby)"
   },
   {
-    "s": "APIdock",
+    "s": "APIDock (Ruby)",
     "d": "apidock.com",
     "t": "apidockruby",
     "u": "https://apidock.com/ruby/search/quick?query={{{s}}}",
@@ -4456,7 +4456,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "API Platform (Kagi Search)",
+    "s": "API Platform (Kagi)",
     "d": "kagi.com",
     "ad": "api-platform.com",
     "t": "apiplatform",
@@ -4465,7 +4465,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Amazon Prime Instant Video",
+    "s": "Amazon (Prime Instant Video)",
     "d": "www.amazon.com",
     "t": "apiv",
     "u": "https://www.amazon.com/s?k={{{s}}}&i=prime-instant-video",
@@ -4539,7 +4539,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Atom Packages",
+    "s": "Atom (Packages)",
     "d": "atom.io",
     "t": "apm",
     "ts": [
@@ -4566,7 +4566,7 @@
     "sc": "Tools"
   },
   {
-    "s": "NASA - Astronomy Picture of the Day",
+    "s": "NASA (Astronomy Picture of the Day)",
     "d": "apod.nasa.gov",
     "t": "apod",
     "u": "https://apod.nasa.gov/cgi-bin/apod/apod_search?tquery={{{s}}}",
@@ -4590,7 +4590,7 @@
     "sc": "Downloads (add-ons)"
   },
   {
-    "s": "Amazon Prime Pantry",
+    "s": "Amazon (Prime Pantry)",
     "d": "www.amazon.com",
     "t": "app",
     "u": "https://www.amazon.com/s/search-alias=pantry&field-keywords={{{s}}}",
@@ -4625,7 +4625,7 @@
     "sc": "Downloads (apps)"
   },
   {
-    "s": "App Engine Docs",
+    "s": "Google App Engine",
     "d": "code.google.com",
     "t": "appengine",
     "u": "https://code.google.com/query/#p=appengine&q={{{s}}}",
@@ -4633,7 +4633,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Salesforce.com AppExchange",
+    "s": "Salesforce (AppExchange)",
     "d": "appexchange.salesforce.com",
     "t": "appex",
     "u": "https://appexchange.salesforce.com/results?keywords={{{s}}}",
@@ -4657,7 +4657,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Apple (Brasil)",
+    "s": "Apple (Brazil)",
     "d": "www.apple.com",
     "t": "applebr",
     "u": "https://www.apple.com/br/search/{{{s}}}",
@@ -4735,7 +4735,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Apple Trailers (Kagi Search)",
+    "s": "Apple Trailers (Kagi)",
     "d": "kagi.com",
     "ad": "trailers.apple.com",
     "t": "appletrailer",
@@ -4744,7 +4744,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Apple TV (Kagi Search)",
+    "s": "Apple TV (Kagi)",
     "d": "kagi.com",
     "ad": "tv.apple.com",
     "t": "appletv",
@@ -4820,7 +4820,7 @@
     "sc": "Downloads (apps)"
   },
   {
-    "s": "App Store UK (iPhone)",
+    "s": "App Store (iPhone, UK)",
     "d": "apps.apple.com",
     "t": "ukappstore",
     "ts": [
@@ -4920,7 +4920,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google Translate (Arabic to English)",
+    "s": "Google Translate (ar-en)",
     "d": "translate.google.com",
     "t": "ar2en",
     "u": "https://translate.google.com/#ar/en/{{{s}}}",
@@ -4928,7 +4928,7 @@
     "sc": "Google"
   },
   {
-    "s": "Arabic dictionary",
+    "s": "Perseus Digital Library (Arabic)",
     "d": "www.perseus.tufts.edu",
     "t": "arabic",
     "u": "https://www.perseus.tufts.edu/hopper/morph?l={{{s}}}&la=ar",
@@ -4979,7 +4979,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Agentur für Arbeit",
+    "s": "Arbeitsagentur",
     "d": "www.arbeitsagentur.de",
     "t": "arbeitsagentur",
     "u": "https://www.arbeitsagentur.de/jobsuche/suche?sort=Relevanz&angebotsart=1&was={{{s}}}",
@@ -5051,7 +5051,7 @@
     "sc": "Topical"
   },
   {
-    "s": "ArchLinux Wiki",
+    "s": "ArchWiki",
     "d": "wiki.archlinux.org",
     "t": "arch",
     "u": "https://wiki.archlinux.org/index.php?title=Special:Search&search={{{s}}}&go=Go",
@@ -5059,7 +5059,7 @@
     "sc": "Sysadmin (Arch)"
   },
   {
-    "s": "ArchLinux User Repository",
+    "s": "Arch Linux (AUR)",
     "d": "aur.archlinux.org",
     "t": "archaur",
     "u": "https://aur.archlinux.org/packages?O=0&K={{{s}}}",
@@ -5105,7 +5105,7 @@
     "sc": "Sysadmin (Arch)"
   },
   {
-    "s": "archlinux.fr",
+    "s": "Arch Linux Wiki (French)",
     "d": "wiki.archlinux.fr",
     "t": "archfr",
     "u": "https://wiki.archlinux.fr/index.php?title=Spécial:Recherche&profile=default&search={{{s}}}&fulltext=Search",
@@ -5148,7 +5148,7 @@
     ]
   },
   {
-    "s": "Internet",
+    "s": "Internet Archive",
     "d": "archive.org",
     "t": "archive",
     "u": "https://archive.org/search.php?query={{{s}}}",
@@ -5164,7 +5164,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Internet Archive TV News",
+    "s": "Internet Archive (TV News)",
     "d": "archive.org",
     "t": "archivetv",
     "u": "https://archive.org/details/tv?q={{{s}}}",
@@ -5228,7 +5228,7 @@
     "sc": "Sysadmin (Arch)"
   },
   {
-    "s": "archlinux wiki pl",
+    "s": "ArchWiki (pl)",
     "d": "wiki.archlinux.org",
     "t": "archpl",
     "u": "https://wiki.archlinux.org/index.php/{{{s}}}_(Polski)",
@@ -5268,7 +5268,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Arduino Reference (Kagi Search)",
+    "s": "Arduino Reference (Kagi)",
     "d": "kagi.com",
     "ad": "arduino.cc",
     "t": "arduinoreference",
@@ -5301,7 +5301,7 @@
     "sc": "General"
   },
   {
-    "s": "Almaany English-Arabic",
+    "s": "Almaany (ar-en)",
     "d": "www.almaany.com",
     "t": "ar-en",
     "u": "https://www.almaany.com/ar/dict/ar-en/{{{s}}}",
@@ -5309,7 +5309,7 @@
     "sc": "Search"
   },
   {
-    "s": "AR15 (Kagi Search)",
+    "s": "AR15 (Kagi)",
     "d": "kagi.com",
     "ad": "ar15.com",
     "t": "arf",
@@ -5410,7 +5410,7 @@
     "sc": "Programming"
   },
   {
-    "s": "armorgames",
+    "s": "Armor Games",
     "d": "armorgames.com",
     "t": "armorgames",
     "u": "https://armorgames.com/search/games?type=games&q={{{s}}}",
@@ -5434,7 +5434,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Azure Quickstart Templates",
+    "s": "Azure (Quickstart Templates)",
     "d": "azure.microsoft.com",
     "t": "armtemp",
     "u": "https://azure.microsoft.com/de-de/resources/templates/?term={{{s}}}",
@@ -5553,7 +5553,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "artcyclopedia.com (artists)",
+    "s": "Artcyclopedia (Artists)",
     "d": "www.artcyclopedia.com",
     "t": "artist",
     "u": "https://www.artcyclopedia.com/scripts/tsearch.pl?type=1&t={{{s}}}",
@@ -5585,7 +5585,7 @@
     "sc": "Reference"
   },
   {
-    "s": "artcyclopedia.com",
+    "s": "Artcyclopedia",
     "d": "www.artcyclopedia.com",
     "t": "artwork",
     "u": "https://www.artcyclopedia.com/scripts/tsearch.pl?t={{{s}}}&type=2",
@@ -5631,7 +5631,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "朝日新聞",
+    "s": "Asahi Shimbun",
     "d": "sitesearch.asahi.com",
     "t": "asahi",
     "u": "https://sitesearch.asahi.com/.cgi/sitesearch/sitesearch.pl?Keywords={{{s}}}",
@@ -5671,7 +5671,7 @@
     "sc": "Online"
   },
   {
-    "s": "ASCL.net - Astrophysics Source Code Library",
+    "s": "ASCL (Astrophysics Source Code Library)",
     "d": "ascl.net",
     "t": "ascl",
     "u": "https://ascl.net/code/search/{{{s}}}",
@@ -5735,7 +5735,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "AsiaVape.co",
+    "s": "AsiaVape",
     "d": "asiavape.co",
     "t": "asiavape",
     "u": "https://asiavape.co/?s={{{s}}}&post_type=product",
@@ -5743,7 +5743,7 @@
     "sc": "Tech"
   },
   {
-    "s": "asics",
+    "s": "ASICS",
     "d": "www.asics.com",
     "t": "asics",
     "u": "https://www.asics.com/us/en-us/search?text={{{s}}}",
@@ -5759,7 +5759,7 @@
     "sc": "Online"
   },
   {
-    "s": "AskaPatient.com",
+    "s": "AskaPatient",
     "d": "www.askapatient.com",
     "t": "askapatient",
     "u": "https://www.askapatient.com/searchresults.asp?searchField={{{s}}}",
@@ -5767,7 +5767,7 @@
     "sc": "Health"
   },
   {
-    "s": "Ask.com",
+    "s": "Ask",
     "d": "www.ask.com",
     "t": "ask",
     "ts": [
@@ -5778,7 +5778,7 @@
     "sc": "Social"
   },
   {
-    "s": "AskF5 (my.f5.com)",
+    "s": "AskF5",
     "d": "my.f5.com",
     "t": "askf5",
     "u": "https://my.f5.com/manage/s/global-search/@uri#q={{{s}}}&aq=@f5_archived",
@@ -5810,7 +5810,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "/r/AskReddit",
+    "s": "Reddit (/r/AskReddit)",
     "d": "www.reddit.com",
     "t": "askreddit",
     "u": "https://www.reddit.com/r/AskReddit/search?q={{{s}}}&restrict_sr=on&sort=relevance&t=all",
@@ -5850,7 +5850,7 @@
     "sc": "Topical"
   },
   {
-    "s": "Asos.com",
+    "s": "ASOS",
     "d": "www.asos.com",
     "t": "asos",
     "u": "https://www.asos.com/search/?q={{{s}}}",
@@ -5858,7 +5858,7 @@
     "sc": "Online"
   },
   {
-    "s": "Amazon Subscribe & Save",
+    "s": "Amazon (Subscribe & Save)",
     "d": "www.amazon.com",
     "t": "ass",
     "u": "https://www.amazon.com/gp/subscribe-and-save/manager/",
@@ -6080,7 +6080,7 @@
     "sc": "Downloads (add-ons)"
   },
   {
-    "s": "Atom themes",
+    "s": "Atom (Themes)",
     "d": "atom.io",
     "t": "atomthemes",
     "u": "https://atom.io/themes/search?q={{{s}}}",
@@ -6136,7 +6136,7 @@
     "sc": "Academic"
   },
   {
-    "s": "XE (AUD2EUR)",
+    "s": "XE (AUD-EUR)",
     "d": "www.xe.com",
     "t": "aud2eur",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=AUD&To=EUR",
@@ -6144,7 +6144,7 @@
     "sc": "Tools"
   },
   {
-    "s": "XE (AUD2GBP)",
+    "s": "XE (AUD-GBP)",
     "d": "www.xe.com",
     "t": "aud2gdp",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=AUD&To=GBP",
@@ -6152,7 +6152,7 @@
     "sc": "Tools"
   },
   {
-    "s": "XE (AUD2USD)",
+    "s": "XE (AUD-USD)",
     "d": "www.xe.com",
     "t": "aud2usd",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=AUD&To=USD",
@@ -6176,7 +6176,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Audible.com",
+    "s": "Audible",
     "d": "www.audible.com",
     "t": "audible",
     "ts": [
@@ -6187,7 +6187,7 @@
     "sc": "Online"
   },
   {
-    "s": "Audible.de",
+    "s": "Audible (Germany)",
     "d": "www.audible.de",
     "t": "audible.de",
     "ts": [
@@ -6278,7 +6278,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "iDicionário Aulete",
+    "s": "Dicionário Aulete",
     "d": "www.aulete.com.br",
     "t": "aulete",
     "u": "https://www.aulete.com.br/{{{s}}}",
@@ -6294,7 +6294,7 @@
     "sc": "Search"
   },
   {
-    "s": "Arch User Repository",
+    "s": "Arch Linux (aUR)",
     "d": "aur.archlinux.org",
     "t": "aur",
     "u": "https://aur.archlinux.org/packages/?K={{{s}}}",
@@ -6302,7 +6302,7 @@
     "sc": "Sysadmin (Arch)"
   },
   {
-    "s": "Arch User Repository Package",
+    "s": "Arch Linux (aUR) (Package)",
     "d": "aur.archlinux.org",
     "t": "aurp",
     "u": "https://aur.archlinux.org/packages/{{{s}}}",
@@ -6334,7 +6334,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Australia Post",
+    "s": "Australia Post (Tracking)",
     "d": "auspost.com.au",
     "t": "auspost",
     "u": "https://auspost.com.au/track/track.html?id={{{s}}}",
@@ -6386,7 +6386,7 @@
     "sc": "General"
   },
   {
-    "s": "Autocar.co.uk",
+    "s": "Autocar",
     "d": "www.autocar.co.uk",
     "t": "autocar",
     "u": "https://www.autocar.co.uk/SearchResults.aspx?q={{{s}}}",
@@ -6418,7 +6418,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "alpenvereinaktiv",
+    "s": "Alpenvereinaktiv",
     "d": "www.alpenvereinaktiv.com",
     "t": "avaktiv",
     "u": "https://www.alpenvereinaktiv.com/en/search/?q={{{s}}}",
@@ -6485,7 +6485,7 @@
     "sc": "Topical"
   },
   {
-    "s": "AVG Secure Search",
+    "s": "AVG",
     "d": "search.avg.com",
     "t": "avg",
     "u": "https://search.avg.com/search?q={{{s}}}",
@@ -6509,7 +6509,7 @@
     "sc": "Academic"
   },
   {
-    "s": "applevis.com",
+    "s": "AppleVis",
     "d": "www.applevis.com",
     "t": "avis",
     "u": "https://www.applevis.com/search?search_api_views_fulltext={{{s}}}",
@@ -6573,7 +6573,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Amazon Warehouse Deals",
+    "s": "Amazon (Warehouse Deals)",
     "d": "www.amazon.com",
     "t": "awd",
     "u": "https://www.amazon.com/s/url=search-alias=warehouse-deals&field-keywords={{{s}}}",
@@ -6621,7 +6621,7 @@
     "sc": "Online"
   },
   {
-    "s": "Amazon Web Services",
+    "s": "AWS (Docs)",
     "d": "docs.aws.amazon.com",
     "t": "aws",
     "u": "https://docs.aws.amazon.com/search/doc-search.html?searchPath=documentation&searchQuery={{{s}}}",
@@ -6707,7 +6707,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "Azure Documentation",
+    "s": "Azure (Docs)",
     "d": "azure.microsoft.com",
     "t": "azure",
     "u": "https://azure.microsoft.com/en-us/search/?q={{{s}}}",
@@ -6755,7 +6755,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "bab.la English-Czech dictionary",
+    "s": "bab.la (en-cs)",
     "d": "en.bab.la",
     "t": "babcs",
     "u": "https://en.bab.la/dictionary/english-czech/{{{s}}}",
@@ -6763,7 +6763,7 @@
     "sc": "General"
   },
   {
-    "s": "bab",
+    "s": "bab.la (da-de)",
     "d": "fr.bab.la",
     "t": "babdedk",
     "u": "https://fr.bab.la/dictionnaire/danois-allemand/{{{s}}}",
@@ -6798,7 +6798,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "en.bab.la/dictionary/english-german/",
+    "s": "bab.la (en-de)",
     "d": "en.bab.la",
     "t": "babende",
     "u": "https://en.bab.la/dictionary/english-german/{{{s}}}",
@@ -6806,7 +6806,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Bab.la English-Esperanto",
+    "s": "bab.la (en-eo)",
     "d": "en.bab.la",
     "t": "babeneo",
     "u": "https://en.bab.la/dictionary/english-esperanto/{{{s}}}",
@@ -6822,7 +6822,7 @@
     "sc": "Tools"
   },
   {
-    "s": "bab.la Spanish-German",
+    "s": "bab.la (es-de)",
     "d": "de.bab.la",
     "t": "babesde",
     "u": "https://de.bab.la/woerterbuch/spanisch-deutsch/{{{s}}}",
@@ -6830,7 +6830,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Bab.la Polish",
+    "s": "bab.la (pl-en)",
     "d": "en.bab.la",
     "t": "babp",
     "u": "https://en.bab.la/dictionary/polish-english/{{{s}}}",
@@ -6838,7 +6838,7 @@
     "sc": "General"
   },
   {
-    "s": "Bab.la",
+    "s": "Bab.la (en-pl)",
     "d": "pl.bab.la",
     "t": "babpl",
     "ts": [
@@ -6849,7 +6849,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Bab.la pl ru",
+    "s": "Bab.la (pl-ru)",
     "d": "pl.bab.la",
     "t": "babplru",
     "u": "https://pl.bab.la/slownik/polski-rosyjski/{{{s}}}",
@@ -6857,7 +6857,7 @@
     "sc": "Tools"
   },
   {
-    "s": "bab.la",
+    "s": "bab.la (en-sv)",
     "d": "sv.bab.la",
     "t": "babsv",
     "u": "https://sv.bab.la/lexikon/engelsk-svensk/{{{s}}}",
@@ -7007,7 +7007,7 @@
     "sc": "Government"
   },
   {
-    "s": "Bambali Marketplace (Kagi Search)",
+    "s": "Bambali Marketplace (Kagi)",
     "d": "kagi.com",
     "ad": "bambali.net",
     "t": "bambali",
@@ -7068,7 +7068,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Pons.eu (enfr)",
+    "s": "PONS (en-fr)",
     "d": "de.pons.com",
     "t": "bangfren",
     "ts": [
@@ -7087,7 +7087,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Pons (dela)",
+    "s": "PONS (de-la)",
     "d": "de.pons.com",
     "t": "banglg",
     "u": "https://de.pons.com/übersetzung?q={{{s}}}&l=dela&in=&lf=de",
@@ -7095,7 +7095,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Pipl - Profile Search enguine",
+    "s": "Pipl (Profile)",
     "d": "pipl.com",
     "t": "bangpeople",
     "u": "https://pipl.com/search/?q={{{s}}}",
@@ -7123,7 +7123,7 @@
     "sc": "Online"
   },
   {
-    "s": "Bibliothèque et Archives Nationales du Québec",
+    "s": "BAnQ",
     "d": "www.banq.qc.ca",
     "t": "banq",
     "u": "https://www.banq.qc.ca/techno/recherche/rms.html?keyword={{{s}}}&Recherche=tout&fonction=chercher&afficherPortail=checked&afficherIris=checked&afficherPistard=checked&afficherColNum=checked",
@@ -7208,7 +7208,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Base Search",
+    "s": "BASE",
     "d": "www.base-search.net",
     "t": "base",
     "u": "https://www.base-search.net/Search/Results?lookfor={{{s}}}&type=all&oaboost=1&ling=1&name=&newsearch=1&refid=dcbasen",
@@ -7224,7 +7224,7 @@
     "sc": "Reference"
   },
   {
-    "s": "BASE Search",
+    "s": "BASE (Search)",
     "d": "www.base-search.net",
     "t": "basesearch",
     "u": "https://www.base-search.net/Search/Results?lookfor={{{s}}}",
@@ -7282,7 +7282,7 @@
     "sc": "Games (Pokemon)"
   },
   {
-    "s": "Battle.Net",
+    "s": "Battle.net",
     "d": "eu.battle.net",
     "t": "battlenet",
     "u": "https://eu.battle.net/en/search?q={{{s}}}",
@@ -7298,7 +7298,7 @@
     "sc": "Online"
   },
   {
-    "s": "Bay 12 Games (Kagi Search)",
+    "s": "Bay 12 Games (Kagi)",
     "d": "kagi.com",
     "ad": "bay12games.com",
     "t": "bay12",
@@ -7331,7 +7331,7 @@
     "sc": "Online"
   },
   {
-    "s": "bazel documentation",
+    "s": "Bazel (Documentation)",
     "d": "docs.bazel.build",
     "t": "bazel",
     "u": "https://docs.bazel.build/search.html?q={{{s}}}",
@@ -7339,7 +7339,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Bazoš.cz",
+    "s": "Bazoš",
     "d": "www.bazos.cz",
     "t": "bazos",
     "u": "https://www.bazos.cz/search.php?hledat={{{s}}}",
@@ -7444,7 +7444,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Bitbucket Code Search",
+    "s": "Bitbucket (Code)",
     "d": "bitbucket.org",
     "t": "bbcs",
     "u": "https://bitbucket.org/search?q={{{s}}}",
@@ -7555,7 +7555,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Bitbucket User",
+    "s": "Bitbucket (User)",
     "d": "bitbucket.org",
     "t": "bbus",
     "u": "https://bitbucket.org/{{{s}}}/",
@@ -7590,7 +7590,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Bestbuy.ca",
+    "s": "Best Buy (Canada)",
     "d": "www.bestbuy.ca",
     "t": "bbyc",
     "ts": [
@@ -7656,7 +7656,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "blockchain.info",
+    "s": "Blockchain.info (Address)",
     "d": "blockchain.info",
     "t": "bchain",
     "u": "https://blockchain.info/address/{{{s}}}",
@@ -7723,7 +7723,7 @@
     "sc": "Government"
   },
   {
-    "s": "Bandcamp tags",
+    "s": "Bandcamp (Tags)",
     "d": "bandcamp.com",
     "t": "bctag",
     "u": "https://bandcamp.com/discover/{{{s}}}",
@@ -7876,7 +7876,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "BDLP",
+    "s": "DBLP",
     "d": "dblp.uni-trier.de",
     "t": "bdlp",
     "ts": [
@@ -7887,7 +7887,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "百度翻译",
+    "s": "Baidu Translate (en-zh)",
     "d": "fanyi.baidu.com",
     "t": "bdtr",
     "u": "https://fanyi.baidu.com/#en/zh/{{{s}}}",
@@ -7895,7 +7895,7 @@
     "sc": "General"
   },
   {
-    "s": "BeamMachine.net",
+    "s": "BeamMachine",
     "d": "www.beammachine.net",
     "t": "beam",
     "u": "https://www.beammachine.net/de/qsearch.php?q={{{s}}}&strict=1",
@@ -8047,7 +8047,7 @@
     "sc": "Design"
   },
   {
-    "s": "Behind the name - Surnames",
+    "s": "Behind the Name (Surnames)",
     "d": "surnames.behindthename.com",
     "t": "behindsurname",
     "u": "https://surnames.behindthename.com/name/{{{s}}}",
@@ -8142,19 +8142,19 @@
     "sc": "Tech"
   },
   {
-    "s": "Beolingus De-en",
+    "s": "BEOLINGUS (de-en)",
     "d": "dict.tu-chemnitz.de",
     "t": "beo",
     "u": "https://dict.tu-chemnitz.de/dings.cgi?service=deen&query={{{s}}}"
   },
   {
-    "s": "Beolingus De-es",
+    "s": "BEOLINGUS (de-es)",
     "d": "dict.tu-chemnitz.de",
     "t": "beoes",
     "u": "https://dict.tu-chemnitz.de/dings.cgi?service=dees&query={{{s}}}"
   },
   {
-    "s": "Beolingus De-pt",
+    "s": "BEOLINGUS (de-pt)",
     "d": "dict.tu-chemnitz.de",
     "t": "beopt",
     "u": "https://dict.tu-chemnitz.de/dings.cgi?service=dept&query={{{s}}}"
@@ -8224,7 +8224,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "BERUFENET - Berufsinformationen einfach finden",
+    "s": "BERUFENET",
     "d": "berufenet.arbeitsagentur.de",
     "t": "berufenet",
     "u": "https://berufenet.arbeitsagentur.de/berufenet/faces/index?path=null/suchergebnisse&such={{{s}}}",
@@ -8240,7 +8240,7 @@
     "sc": "Tools"
   },
   {
-    "s": "BESLIST.nl",
+    "s": "Beslist",
     "d": "www.beslist.nl",
     "t": "beslist",
     "u": "https://www.beslist.nl/products/r/{{{s}}}/",
@@ -8339,7 +8339,7 @@
     "sc": "Events"
   },
   {
-    "s": "babelfish.de",
+    "s": "Babelfish (German)",
     "d": "www.babelfish.de",
     "t": "bfde",
     "u": "https://www.babelfish.de/dict?query={{{s}}}&src=auto&dst=en&submit=übersetzen",
@@ -8384,7 +8384,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Bankgirot - Search Bankgiro number by Company Name",
+    "s": "Bankgirot (Company)",
     "d": "www.bankgirot.se",
     "t": "bgc",
     "u": "https://www.bankgirot.se/en/sok-bg-nr/?company={{{s}}}",
@@ -8414,7 +8414,7 @@
     "sc": "Games (offline)"
   },
   {
-    "s": "na",
+    "s": "BoardGameGeek (Geek Market)",
     "d": "boardgamegeek.com",
     "t": "bgggm",
     "u": "https://boardgamegeek.com/geekmarket/search?q={{{s}}}",
@@ -8422,7 +8422,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "BibleGateway: King James Version",
+    "s": "BibleGateway (King James Version)",
     "d": "www.biblegateway.com",
     "t": "bgkj",
     "ts": [
@@ -8449,7 +8449,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Bankgirot - Search Bankgiro number",
+    "s": "Bankgirot (Number)",
     "d": "www.bankgirot.se",
     "t": "bgn",
     "u": "https://www.bankgirot.se/en/sok-bg-nr/?bgnr={{{s}}}",
@@ -8457,7 +8457,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Bankgirot - Search Bankgiro number by Organization Number",
+    "s": "Bankgirot (Organization)",
     "d": "www.bankgirot.se",
     "t": "bgo",
     "u": "https://www.bankgirot.se/en/sok-bg-nr/?orgnr={{{s}}}",
@@ -8522,7 +8522,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "BibleHub",
+    "s": "Bible Hub",
     "d": "biblehub.net",
     "t": "bhb",
     "ts": [
@@ -8561,7 +8561,7 @@
     "sc": "Academic"
   },
   {
-    "s": "BibleStudyTools Encyclopedias",
+    "s": "Bible Study Tools (Encyclopedias)",
     "d": "www.biblestudytools.com",
     "t": "biben",
     "u": "https://www.biblestudytools.com/search/?s=references&q={{{s}}}&rc=ENC&rc2=",
@@ -8598,7 +8598,7 @@
     "sc": "Search"
   },
   {
-    "s": "Bible Atlas",
+    "s": "Bible Hub (Atlas)",
     "d": "biblehub.net",
     "t": "bibleatlas",
     "u": "https://biblehub.net/searchatlas.php?q={{{s}}}",
@@ -8634,7 +8634,7 @@
     "sc": "Reference (religion)"
   },
   {
-    "s": "Biblija.net",
+    "s": "Biblija",
     "d": "www.biblija.net",
     "t": "biblija",
     "u": "https://www.biblija.net/biblija.cgi?m={{{s}}}",
@@ -8658,7 +8658,7 @@
     "sc": "Books"
   },
   {
-    "s": "Biblionetka.pl",
+    "s": "Biblionetka",
     "d": "www.biblionetka.pl",
     "t": "biblionetka",
     "u": "https://www.biblionetka.pl/search.aspx?searchType=book_catalog&searchPhrase={{{s}}}",
@@ -8682,7 +8682,7 @@
     "sc": "Books"
   },
   {
-    "s": "Bibleserver",
+    "s": "BibleServer",
     "d": "www.bibleserver.com",
     "t": "biblsrv",
     "u": "https://www.bibleserver.com/search/{{{s}}}",
@@ -8698,7 +8698,7 @@
     "sc": "Tools"
   },
   {
-    "s": "catalogue des bibliothèques de Paris",
+    "s": "Bibliothèques de Paris (Catalogue)",
     "d": "bibliotheques.paris.fr",
     "t": "bibparis",
     "u": "https://bibliotheques.paris.fr/Default/search.aspx?SC=CATALOGUE&QUERY={{{s}}}",
@@ -8817,7 +8817,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "BigWords.com",
+    "s": "BigWords",
     "d": "www5.bigwords.com",
     "t": "bigwords",
     "u": "https://www5.bigwords.com/search/easy-search/?producttype=all&searchtype=isbn&searchstring={{{s}}}&buySell=",
@@ -8857,7 +8857,7 @@
     "sc": "Online"
   },
   {
-    "s": "Billiger.de",
+    "s": "Billiger",
     "d": "www.billiger.de",
     "t": "bil",
     "ts": [
@@ -9053,7 +9053,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "Bisafans.de",
+    "s": "Bisafans",
     "d": "www.bisafans.de",
     "t": "bisa",
     "u": "https://www.bisafans.de/suchbisa.php?q={{{s}}}",
@@ -9233,7 +9233,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Bookshare.org",
+    "s": "Bookshare",
     "d": "www.bookshare.org",
     "t": "bkshare",
     "u": "https://www.bookshare.org/search?keyword={{{s}}}",
@@ -9260,7 +9260,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "MXToolbox (blacklist)",
+    "s": "MXToolbox (Blacklist)",
     "d": "mxtoolbox.com",
     "t": "blacklist",
     "ts": [
@@ -9370,7 +9370,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Blender API",
+    "s": "Blender (API)",
     "d": "docs.blender.org",
     "t": "blenderapi",
     "u": "https://docs.blender.org/api/current/search.html?q={{{s}}}",
@@ -9378,7 +9378,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Blender Manual",
+    "s": "Blender (Manual)",
     "d": "docs.blender.org",
     "t": "blender",
     "u": "https://docs.blender.org/manual/en/latest/search.html?q={{{s}}}&check_keywords=yes",
@@ -9405,7 +9405,7 @@
     "sc": "Academic"
   },
   {
-    "s": "BudgetLightForum.com",
+    "s": "BudgetLightForum",
     "d": "budgetlightforum.com",
     "t": "blf",
     "u": "https://budgetlightforum.com/search?q_as={{{s}}}",
@@ -9421,7 +9421,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Blindekuh.de",
+    "s": "Blinde Kuh",
     "d": "www.blinde-kuh.de",
     "t": "blindekuh",
     "u": "https://www.blinde-kuh.de/bksearch.cgi?input=bksearchbox+start&query={{{s}}}",
@@ -9507,7 +9507,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "Duck Blog (Kagi Search)",
+    "s": "Duck Blog (Kagi)",
     "d": "kagi.com",
     "ad": "duck.co/blog",
     "t": "blog",
@@ -9608,7 +9608,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Blox.pl",
+    "s": "Blox",
     "d": "www.blox.pl",
     "t": "blx",
     "u": "https://www.blox.pl/html?page=blogPublicSearch&container_search={{{s}}}",
@@ -9859,7 +9859,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "boingboing",
+    "s": "Boing Boing",
     "d": "www.google.com",
     "t": "boingboing",
     "u": "https://www.google.com/cse?cx=partner-pub-2170174688585464:d58nno-rqp8&ie=ISO-8859-1&q={{{s}}}&siteurl=www.boingboing.net/",
@@ -9925,7 +9925,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "bolor-toli",
+    "s": "Bolor Toli",
     "d": "www.bolor-toli.com",
     "t": "bolor",
     "u": "https://www.bolor-toli.com/dictionary/word?search={{{s}}}",
@@ -10040,7 +10040,7 @@
     "sc": "Books"
   },
   {
-    "s": "Booking España",
+    "s": "Booking.com (Spain)",
     "d": "www.booking.com",
     "t": "bookinges",
     "u": "https://www.booking.com/search.es.html?ss={{{s}}}",
@@ -10107,7 +10107,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Boost.org",
+    "s": "Boost",
     "d": "kagi.com",
     "ad": "boost.org",
     "t": "boost",
@@ -10156,7 +10156,7 @@
     "sc": "General"
   },
   {
-    "s": "Battle of the Bits (Kagi Search)",
+    "s": "Battle of the Bits (Kagi)",
     "d": "kagi.com",
     "ad": "battleofthebits.com",
     "t": "botb",
@@ -10213,7 +10213,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "bower",
+    "s": "Libraries.io (Bower)",
     "d": "libraries.io",
     "t": "bower",
     "u": "https://libraries.io/search?q={{{s}}}&platforms=Bower&sort=rank&sort=rank",
@@ -10410,7 +10410,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Brave Search",
+    "s": "Brave",
     "d": "search.brave.com",
     "t": "brave",
     "u": "https://search.brave.com/search?q={{{s}}}",
@@ -10451,7 +10451,7 @@
     "sc": "Downloads (software)"
   },
   {
-    "s": "Home Manager - Option Search",
+    "s": "Home Manager (Options)",
     "d": "home-manager-options.extranix.com",
     "t": "hmo",
     "u": "https://home-manager-options.extranix.com/?query={{{s}}}&release=master",
@@ -10467,7 +10467,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Bricklink",
+    "s": "BrickLink",
     "d": "www.bricklink.com",
     "t": "bricklink",
     "u": "https://www.bricklink.com/search.asp?q={{{s}}}",
@@ -10475,7 +10475,7 @@
     "sc": "Online"
   },
   {
-    "s": "Bricklink Catalog",
+    "s": "BrickLink (Catalog)",
     "d": "www.bricklink.com",
     "t": "bricklinkcat",
     "u": "https://www.bricklink.com/catalogList.asp?q={{{s}}}",
@@ -10483,7 +10483,7 @@
     "sc": "Reference (fun)"
   },
   {
-    "s": "Brickset (parts)",
+    "s": "Brickset (Parts)",
     "d": "brickset.com",
     "t": "brickpart",
     "u": "https://brickset.com/parts?query={{{s}}}",
@@ -10539,7 +10539,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Britannica School (High)",
+    "s": "Britannica School (High School)",
     "d": "school.eb.com",
     "t": "britannicaschoolh",
     "ts": [
@@ -10550,7 +10550,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Britannica School (Middle)",
+    "s": "Britannica School (Middle School)",
     "d": "school.eb.com",
     "t": "britannicaschoolm",
     "ts": [
@@ -10588,7 +10588,7 @@
     "sc": "Online (intl)"
   },
   {
-    "s": "XE (brl2eur)",
+    "s": "XE (BRL-EUR)",
     "d": "www.xe.com",
     "t": "brl2eur",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=BRL&To=EUR",
@@ -10596,7 +10596,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "XE (brl2gdp)",
+    "s": "XE (BRL-GBP)",
     "d": "www.xe.com",
     "t": "brl2gbp",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=BRL&To=GBP",
@@ -10604,7 +10604,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "XE (brl2usd)",
+    "s": "XE (BRL-USD)",
     "d": "www.xe.com",
     "t": "brl2usd",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=BRL&To=USD",
@@ -10620,7 +10620,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Broadsign (Kagi Search)",
+    "s": "Broadsign (Kagi)",
     "d": "kagi.com",
     "ad": "broadsign.com",
     "t": "broadsign",
@@ -10719,7 +10719,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Biblioteca - Universidad de Salamanca",
+    "s": "Biblioteca (Universidad de Salamanca)",
     "d": "brumario.usal.es",
     "t": "brumario",
     "u": "https://brumario.usal.es/search/?searchtype=X&searcharg={{{s}}}&op=Buscar&SORT=D&searchscope=",
@@ -10925,7 +10925,7 @@
     "sc": "Cryptocurrency"
   },
   {
-    "s": "Blockchain Address",
+    "s": "Blockchain (Address)",
     "d": "www.blockchain.com",
     "t": "btcaddr",
     "u": "https://www.blockchain.com/btc/address/{{{s}}}",
@@ -10978,7 +10978,7 @@
     "sc": "Sysadmin (debian)"
   },
   {
-    "s": "Microsoft/Bing Translator URL",
+    "s": "Microsoft Translator (URL)",
     "d": "www.microsofttranslator.com",
     "t": "bturl",
     "ts": [
@@ -10997,7 +10997,7 @@
     "sc": "Search"
   },
   {
-    "s": "BUCea - Bibliotecas UCM",
+    "s": "BUCea (Bibliotecas UCM)",
     "d": "ucm.summon.serialssolutions.com",
     "t": "bucea",
     "u": "https://ucm.summon.serialssolutions.com/es-ES/#!/search?ho=t&fvf=ContentType,Newspaper Article,t&l=es-ES&q={{{s}}}&pg=buscador&utf8=%E2%9C%93",
@@ -11107,7 +11107,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Bukkit Plugins Search",
+    "s": "CurseForge (Bukkit Plugins)",
     "d": "www.curseforge.com",
     "t": "bukkit",
     "u": "https://www.curseforge.com/minecraft/bukkit-plugins/search?search={{{s}}}",
@@ -11131,7 +11131,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Bund für Umwelt und Naturschutz",
+    "s": "BUND",
     "d": "www.bund.net",
     "t": "bund",
     "u": "https://www.bund.net/service/suchergebnis/?L=0&q={{{s}}}",
@@ -11250,7 +11250,7 @@
     "sc": "Online"
   },
   {
-    "s": "www.buzer.de",
+    "s": "Buzer",
     "d": "www.buzer.de",
     "t": "buz",
     "u": "https://www.buzer.de/s1.htm?a=&g={{{s}}}",
@@ -11415,7 +11415,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Camptocamp (forum)",
+    "s": "Camptocamp (Forum)",
     "d": "www.camptocamp.org",
     "t": "c2cforum",
     "u": "https://www.camptocamp.org/documents/search?type=forums&q={{{s}}}",
@@ -11423,7 +11423,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Camp to Camp (sites)",
+    "s": "Camptocamp (Sites)",
     "d": "www.camptocamp.org",
     "t": "c2csite",
     "u": "https://www.camptocamp.org/documents/search?type=sites&q={{{s}}}",
@@ -11431,7 +11431,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Camp to Camp (summits)",
+    "s": "Camptocamp (Summits)",
     "d": "www.camptocamp.org",
     "t": "c2csummit",
     "u": "https://www.camptocamp.org/documents/search?type=summits&q={{{s}}}",
@@ -11439,7 +11439,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Google Translate (Czech to English)",
+    "s": "Google Translate (cs-en)",
     "d": "translate.google.com",
     "t": "c2e",
     "u": "https://translate.google.com/#cs/en/{{{s}}}",
@@ -11510,7 +11510,7 @@
     "sc": "Government"
   },
   {
-    "s": "Cactus2000 - Conjugation Table (German)",
+    "s": "Cactus2000 (Conjugation Table)",
     "d": "conjd.cactus2000.de",
     "t": "cact",
     "u": "https://conjd.cactus2000.de/index.php?q={{{s}}}",
@@ -11593,7 +11593,7 @@
     "sc": "Music (Lyrics)"
   },
   {
-    "s": "Cakephp 2 Book",
+    "s": "CakePHP (2.x)",
     "d": "book.cakephp.org",
     "t": "cake2book",
     "ts": [
@@ -11604,7 +11604,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "CakePHP Cakebook 3.x",
+    "s": "CakePHP (3.x)",
     "d": "book.cakephp.org",
     "t": "cakebook",
     "u": "https://book.cakephp.org/3.0/en/search.html?check_keywords=yes&area=default&q={{{s}}}",
@@ -11620,7 +11620,7 @@
     "sc": "Languages (php)"
   },
   {
-    "s": "DuckDuckGo AI Chat",
+    "s": "DuckDuckGo (AI Chat)",
     "d": "duckduckgo.com",
     "t": "ddg-chat",
     "ts": [
@@ -11631,7 +11631,7 @@
     "sc": "Tools"
   },
   {
-    "s": "DuckDuckGo Calculator",
+    "s": "DuckDuckGo (Calculator)",
     "d": "duckduckgo.com",
     "t": "ddg-calc",
     "ts": [
@@ -11690,7 +11690,7 @@
     "sc": "Food"
   },
   {
-    "s": "Camaro Forums @ Z28.com",
+    "s": "Z28 (Camaro Forums)",
     "d": "www.z28.com",
     "t": "camaro",
     "u": "https://www.z28.com/search/search?keywords={{{s}}}&order=relevance",
@@ -11744,7 +11744,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Cambridge Dictionary Spanish-English",
+    "s": "Cambridge Dictionary (es-en)",
     "d": "dictionary.cambridge.org",
     "t": "camesen",
     "u": "https://dictionary.cambridge.org/dictionary/spanish-english/{{{s}}}",
@@ -11752,7 +11752,7 @@
     "sc": "General"
   },
   {
-    "s": "Cambridge French-English Dictionary",
+    "s": "Cambridge Dictionary (fr-en)",
     "d": "dictionary.cambridge.org",
     "t": "camfren",
     "u": "https://dictionary.cambridge.org/dictionary/french-english/{{{s}}}",
@@ -11776,7 +11776,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Cambridge PL",
+    "s": "Cambridge Dictionary (en-pl)",
     "d": "dictionary.cambridge.org",
     "t": "campl",
     "u": "https://dictionary.cambridge.org/dictionary/english-polish/{{{s}}}",
@@ -11784,7 +11784,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Cambridge Polish-English Dictionary",
+    "s": "Cambridge Dictionary (pl-en)",
     "d": "dictionary.cambridge.org",
     "t": "camplen",
     "u": "https://dictionary.cambridge.org/dictionary/polish-english/{{{s}}}",
@@ -11808,7 +11808,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Cambridge Traditional Chinese",
+    "s": "Cambridge Dictionary (en-zh-TW)",
     "d": "dictionary.cambridge.org",
     "t": "camtw",
     "u": "https://dictionary.cambridge.org/dictionary/english-chinese-traditional/{{{s}}}",
@@ -11843,7 +11843,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Canada Post Tracking",
+    "s": "Canada Post (Tracking)",
     "d": "www.canadapost.ca",
     "t": "canadapost",
     "u": "https://www.canadapost.ca/cpotools/apps/track/personal/findByTrackNumber?trackingNumber={{{s}}}&LOCALE=en&LOCALE2=en",
@@ -11919,7 +11919,7 @@
     "sc": "Tech"
   },
   {
-    "s": "canoonet",
+    "s": "CanooNet",
     "d": "www.canoonet.eu",
     "t": "canoo",
     "u": "https://www.canoonet.eu/services/Controller?input={{{s}}}",
@@ -11927,7 +11927,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "11foot8.com",
+    "s": "11foot8",
     "d": "11foot8.com",
     "t": "canopener",
     "u": "https://11foot8.com/?s={{{s}}}",
@@ -11935,7 +11935,7 @@
     "sc": "Video"
   },
   {
-    "s": "CC-Canto - A Cantonese Dictionary",
+    "s": "CC-Canto",
     "d": "cantonese.org",
     "t": "canto",
     "u": "https://cantonese.org/search.php?q={{{s}}}",
@@ -12000,7 +12000,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "CarMagazine.co.uk",
+    "s": "CAR Magazine",
     "d": "www.carmagazine.co.uk",
     "t": "car",
     "ts": [
@@ -12062,7 +12062,7 @@
     "sc": "Online"
   },
   {
-    "s": "carousell",
+    "s": "Carousell",
     "d": "carousell.com",
     "t": "carousell",
     "u": "https://carousell.com/search/products/?query={{{s}}}",
@@ -12166,7 +12166,7 @@
     "sc": "Reference (religion)"
   },
   {
-    "s": "Zieglers - Catholic Store",
+    "s": "Zieglers (Catholic Store)",
     "d": "www.zieglers.com",
     "t": "catholicstore",
     "u": "https://www.zieglers.com/search.php?search_query={{{s}}}",
@@ -12229,7 +12229,7 @@
     "sc": "Books"
   },
   {
-    "s": "Christianbook.com",
+    "s": "Christianbook",
     "d": "www.christianbook.com",
     "t": "cbd",
     "u": "https://www.christianbook.com/Christian/Books/easy_find?Ntt={{{s}}}&N=0&Ntk=keywords&action=Search&Ne=0",
@@ -12352,7 +12352,7 @@
     "sc": "Online"
   },
   {
-    "s": "Openverse Creative Commons Search",
+    "s": "Openverse",
     "d": "openverse.org",
     "t": "cc",
     "u": "https://openverse.org/search/?q={{{s}}}",
@@ -12384,7 +12384,7 @@
     "sc": "Reference (religion)"
   },
   {
-    "s": "Christ Centered Gamer Forums",
+    "s": "Christ Centered Gamer (Forums)",
     "d": "www.christcenteredgamer.com",
     "t": "ccgrforum",
     "u": "https://www.christcenteredgamer.com/phpBB3/search.php?keywords={{{s}}}&submit=Search",
@@ -12392,7 +12392,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Christ Centered Gamer Reviews",
+    "s": "Christ Centered Gamer (Reviews)",
     "d": "www.christcenteredgamer.com",
     "t": "ccgrreviews",
     "u": "https://www.christcenteredgamer.com/index.php/component/search/?searchword={{{s}}}&ordering=newest&searchphrase=all&areas[0]=blogs",
@@ -12475,7 +12475,7 @@
     "sc": "Maps"
   },
   {
-    "s": "cplusplus.com",
+    "s": "Cplusplus",
     "d": "www.cplusplus.com",
     "t": "c++",
     "ts": [
@@ -12488,7 +12488,7 @@
     "sc": "Languages (c++)"
   },
   {
-    "s": "Creative commons search",
+    "s": "Creative Commons",
     "d": "ccsearch.creativecommons.org",
     "t": "ccsearch",
     "u": "https://ccsearch.creativecommons.org/search?q={{{s}}}",
@@ -12605,7 +12605,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "Collins Dictionary (English German)",
+    "s": "Collins Dictionary (en-de)",
     "d": "www.collinsdictionary.com",
     "t": "cdeen",
     "u": "https://www.collinsdictionary.com/spellcheck/english-german?q={{{s}}}",
@@ -12613,7 +12613,7 @@
     "sc": "Search (Private)"
   },
   {
-    "s": "Cambridge Dictionary English-German",
+    "s": "Cambridge Dictionary (en-de)",
     "d": "dictionary.cambridge.org",
     "t": "cdende",
     "u": "https://dictionary.cambridge.org/dictionary/english-german/{{{s}}}",
@@ -12621,7 +12621,7 @@
     "sc": "General"
   },
   {
-    "s": "Cambridge Dictionary English-Spanish",
+    "s": "Cambridge Dictionary (en-es)",
     "d": "dictionary.cambridge.org",
     "t": "cdenes",
     "u": "https://dictionary.cambridge.org/dictionary/english-spanish/{{{s}}}",
@@ -12629,7 +12629,7 @@
     "sc": "General"
   },
   {
-    "s": "Cambridge Dictionaries Online",
+    "s": "Cambridge Dictionary (Spellcheck)",
     "d": "dictionary.cambridge.org",
     "t": "cdgdic",
     "u": "https://dictionary.cambridge.org/spellcheck/learner-english/?q={{{s}}}",
@@ -12673,7 +12673,7 @@
     "sc": "Online"
   },
   {
-    "s": "ChronoDiver.com",
+    "s": "ChronoDiver",
     "d": "chronodivers.com",
     "t": "cdiver",
     "u": "https://chronodivers.com/?s={{{s}}}",
@@ -12697,7 +12697,7 @@
     "sc": "Online"
   },
   {
-    "s": "Collins Dictionaries (English for Learners)",
+    "s": "Collins Dictionary (Learners)",
     "d": "www.collinsdictionary.com",
     "t": "cdl",
     "u": "https://www.collinsdictionary.com/dictionary/english-cobuild-learners/{{{s}}}",
@@ -12748,7 +12748,7 @@
     "sc": "Online"
   },
   {
-    "s": "CDON.com (Denmark/Danmark)",
+    "s": "CDON (Denmark)",
     "d": "cdon.dk",
     "t": "cdondk",
     "u": "https://cdon.dk/search?q={{{s}}}",
@@ -12756,7 +12756,7 @@
     "sc": "Online"
   },
   {
-    "s": "CDON.com (Finland/Suomi)",
+    "s": "CDON (Finland)",
     "d": "cdon.fi",
     "t": "cdonfi",
     "u": "https://cdon.fi/search?q={{{s}}}",
@@ -12764,7 +12764,7 @@
     "sc": "Online"
   },
   {
-    "s": "CDON.com (Norway/Norge)",
+    "s": "CDON (Norway)",
     "d": "cdon.no",
     "t": "cdonno",
     "u": "https://cdon.no/search?q={{{s}}}",
@@ -12820,7 +12820,7 @@
     "sc": "Online"
   },
   {
-    "s": "eBay: completed listings",
+    "s": "eBay (Completed Listings)",
     "d": "www.ebay.com",
     "t": "ceb",
     "u": "https://www.ebay.com/csc/items/?_nkw={{{s}}}+&LH_Complete=1",
@@ -12892,7 +12892,7 @@
     "sc": "Services"
   },
   {
-    "s": "Collins Dictionary (English - Spanish)",
+    "s": "Collins Dictionary (en-es)",
     "d": "www.collinsdictionary.com",
     "t": "cenes",
     "u": "https://www.collinsdictionary.com/dictionary/english-spanish/{{{s}}}",
@@ -12900,7 +12900,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Collins French Dictionary (to French)",
+    "s": "Collins Dictionary (en-fr)",
     "d": "www.collinsdictionary.com",
     "t": "cenfr",
     "u": "https://www.collinsdictionary.com/dictionary/english-french/{{{s}}}",
@@ -12964,7 +12964,7 @@
     "sc": "Maps"
   },
   {
-    "s": "BibleGateway: Contemporary English Version",
+    "s": "BibleGateway (Contemporary English Version)",
     "d": "www.biblegateway.com",
     "t": "cev",
     "u": "https://www.biblegateway.com/quicksearch/?quicksearch={{{s}}}&qs_version=CEV",
@@ -13020,7 +13020,7 @@
     "sc": "Startups"
   },
   {
-    "s": "AWS CloudFormation Documentation",
+    "s": "AWS (CloudFormation)",
     "d": "docs.aws.amazon.com",
     "t": "cfn",
     "ts": [
@@ -13047,7 +13047,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Collins French Dictionary (to English)",
+    "s": "Collins Dictionary (fr-en)",
     "d": "www.collinsdictionary.com",
     "t": "cfren",
     "u": "https://www.collinsdictionary.com/dictionary/french-english/{{{s}}}",
@@ -13119,7 +13119,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "The Chakra Project",
+    "s": "Chakra (Forum)",
     "d": "chakraos.org",
     "t": "chakraforum",
     "u": "https://chakraos.org/forum/search.php?action=search&keywords={{{s}}}&author=&search_in=0&sort_by=0&sort_dir=DESC&show_as=topics&search=Submit",
@@ -13135,7 +13135,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Chakra Wiki",
+    "s": "Chakra (Wiki)",
     "d": "chakraos.org",
     "t": "chakrawiki",
     "u": "https://chakraos.org/wiki/index.php?search={{{s}}}&go=Go",
@@ -13175,7 +13175,7 @@
     "sc": "Online"
   },
   {
-    "s": "r/ChapoTrapHouse",
+    "s": "Reddit (/r/ChapoTrapHouse)",
     "d": "www.reddit.com",
     "t": "chapo",
     "u": "https://www.reddit.com/r/ChapoTrapHouse/search?q={{{s}}}&restrict_sr=1",
@@ -13183,7 +13183,7 @@
     "sc": "Forum"
   },
   {
-    "s": "charcod.es",
+    "s": "CharCodes",
     "d": "charcodes.netlify.app",
     "t": "char",
     "u": "https://charcodes.netlify.app/#{{{s}}}",
@@ -13286,7 +13286,7 @@
     "sc": "AI Chatbots"
   },
   {
-    "s": "Google AI Mode",
+    "s": "Google (AI Mode)",
     "d": "www.google.com",
     "t": "gai",
     "ts": [
@@ -13379,7 +13379,7 @@
     "sc": "Online"
   },
   {
-    "s": "Check-host.net",
+    "s": "Check-Host",
     "d": "check-host.net",
     "t": "checkhost",
     "u": "https://check-host.net/ip-info?host={{{s}}}",
@@ -13411,7 +13411,7 @@
     "sc": "General"
   },
   {
-    "s": "Chefkoch",
+    "s": "ChefKoch",
     "d": "www.chefkoch.de",
     "t": "chef",
     "ts": [
@@ -13441,7 +13441,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Chefkoch.de Vegan",
+    "s": "ChefKoch (Vegan)",
     "d": "www.chefkoch.de",
     "t": "chefkochvegan",
     "u": "https://www.chefkoch.de/rs/s0t57/{{{s}}}/Vegan-Rezepte.html",
@@ -13783,7 +13783,7 @@
     "sc": "TV"
   },
   {
-    "s": "Companies House",
+    "s": "Companies House (UK)",
     "d": "beta.companieshouse.gov.uk",
     "t": "chuk",
     "u": "https://beta.companieshouse.gov.uk/search?q={{{s}}}",
@@ -13887,7 +13887,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Lirikcinta.com",
+    "s": "Lirikcinta",
     "d": "www.lirikcinta.com",
     "t": "cinta",
     "u": "https://www.lirikcinta.com/result/?q={{{s}}}",
@@ -14053,7 +14053,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Seznam Články",
+    "s": "Seznam (Articles)",
     "d": "clanky.seznam.cz",
     "t": "clanky",
     "u": "https://clanky.seznam.cz/?q={{{s}}}",
@@ -14093,7 +14093,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Clas Ohlson Finland",
+    "s": "Clas Ohlson (Finland)",
     "d": "www.clasohlson.com",
     "t": "clasfi",
     "u": "https://www.clasohlson.com/se/search?text={{{s}}}",
@@ -14109,7 +14109,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Clas Ohlson Norge",
+    "s": "Clas Ohlson (Norway)",
     "d": "www.clasohlson.com",
     "t": "clasno",
     "u": "https://www.clasohlson.com/no/view/content/search?searchKey=All&search_prefix={{{s}}}",
@@ -14347,7 +14347,7 @@
     "sc": "Programming"
   },
   {
-    "s": "WorldCat",
+    "s": "WorldCat (Books)",
     "d": "www.worldcat.org",
     "t": "closebook",
     "u": "https://www.worldcat.org/search?qt=worldcat_org_bks&q={{{s}}}&fq=dt:bks",
@@ -14411,7 +14411,7 @@
     "sc": "Academic"
   },
   {
-    "s": "clwb",
+    "s": "Clwb",
     "d": "clwb.net",
     "t": "clwb",
     "u": "https://clwb.net/?post_type=event&s={{{s}}}",
@@ -14470,7 +14470,7 @@
     "sc": "Companies"
   },
   {
-    "s": "compare.eu",
+    "s": "Compare.eu",
     "d": "compare.eu",
     "t": "cmpeu",
     "u": "https://compare.eu/?fs={{{s}}}",
@@ -14566,7 +14566,7 @@
     "sc": "Movies"
   },
   {
-    "s": "CNRTL",
+    "s": "CNRTL (Antonymie)",
     "d": "www.cnrtl.fr",
     "t": "cnrtla",
     "u": "https://www.cnrtl.fr/antonymie/{{{s}}}",
@@ -14574,7 +14574,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "cnrtl concordance",
+    "s": "CNRTL (Concordance)",
     "d": "www.cnrtl.fr",
     "t": "cnrtlc",
     "u": "https://www.cnrtl.fr/concordance/{{{s}}}",
@@ -14582,7 +14582,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Centre national de ressources textuelles et lexicales",
+    "s": "CNRTL",
     "d": "www.cnrtl.fr",
     "t": "cnrtl",
     "ts": [
@@ -14595,7 +14595,7 @@
     "sc": "Tools"
   },
   {
-    "s": "cnrtl étymologie",
+    "s": "CNRTL (Étymologie)",
     "d": "www.cnrtl.fr",
     "t": "cnrtle",
     "u": "https://www.cnrtl.fr/etymologie/{{{s}}}",
@@ -14603,7 +14603,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "cnrtl morphologie",
+    "s": "CNRTL (Morphologie)",
     "d": "www.cnrtl.fr",
     "t": "cnrtlm",
     "u": "https://www.cnrtl.fr/morphologie/{{{s}}}",
@@ -14611,7 +14611,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "cnrtl proxemie",
+    "s": "CNRTL (Proxémie)",
     "d": "www.cnrtl.fr",
     "t": "cnrtlp",
     "u": "https://www.cnrtl.fr/proxemie/{{{s}}}",
@@ -14619,7 +14619,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "cnrtl synonymie",
+    "s": "CNRTL (Synonymie)",
     "d": "www.cnrtl.fr",
     "t": "cnrtls",
     "u": "https://www.cnrtl.fr/synonymie/{{{s}}}",
@@ -14643,7 +14643,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "XE (cny2eur)",
+    "s": "XE (CNY-EUR)",
     "d": "www.xe.com",
     "t": "cny2eur",
     "u": "https://www.xe.com/currencyconverter/convert/?From=CNY&To=EUR&Amount={{{s}}}",
@@ -14659,7 +14659,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Copyright Catalog (title)",
+    "s": "Copyright Catalog (Title)",
     "d": "cocatalog.loc.gov",
     "t": "cocatalog",
     "u": "https://cocatalog.loc.gov/cgi-bin/Pwebrecon.cgi?Search_Arg={{{s}}}&Search_Code=TALL&CNT=25&HIST=1",
@@ -14667,7 +14667,7 @@
     "sc": "Law"
   },
   {
-    "s": "Copyright Catalog (name)",
+    "s": "Copyright Catalog (Name)",
     "d": "cocatalog.loc.gov",
     "t": "cocatalogn",
     "u": "https://cocatalog.loc.gov/cgi-bin/Pwebrecon.cgi?Search_Arg={{{s}}}&Search_Code=NALL&CNT=25&HIST=1",
@@ -14806,7 +14806,7 @@
     "sc": "Libraries/Frameworks (wordpress)"
   },
   {
-    "s": "thecodinglove.com",
+    "s": "The Coding Love",
     "d": "thecodinglove.com",
     "t": "codinglove",
     "u": "https://thecodinglove.com/search/{{{s}}}",
@@ -14914,7 +14914,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Collins German to English",
+    "s": "Collins Dictionary (de-en)",
     "d": "www.collinsdictionary.com",
     "t": "collinsge",
     "u": "https://www.collinsdictionary.com/dictionary/german-english/{{{s}}}",
@@ -14930,7 +14930,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Colloq.io",
+    "s": "Colloq",
     "d": "colloq.io",
     "t": "colloq",
     "u": "https://colloq.io/search?query={{{s}}}",
@@ -15093,7 +15093,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Compose Email (Gmail)",
+    "s": "Gmail (Compose)",
     "d": "mail.google.com",
     "t": "compose",
     "u": "https://mail.google.com/mail/?view=cm&to=&su={{{s}}}",
@@ -15190,7 +15190,7 @@
     "sc": "Government"
   },
   {
-    "s": "conjugator.reverso.net",
+    "s": "Reverso (Conjugator)",
     "d": "conjugator.reverso.net",
     "t": "conjen",
     "ts": [
@@ -15202,7 +15202,7 @@
     "sc": "Tools"
   },
   {
-    "s": "SpanishDict - Conjugate",
+    "s": "SpanishDict (Conjugate)",
     "d": "www.spanishdict.com",
     "t": "conjes",
     "ts": [
@@ -15213,7 +15213,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "conjugueur.reverso.net",
+    "s": "Reverso Conjugueur",
     "d": "conjugueur.reverso.net",
     "t": "conjfr",
     "u": "https://conjugueur.reverso.net/conjugaison-francais-verbe-{{{s}}}.html",
@@ -15221,7 +15221,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Le conjugueur",
+    "s": "Le Conjugueur",
     "d": "leconjugueur.lefigaro.fr",
     "t": "conj",
     "u": "https://leconjugueur.lefigaro.fr/conjugaison/verbe/{{{s}}}",
@@ -15325,7 +15325,7 @@
     "sc": "Google"
   },
   {
-    "s": "contamet.wordpress.com",
+    "s": "Contamet",
     "d": "contamet.wordpress.com",
     "t": "contamet",
     "u": "https://contamet.wordpress.com/?s={{{s}}}",
@@ -15465,7 +15465,7 @@
     "sc": "Social"
   },
   {
-    "s": "Cool Math Games (Kagi Search)",
+    "s": "Cool Math Games (Kagi)",
     "d": "kagi.com",
     "ad": "coolmathgames.com",
     "t": "coolmath",
@@ -15509,7 +15509,7 @@
     "sc": "Online"
   },
   {
-    "s": "Coop (DE)",
+    "s": "Coop (Germany)",
     "d": "www.coop.ch",
     "t": "coop_de",
     "u": "https://www.coop.ch/pb/site/search/search/2057/Lde/index.html?qs={{{s}}}&fr=coop2012&SuchButton.x=0&SuchButton.y=0&search=search&backend=backend_coop2012&la=de&_sid=4aea1684-910e-4741-9099-86fff3d8a570",
@@ -15517,7 +15517,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Coop (FR)",
+    "s": "Coop (France)",
     "d": "www.coop.ch",
     "t": "coop_fr",
     "u": "https://www.coop.ch/pb/site/search/search/2057/Lfr/index.html?qs={{{s}}}&fr=coop2012&SuchButton.x=0&SuchButton.y=0&search=search&backend=backend_coop2012&la=fr&_sid=2fae98df-7f08-49a8-86b5-38148b71ebdb",
@@ -15525,7 +15525,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Coop (IT)",
+    "s": "Coop (Italy)",
     "d": "www.coop.ch",
     "t": "coop_it",
     "u": "https://www.coop.ch/pb/site/search/search/2057/Lit/index.html?qs={{{s}}}&fr=coop2012&SuchButton.x=0&SuchButton.y=0&search=search&backend=backend_coop2012&la=it&_sid=537d493c-9c35-41dc-8881-d878b57e702f",
@@ -15533,7 +15533,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Coop Sweden",
+    "s": "Coop (Sweden)",
     "d": "www.coop.se",
     "t": "coop_se",
     "u": "https://www.coop.se/Sok/Receptsok/{{{s}}}",
@@ -15541,7 +15541,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Xe (cop2usd)",
+    "s": "XE (COP-USD)",
     "d": "www.xe.com",
     "t": "cop2usd",
     "u": "https://www.xe.com/currencyconverter/convert/?From=COP&To=USD&Amount={{{s}}}",
@@ -15683,7 +15683,7 @@
     "sc": "Health"
   },
   {
-    "s": "COSMOTY.de",
+    "s": "COSMOTY",
     "d": "www.cosmoty.de",
     "t": "cosmoty",
     "u": "https://www.cosmoty.de/suche/{{{s}}}/",
@@ -15699,7 +15699,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Costco.com",
+    "s": "Costco",
     "d": "www.costco.com",
     "t": "costco",
     "u": "https://www.costco.com/CatalogSearch?storeId=10301&catalogId=10701&langId=-1&keyword={{{s}}}",
@@ -15755,7 +15755,7 @@
     "sc": "Search"
   },
   {
-    "s": "쿠팡",
+    "s": "Coupang",
     "d": "www.coupang.com",
     "t": "coupang",
     "u": "https://www.coupang.com/np/search?component=&q={{{s}}}",
@@ -15881,7 +15881,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Cpu Benchmarks",
+    "s": "PassMark (CPU Benchmarks)",
     "d": "www.passmark.com",
     "t": "cpb",
     "u": "https://www.passmark.com/search/zoomsearch.php?zoom_query={{{s}}}",
@@ -15905,7 +15905,7 @@
     "sc": "Music"
   },
   {
-    "s": "Cygwin Package Grep",
+    "s": "Cygwin (Package Grep)",
     "d": "cygwin.com",
     "t": "cpg",
     "ts": [
@@ -15961,7 +15961,7 @@
     "sc": "Languages (c++)"
   },
   {
-    "s": "cppreference",
+    "s": "cppreference (German)",
     "d": "de.cppreference.com",
     "t": "cppde",
     "u": "https://de.cppreference.com/mwiki/index.php?title=Spezial:Suche&search={{{s}}}",
@@ -16004,7 +16004,7 @@
     "sc": "Health"
   },
   {
-    "s": "Collins Dictionary (Portuguese - English)",
+    "s": "Collins Dictionary (pt-en)",
     "d": "www.collinsdictionary.com",
     "t": "cpten",
     "u": "https://www.collinsdictionary.com/dictionary/portuguese-english/{{{s}}}",
@@ -16068,7 +16068,7 @@
     "sc": "Learning"
   },
   {
-    "s": "cran.r-project.org",
+    "s": "CRAN",
     "d": "finzi.psych.upenn.edu",
     "t": "cran",
     "u": "https://finzi.psych.upenn.edu/cgi-bin/namazu.cgi?query={{{s}}}&max=100&result=normal&sort=score&idxname=functions&idxname=vignettes&idxname=views",
@@ -16076,7 +16076,7 @@
     "sc": "Languages (r)"
   },
   {
-    "s": "crate.io",
+    "s": "CrateDB",
     "d": "crate.io",
     "t": "crate",
     "u": "https://crate.io/docs/stable/search.html?check_keywords=yes&area=default&q={{{s}}}",
@@ -16333,7 +16333,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "crossref",
+    "s": "Crossref",
     "d": "search.crossref.org",
     "t": "crossref",
     "ts": [
@@ -16526,7 +16526,7 @@
     "sc": "Video"
   },
   {
-    "s": "reddit.com/r/GlobalOffensive",
+    "s": "Reddit (/r/GlobalOffensive)",
     "d": "www.reddit.com",
     "t": "csgo",
     "ts": [
@@ -16561,7 +16561,7 @@
     "sc": "Search"
   },
   {
-    "s": "Liquipedia Counter-Strike Wiki",
+    "s": "Liquipedia (Counter-Strike)",
     "d": "wiki.teamliquid.net",
     "t": "cslq",
     "ts": [
@@ -16580,7 +16580,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "Catálogo cisne UCM",
+    "s": "Cisne (UCM)",
     "d": "cisne.sim.ucm.es",
     "t": "csn",
     "u": "https://cisne.sim.ucm.es/search*spi~S/X?SEARCH={{{s}}}&sort=D",
@@ -16604,7 +16604,7 @@
     "sc": "Broadcast"
   },
   {
-    "s": "Collins Dictionary (Spanish English)",
+    "s": "Collins Dictionary (es-en)",
     "d": "www.collinsdictionary.com",
     "t": "cspen",
     "u": "https://www.collinsdictionary.com/dictionary/spanish-english/{{{s}}}",
@@ -16612,7 +16612,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Mozilla Developer Network CSS",
+    "s": "MDN Web Docs (CSS)",
     "d": "developer.mozilla.org",
     "t": "css",
     "ts": [
@@ -16639,7 +16639,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Theoretical Computer Science - Stack Exchange",
+    "s": "Theoretical Computer Science (Stack Exchange)",
     "d": "cstheory.stackexchange.com",
     "t": "cstheory",
     "u": "https://cstheory.stackexchange.com/search?q={{{s}}}",
@@ -16647,7 +16647,7 @@
     "sc": "Programming"
   },
   {
-    "s": "/r/globaloffensivetrade",
+    "s": "Reddit (/r/GlobalOffensiveTrade)",
     "d": "www.reddit.com",
     "t": "cstrade",
     "ts": [
@@ -16682,7 +16682,7 @@
     "sc": "Online"
   },
   {
-    "s": "Chicken Scheme Wiki",
+    "s": "Chicken Scheme (Wiki)",
     "d": "wiki.call-cc.org",
     "t": "csw",
     "u": "https://wiki.call-cc.org/search?text={{{s}}}&ident=",
@@ -16722,7 +16722,7 @@
     "sc": "Health"
   },
   {
-    "s": "Collins English Thesaurus",
+    "s": "Collins Dictionary (Thesaurus)",
     "d": "www.collinsdictionary.com",
     "t": "cth",
     "ts": [
@@ -16797,7 +16797,7 @@
     "sc": "Online"
   },
   {
-    "s": "Cuchilleria Albacete - Grupo Marpasi S.L.",
+    "s": "Cuchilleria Albacete",
     "d": "cuchilleriaalbacete.com",
     "t": "cuchilleriaalbacete",
     "u": "https://cuchilleriaalbacete.com/articulos-buscar.php?busco={{{s}}}",
@@ -16864,7 +16864,7 @@
     "sc": "Online"
   },
   {
-    "s": "cults3d",
+    "s": "Cults3D",
     "d": "cults3d.com",
     "t": "cults3d",
     "u": "https://cults3d.com/fr/recherche?utf8=%E2%9C%93&q={{{s}}}",
@@ -16904,7 +16904,7 @@
     "sc": "Online"
   },
   {
-    "s": "Curia (Case number)",
+    "s": "Curia (Case Number)",
     "d": "curia.europa.eu",
     "t": "curiac",
     "u": "https://curia.europa.eu/juris/liste.jsf?pro=&lgrec=en&nat=&oqp=&dates=&lg=&language=en&jur=C,T,F&cit=none,C,CJ,R,2008E,,,,,,,,,,true,false,false&num={{{s}}}&td=ALL&pcs=O&avg=&page=1&mat=or&jge=&for=&cid=114819",
@@ -16912,7 +16912,7 @@
     "sc": "Law"
   },
   {
-    "s": "InfoCuria",
+    "s": "Curia",
     "d": "curia.europa.eu",
     "t": "curia",
     "u": "https://curia.europa.eu/juris/liste.jsf?&num={{{s}}}",
@@ -16920,7 +16920,7 @@
     "sc": "Law"
   },
   {
-    "s": "Curia (Name of the parties)",
+    "s": "Curia (Parties)",
     "d": "curia.europa.eu",
     "t": "curian",
     "u": "https://curia.europa.eu/juris/liste.jsf?pro=&nat=&oqp=&dates=&lg=&language=en&jur=C,T,F&cit=none,C,CJ,R,2008E,,,,,,,,,,true,false,false&td=ALL&pcs=O&avg=&page=1&mat=or&parties={{{s}}}&jge=&for=&cid=114819",
@@ -16936,7 +16936,7 @@
     "sc": "Learning"
   },
   {
-    "s": "WoW Curseforge",
+    "s": "CurseForge (WoW Addons)",
     "d": "www.curseforge.com",
     "t": "curse",
     "u": "https://www.curseforge.com/wow/addons/search?search={{{s}}}",
@@ -16944,7 +16944,7 @@
     "sc": "Downloads (add-ons)"
   },
   {
-    "s": "CurseForge (Kagi Search)",
+    "s": "CurseForge (Kagi)",
     "d": "kagi.com",
     "ad": "curseforge.com",
     "t": "curseforge",
@@ -17158,7 +17158,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Google Translate - Welsh to English",
+    "s": "Google Translate (cy-en)",
     "d": "translate.google.com",
     "t": "cyen",
     "u": "https://translate.google.com/#cy/en/{{{s}}}",
@@ -17166,7 +17166,7 @@
     "sc": "Google"
   },
   {
-    "s": "Cygwin Package Search",
+    "s": "Cygwin (x86_64)",
     "d": "cygwin.com",
     "t": "cyg64",
     "u": "https://cygwin.com/cgi-bin2/package-grep.cgi?grep={{{s}}}&arch=x86_64",
@@ -17190,7 +17190,7 @@
     "sc": "Online"
   },
   {
-    "s": "XE (czk2eur)",
+    "s": "XE (CZK-EUR)",
     "d": "www.xe.com",
     "t": "czk2eur",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=CZK&To=EUR",
@@ -17321,7 +17321,7 @@
     "sc": "Images"
   },
   {
-    "s": "Google Translate da-en",
+    "s": "Google Translate (da-en)",
     "d": "translate.google.com",
     "t": "daen",
     "u": "https://translate.google.com/#da/en/{{{s}}}",
@@ -17426,7 +17426,7 @@
     "sc": "Search"
   },
   {
-    "s": "Abrete Libro Forum (Kagi Search)",
+    "s": "Abrete Libro Forum (Kagi)",
     "d": "kagi.com",
     "ad": "abretelibro.com",
     "t": "dal",
@@ -17473,7 +17473,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Danbooru",
+    "s": "Danbooru (Safe)",
     "d": "danbooru.donmai.us",
     "t": "danbooru",
     "ts": [
@@ -17508,7 +17508,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Dragon Age NexusMods",
+    "s": "Nexus Mods (Dragon Age)",
     "d": "www.nexusmods.com",
     "t": "danm",
     "u": "https://www.nexusmods.com/dragonage/search/?gsearch={{{s}}}&gsearchtype=mods",
@@ -17567,7 +17567,7 @@
     "sc": "Blogs (intl)"
   },
   {
-    "s": "DuckDuckGo Dark Theme",
+    "s": "DuckDuckGo (Dark Theme)",
     "d": "duckduckgo.com",
     "t": "dark",
     "u": "https://duckduckgo.com/?q={{{s}}}&kae=d",
@@ -17631,7 +17631,7 @@
     "sc": "Online"
   },
   {
-    "s": "dic.academic.ru",
+    "s": "Academic (auto-ru)",
     "d": "dic.academic.ru",
     "t": "daru",
     "u": "https://dic.academic.ru/searchall.php?SWord={{{s}}}&from=xx&to=ru&did=&stype=0",
@@ -17663,7 +17663,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "datacite.org",
+    "s": "DataCite",
     "d": "search.datacite.org",
     "t": "datacite",
     "u": "https://search.datacite.org/works?query={{{s}}}",
@@ -17671,7 +17671,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Google Dataset Search",
+    "s": "Google (Dataset)",
     "d": "toolbox.google.com",
     "t": "data",
     "ts": [
@@ -17746,7 +17746,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Daum 어학사전",
+    "s": "Daum Dictionary",
     "d": "dic.daum.net",
     "t": "daumdic",
     "ts": [
@@ -17845,7 +17845,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "IBM DB2 for z/OS doc search",
+    "s": "IBM DB2 (z/OS)",
     "d": "www.ibm.com",
     "t": "db2z",
     "u": "https://www.ibm.com/support/knowledgecenter/search/{{{s}}}?scope=SSEPEK_11.0.0",
@@ -17853,7 +17853,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Den Blå Avis",
+    "s": "DBA",
     "d": "www.dba.dk",
     "t": "dba",
     "u": "https://www.dba.dk/soeg/?soeg={{{s}}}",
@@ -17904,7 +17904,7 @@
     "sc": "Academic"
   },
   {
-    "s": "BGB - dejure.org",
+    "s": "Dejure (BGB)",
     "d": "dejure.org",
     "t": "dbgb",
     "u": "https://dejure.org/gesetze/BGB/{{{s}}}.html",
@@ -17912,7 +17912,7 @@
     "sc": "Law"
   },
   {
-    "s": "Dotabuff Hero Guides",
+    "s": "Dotabuff (Hero Guides)",
     "d": "www.dotabuff.com",
     "t": "dbguide",
     "u": "https://www.dotabuff.com/heroes/{{{s}}}/guides",
@@ -17936,7 +17936,7 @@
     "sc": "Tools"
   },
   {
-    "s": "DBLP",
+    "s": "DBLP (Publications)",
     "d": "dblp.uni-trier.de",
     "t": "dblp.pub",
     "u": "https://dblp.uni-trier.de/search/publ?q={{{s}}}",
@@ -18011,7 +18011,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Danbooru Artists",
+    "s": "Danbooru (Artists)",
     "d": "danbooru.donmai.us",
     "t": "dbrartist",
     "u": "https://danbooru.donmai.us/artists?commit=Search&search[any_name_matches]={{{s}}}&search[order]=created_at&utf8=%E2%9C%93",
@@ -18019,7 +18019,7 @@
     "sc": "Images"
   },
   {
-    "s": "read.douban",
+    "s": "Douban (Read)",
     "d": "read.douban.com",
     "t": "dbread",
     "u": "https://read.douban.com/search?q={{{s}}}",
@@ -18035,7 +18035,7 @@
     "sc": "Health"
   },
   {
-    "s": "diebuchsuche.de",
+    "s": "DieBuchSuche",
     "d": "diebuchsuche.de",
     "t": "dbuch",
     "u": "https://diebuchsuche.de/r.php?q={{{s}}}",
@@ -18099,7 +18099,7 @@
     "sc": "Comics"
   },
   {
-    "s": "DuckDuckGo Community",
+    "s": "DuckDuckGo (Community)",
     "d": "duck.co",
     "t": "dc",
     "ts": [
@@ -18110,7 +18110,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "dcinside",
+    "s": "DCInside",
     "d": "search.dcinside.com",
     "t": "dcinside",
     "u": "https://search.dcinside.com/combine/q/{{{s}}}",
@@ -18118,7 +18118,7 @@
     "sc": "Forum"
   },
   {
-    "s": "Dict.cn Chinese<>English Dictionary",
+    "s": "Dict.cn (zh-en)",
     "d": "dict.cn",
     "t": "dcn",
     "ts": [
@@ -18165,7 +18165,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Rutgers University – Digital Classroom Services",
+    "s": "Rutgers University (Digital Classroom Services)",
     "d": "dcs.rutgers.edu",
     "t": "dcs",
     "u": "https://dcs.rutgers.edu/search/node/{{{s}}}",
@@ -18181,7 +18181,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Dublin City University Library Catalogue",
+    "s": "DCU Library",
     "d": "capitadiscovery.co.uk",
     "t": "dcul",
     "u": "https://capitadiscovery.co.uk/dcu/items?query={{{s}}}",
@@ -18237,7 +18237,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Duckduckgo Germany",
+    "s": "DuckDuckGo (Germany)",
     "d": "duckduckgo.com",
     "t": "dde",
     "ts": [
@@ -18256,7 +18256,7 @@
     "sc": "Sysadmin (debian)"
   },
   {
-    "s": "DansDeals Forum (Kagi Search)",
+    "s": "DansDeals Forum (Kagi)",
     "d": "kagi.com",
     "ad": "forums.dansdeals.com",
     "t": "ddf",
@@ -18265,7 +18265,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "DuckDuckGo América Latina con Pale Moon",
+    "s": "DuckDuckGo (América Latina, Pale Moon)",
     "d": "duckduckgo.com",
     "t": "ddgal",
     "u": "https://duckduckgo.com/?t=palemoon&kl=xl-es&ko=1&k1=1&q={{{s}}}",
@@ -18273,7 +18273,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "DuckDuckGo Argentina con Pale Moon",
+    "s": "DuckDuckGo (Argentina, Pale Moon)",
     "d": "duckduckgo.com",
     "t": "ddgar",
     "u": "https://duckduckgo.com/?t=palemoon&kl=ar-es&ko=1&k1=1&q={{{s}}}",
@@ -18281,7 +18281,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "DuckDuckGo Brazilian Portuguese Search",
+    "s": "DuckDuckGo (Brazil)",
     "d": "duckduckgo.com",
     "t": "ddgbr",
     "u": "https://duckduckgo.com/?q={{{s}}}&kp=-1&kl=br-pt",
@@ -18289,7 +18289,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "DuckDuckGo dictionary definitions",
+    "s": "DuckDuckGo (Dictionary)",
     "d": "duckduckgo.com",
     "t": "ddgd",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=definition",
@@ -18297,7 +18297,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "DuckDuckGo Estonia",
+    "s": "DuckDuckGo (Estonia)",
     "d": "duckduckgo.com",
     "t": "ddgee",
     "u": "https://duckduckgo.com/?kl=ee-et&q={{{s}}}",
@@ -18305,7 +18305,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "DuckDuckGo Estados Unidos",
+    "s": "DuckDuckGo (US, Spanish)",
     "d": "duckduckgo.com",
     "t": "ddgeue",
     "u": "https://duckduckgo.com/?kl=ue-es&q={{{s}}}",
@@ -18313,7 +18313,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "DuckDuckgo France",
+    "s": "DuckDuckGo (France)",
     "d": "duckduckgo.com",
     "t": "ddgf",
     "u": "https://duckduckgo.com/?kl=fr-fr&q={{{s}}}",
@@ -18321,7 +18321,7 @@
     "sc": "Reference"
   },
   {
-    "s": "DuckDuckGo Hungary",
+    "s": "DuckDuckGo (Hungary)",
     "d": "duckduckgo.com",
     "t": "ddghu",
     "u": "https://duckduckgo.com/?kl=hu-hu&q={{{s}}}",
@@ -18350,7 +18350,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "DuckDuckGo in Japan",
+    "s": "DuckDuckGo (Japan)",
     "d": "duckduckgo.com",
     "t": "ddgja",
     "u": "https://duckduckgo.com/?q={{{s}}}&kl=jp-jp&kp=-1",
@@ -18358,7 +18358,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "DuckDuckGo Maps",
+    "s": "DuckDuckGo (Maps)",
     "d": "duckduckgo.com",
     "t": "ddgm",
     "u": "https://duckduckgo.com/?q={{{s}}}&iaxm=maps",
@@ -18366,7 +18366,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "DuckDuckGo news",
+    "s": "DuckDuckGo (News)",
     "d": "duckduckgo.com",
     "t": "ddgn",
     "ts": [
@@ -18390,7 +18390,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "DuckDuckGo Norway",
+    "s": "DuckDuckGo (Norway)",
     "d": "duckduckgo.com",
     "t": "ddgno",
     "u": "https://duckduckgo.com/?kl=no-no&q={{{s}}}",
@@ -18398,7 +18398,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "DuckDuckGo Past Day",
+    "s": "DuckDuckGo (Past Day)",
     "d": "duckduckgo.com",
     "t": "ddgpd",
     "u": "https://duckduckgo.com/?df=d&q={{{s}}}",
@@ -18406,7 +18406,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "Reddit (Kagi Search)",
+    "s": "Reddit (Kagi)",
     "d": "kagi.com",
     "ad": "reddit.com",
     "t": "ddgr",
@@ -18434,7 +18434,7 @@
     "sc": "Music"
   },
   {
-    "s": "DansDeals (Kagi Search)",
+    "s": "DansDeals (Kagi)",
     "d": "kagi.com",
     "ad": "dansdeals.com",
     "t": "ddms",
@@ -18471,7 +18471,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Stack Overflow (Kagi Search)",
+    "s": "Stack Overflow (Kagi)",
     "d": "kagi.com",
     "ad": "stackoverflow.com",
     "t": "ddso",
@@ -18499,7 +18499,7 @@
     "sc": "Downloads (software)"
   },
   {
-    "s": "Google Translate (de2fr)",
+    "s": "Google Translate (de-fr)",
     "d": "translate.google.com",
     "t": "de2fr",
     "u": "https://translate.google.com/#de/fr/{{{s}}}",
@@ -18571,7 +18571,7 @@
     "sc": "Online"
   },
   {
-    "s": "r/deals",
+    "s": "Reddit (/r/deals)",
     "d": "www.reddit.com",
     "t": "deals",
     "u": "https://www.reddit.com/r/deals/search/?q={{{s}}}&restrict_sr=1",
@@ -18611,7 +18611,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Debian Package Contents",
+    "s": "Debian Packages (Contents)",
     "d": "packages.debian.org",
     "t": "debfiles",
     "ts": [
@@ -18622,7 +18622,7 @@
     "sc": "Sysadmin (debian)"
   },
   {
-    "s": "Google Translate de-bg",
+    "s": "Google Translate (de-bg)",
     "d": "translate.google.com",
     "t": "debg",
     "u": "https://translate.google.com/#view=home&op=translate&sl=de&tl=bg&text={{{s}}}",
@@ -18646,7 +18646,7 @@
     "sc": "Sysadmin (debian)"
   },
   {
-    "s": "Debian Pages (French)",
+    "s": "Debian (French)",
     "d": "www.google.com",
     "t": "debianfr",
     "u": "https://www.google.com/cse?cx=007724375775369850404:jwpah_hbbjk&ie=UTF-8&q={{{s}}}&siteurl=www.google.com/cse/home?cx=007724375775369850404:jwpah_hbbjk",
@@ -18654,7 +18654,7 @@
     "sc": "Google"
   },
   {
-    "s": "Forum Debianizzati.org",
+    "s": "Debianizzati (Forum)",
     "d": "forum.debianizzati.org",
     "t": "debianizzati",
     "u": "https://forum.debianizzati.org/search.php?keywords={{{s}}}",
@@ -18697,7 +18697,7 @@
     "sc": "Sysadmin (debian)"
   },
   {
-    "s": "snapshot.debian.org (binary)",
+    "s": "Debian Snapshot (Binary)",
     "d": "snapshot.debian.org",
     "t": "debsnap",
     "ts": [
@@ -18788,7 +18788,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "UrlDecode.org",
+    "s": "UrlDecode",
     "d": "urldecode.org",
     "t": "decode",
     "u": "https://urldecode.org/?text={{{s}}}&mode=decode",
@@ -18804,7 +18804,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Dedalus - Catálogo Geral",
+    "s": "Dedalus (Catálogo Geral)",
     "d": "dedalus.usp.br",
     "t": "ded",
     "u": "https://dedalus.usp.br/F/2GT4AME1FV9M25Q886NF9PCLB2BK39NF8XMFRXNHCQIL1JX5IG-19193?func=find-b&request={{{s}}}&find_code=WRD&adjacent=N&local_base=USP01&x=39&y=11&filter_code_1=WLN&filter_request_1=&filter_code_2=WYR&filter_request_2=&filter_code_3=WYR&filter_request_3=&filter_code_4=WMA&filter_request_4=&filter_code_5=WBA&filter_request_5=",
@@ -18812,7 +18812,7 @@
     "sc": "Academic"
   },
   {
-    "s": "dict.cc: Esperanto-Deutsch",
+    "s": "dict.cc (de-eo)",
     "d": "deeo.dict.cc",
     "t": "deeo",
     "u": "https://deeo.dict.cc/?s={{{s}}}",
@@ -18828,7 +18828,7 @@
     "sc": "Academic"
   },
   {
-    "s": "DeepL Translator",
+    "s": "DeepL (auto-en)",
     "d": "www.deepl.com",
     "t": "deepl",
     "ts": [
@@ -18843,7 +18843,7 @@
     ]
   },
   {
-    "s": "DeepL ES-EN",
+    "s": "DeepL (es-en)",
     "d": "www.deepl.com",
     "t": "deepleen",
     "ts": [
@@ -18858,7 +18858,7 @@
     ]
   },
   {
-    "s": "DeepL (enfr)",
+    "s": "DeepL (en-fr)",
     "d": "www.deepl.com",
     "t": "deeplef",
     "u": "https://www.deepl.com/translator#en/fr/{{{s}}}",
@@ -18870,7 +18870,7 @@
     ]
   },
   {
-    "s": "DeepL (ende)",
+    "s": "DeepL (en-de)",
     "d": "www.deepl.com",
     "t": "deepleg",
     "u": "https://www.deepl.com/translator#en/de/{{{s}}}",
@@ -18882,7 +18882,7 @@
     ]
   },
   {
-    "s": "Deepl en-es",
+    "s": "DeepL (en-es)",
     "d": "www.deepl.com",
     "t": "deeplenes",
     "ts": [
@@ -18898,7 +18898,7 @@
     ]
   },
   {
-    "s": "DeepL en-pt",
+    "s": "DeepL (de-pt)",
     "d": "www.deepl.com",
     "t": "deeplenpt",
     "u": "https://www.deepl.com/translator#de/pt/{{{s}}}",
@@ -18910,7 +18910,7 @@
     ]
   },
   {
-    "s": "deepl.com",
+    "s": "DeepL (fr-en)",
     "d": "www.deepl.com",
     "t": "deeplfr",
     "u": "https://www.deepl.com/translator#fr/en/{{{s}}}",
@@ -18922,7 +18922,7 @@
     ]
   },
   {
-    "s": "DeepL (deen)",
+    "s": "DeepL (de-en)",
     "d": "www.deepl.com",
     "t": "deeplge",
     "u": "https://www.deepl.com/translator#de/en/{{{s}}}",
@@ -19009,7 +19009,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "defkey",
+    "s": "Defkey",
     "d": "defkey.com",
     "t": "defkey",
     "u": "https://defkey.com/search?irq={{{s}}}",
@@ -19017,7 +19017,7 @@
     "sc": "Programming"
   },
   {
-    "s": "dict.cc Deutsch-Französisch",
+    "s": "dict.cc (de-fr)",
     "d": "defr.dict.cc",
     "t": "defr",
     "u": "https://defr.dict.cc/?s={{{s}}}",
@@ -19025,7 +19025,7 @@
     "sc": "Tools"
   },
   {
-    "s": "dict.cc DE <> HR",
+    "s": "dict.cc (de-hr)",
     "d": "dehr.dict.cc",
     "t": "dehr",
     "u": "https://dehr.dict.cc/?s={{{s}}}",
@@ -19033,7 +19033,7 @@
     "sc": "General"
   },
   {
-    "s": "Google Translate de-hu",
+    "s": "Google Translate (de-hu)",
     "d": "translate.google.com",
     "t": "dehu",
     "u": "https://translate.google.com/#de/hu/{{{s}}}",
@@ -19119,7 +19119,7 @@
     "sc": "Games (offline)"
   },
   {
-    "s": "Delaware Library Search",
+    "s": "Delaware Library",
     "d": "dlc.lib.de.us",
     "t": "delib",
     "u": "https://dlc.lib.de.us/client/default/search/results?qu={{{s}}}&te=",
@@ -19149,7 +19149,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Dell Support Search",
+    "s": "Dell (Support)",
     "d": "www.dell.com",
     "t": "dellsp",
     "u": "https://www.dell.com/support/search/us/en/19#q={{{s}}}&sort=relevancy",
@@ -19157,7 +19157,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Dell Support Service Tag",
+    "s": "Dell (Service Tag)",
     "d": "www.dell.com",
     "t": "dellst",
     "u": "https://www.dell.com/support/home/us/en/19/product-support/servicetag/{{{s}}}",
@@ -19165,7 +19165,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Dell UK",
+    "s": "Dell (UK)",
     "d": "www.dell.com",
     "t": "delluk",
     "u": "https://www.dell.com/en-uk/search/{{{s}}}",
@@ -19216,7 +19216,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Dict.cc Deutsch-Niederländisch",
+    "s": "Dict.cc (de-nl)",
     "d": "denl.dict.cc",
     "t": "denl",
     "u": "https://denl.dict.cc/?s={{{s}}}",
@@ -19224,7 +19224,7 @@
     "sc": "Tools"
   },
   {
-    "s": "dict.cc (deno)",
+    "s": "dict.cc (de-no)",
     "d": "deno.dict.cc",
     "t": "deno",
     "u": "https://deno.dict.cc/?s={{{s}}}",
@@ -19232,7 +19232,7 @@
     "sc": "Search"
   },
   {
-    "s": "Deepl English to Russian",
+    "s": "DeepL (en-ru)",
     "d": "www.deepl.com",
     "t": "denru",
     "u": "https://www.deepl.com/translator#en/ru/{{{s}}}",
@@ -19252,7 +19252,7 @@
     "sc": "Forum"
   },
   {
-    "s": "google translate de-pl",
+    "s": "Google Translate (de-pl)",
     "d": "translate.google.com",
     "t": "depl",
     "u": "https://translate.google.com/#de/pl/{{{s}}}",
@@ -19268,7 +19268,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "deredactie.be",
+    "s": "De Redactie",
     "d": "deredactie.be",
     "t": "deredactie",
     "u": "https://deredactie.be/cm/vrtnieuws/1.516538?text={{{s}}}&action=submit",
@@ -19289,7 +19289,7 @@
     "sc": "Images"
   },
   {
-    "s": "derStandard.at",
+    "s": "DerStandard",
     "d": "www.derstandard.at",
     "t": "derstandard",
     "u": "https://www.derstandard.at/search?query={{{s}}}",
@@ -19297,7 +19297,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Google Translate (deru)",
+    "s": "Google Translate (de-ru)",
     "d": "translate.google.com",
     "t": "deru",
     "u": "https://translate.google.com/#view=home&op=translate&sl=de&tl=ru&text={{{s}}}",
@@ -19348,7 +19348,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "dict.cc (desv)",
+    "s": "dict.cc (de-sv)",
     "d": "desv.dict.cc",
     "t": "desv",
     "u": "https://desv.dict.cc/?s={{{s}}}",
@@ -19424,7 +19424,7 @@
     "sc": "Blogs (intl)"
   },
   {
-    "s": "dev.splunk.com",
+    "s": "Splunk (Dev)",
     "d": "dev.splunk.com",
     "t": "dev.splunk",
     "u": "https://dev.splunk.com/search/dev?q={{{s}}}",
@@ -19525,7 +19525,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Debian file search",
+    "s": "Debian Packages (Files)",
     "d": "packages.debian.org",
     "t": "dfiles",
     "u": "https://packages.debian.org/search?section=all&arch=any&searchon=contents&keywords={{{s}}}",
@@ -19541,7 +19541,7 @@
     "sc": "Programming"
   },
   {
-    "s": "dict.cc Dictionary French-English",
+    "s": "dict.cc (en-fr)",
     "d": "enfr.dict.cc",
     "t": "dfren",
     "u": "https://enfr.dict.cc/?s={{{s}}}",
@@ -19569,7 +19569,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "GG - dejure.org",
+    "s": "Dejure (GG)",
     "d": "dejure.org",
     "t": "dgg",
     "u": "https://dejure.org/gesetze/GG/{{{s}}}.html",
@@ -19588,7 +19588,7 @@
     "sc": "Tech"
   },
   {
-    "s": "OpenGL Docs (Kagi Search)",
+    "s": "OpenGL Docs (Kagi)",
     "d": "kagi.com",
     "ad": "docs.gl/gl4",
     "t": "dgl4",
@@ -19706,7 +19706,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Instant Answers",
+    "s": "DuckDuckGo (Instant Answers)",
     "d": "duck.co",
     "t": "dia",
     "u": "https://duck.co/ia?q={{{s}}}",
@@ -19815,7 +19815,7 @@
     "sc": "General"
   },
   {
-    "s": "Michaelis Online",
+    "s": "Michaelis (pt-BR)",
     "d": "michaelis.uol.com.br",
     "t": "dic-ptbr",
     "ts": [
@@ -19826,7 +19826,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Dicionário Infopédia da Língua Portuguesa",
+    "s": "Infopédia (Portuguese)",
     "d": "www.infopedia.pt",
     "t": "dicpt",
     "ts": [
@@ -19877,7 +19877,7 @@
     "sc": "Search"
   },
   {
-    "s": "Dict-Na'vi (English)",
+    "s": "Dict-Na'vi (en)",
     "d": "dict-navi.com",
     "t": "dictn",
     "u": "https://dict-navi.com/en/dictionary/list/?type=search&search_term={{{s}}}",
@@ -19885,7 +19885,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Dict.pl",
+    "s": "Dict",
     "d": "dict.pl",
     "t": "dictpl",
     "u": "https://dict.pl/dict?word={{{s}}}",
@@ -19893,7 +19893,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "dict.org",
+    "s": "Dict (Regex)",
     "d": "www.dict.org",
     "t": "dictre",
     "u": "https://www.dict.org/bin/Dict?Form=Dict1&Database=*&Strategy=re&Query=^{{{s}}}$",
@@ -19944,7 +19944,7 @@
     "sc": "Online"
   },
   {
-    "s": "Kagi Search (difference between)",
+    "s": "Kagi (Difference Between)",
     "d": "kagi.com",
     "ad": "",
     "t": "diff",
@@ -19961,7 +19961,7 @@
     "sc": "Audio"
   },
   {
-    "s": "dig Lookup",
+    "s": "Ring of Saturn (Dig)",
     "d": "networking.ringofsaturn.com",
     "t": "dig",
     "ts": [
@@ -19988,7 +19988,7 @@
     "sc": "Online"
   },
   {
-    "s": "digiato",
+    "s": "Digiato",
     "d": "digiato.com",
     "t": "digiato",
     "u": "https://digiato.com/?q={{{s}}}:",
@@ -20095,7 +20095,7 @@
     "sc": "Learning"
   },
   {
-    "s": "diki.pl/slownik-niemieckiego",
+    "s": "Diki (pl-de)",
     "d": "www.diki.pl",
     "t": "dikide",
     "u": "https://www.diki.pl/slownik-niemieckiego?q={{{s}}}",
@@ -20103,7 +20103,7 @@
     "sc": "General"
   },
   {
-    "s": "diki.pl",
+    "s": "Diki",
     "d": "www.diki.pl",
     "t": "diki",
     "u": "https://www.diki.pl/slownik-angielskiego/?q={{{s}}}",
@@ -20181,7 +20181,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Google.de Maps",
+    "s": "Google Maps (DE, Directions)",
     "d": "www.google.de",
     "t": "dir",
     "ts": [
@@ -20244,7 +20244,7 @@
     "sc": "Music"
   },
   {
-    "s": "Disconnect Search",
+    "s": "Disconnect",
     "d": "search.disconnect.me",
     "t": "disconnect",
     "u": "https://search.disconnect.me/searchTerms/search?query={{{s}}}&ses=Google",
@@ -20252,7 +20252,7 @@
     "sc": "Search (Private)"
   },
   {
-    "s": "Disconnect Image Search",
+    "s": "Disconnect (Images)",
     "d": "search.disconnect.me",
     "t": "disconnectimg",
     "u": "https://search.disconnect.me/searchTerms/search?query={{{s}}}&option=Images",
@@ -20284,7 +20284,7 @@
     "sc": "Startups"
   },
   {
-    "s": "Discovery.com",
+    "s": "Discovery",
     "d": "dsc.discovery.com",
     "t": "discovery",
     "u": "https://dsc.discovery.com/search.htm?terms={{{s}}}",
@@ -20304,7 +20304,7 @@
     "sc": "Programming"
   },
   {
-    "s": "discworld",
+    "s": "Discworld",
     "d": "discworld.wikia.com",
     "t": "discworld",
     "u": "https://discworld.wikia.com/wiki/Special:Search?query={{{s}}}",
@@ -20312,7 +20312,7 @@
     "sc": "Forum"
   },
   {
-    "s": "Disney.com",
+    "s": "Disney",
     "d": "search.disney.go.com",
     "t": "disney",
     "u": "https://search.disney.go.com/?q={{{s}}}",
@@ -20367,7 +20367,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "DiVA - Digitala Vetenskapliga Arkivet",
+    "s": "DiVA",
     "d": "www.diva-portal.org",
     "t": "diva",
     "u": "https://www.diva-portal.org/smash/resultList.jsf?dswid=8805&language=en&searchType=SIMPLE&query={{{s}}}&af=[]&aq=[[]]&aq2=[[]]&aqe=[]&noOfRows=50&sortOrder=author_sort_asc&sortOrder2=title_sort_asc&onlyFullText=false&sf=all",
@@ -20375,7 +20375,7 @@
     "sc": "Academic"
   },
   {
-    "s": "divaliu",
+    "s": "DiVA (LIU)",
     "d": "liu.diva-portal.org",
     "t": "divaliu",
     "u": "https://liu.diva-portal.org/smash/resultList.jsf?searchType=SIMPLE&query={{{s}}}",
@@ -20383,7 +20383,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Divazus ®",
+    "s": "Divazus",
     "d": "divazus.com",
     "t": "divazus",
     "u": "https://divazus.com/?s={{{s}}}",
@@ -20440,7 +20440,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Django Docs",
+    "s": "Django (Docs)",
     "d": "docs.djangoproject.com",
     "t": "django",
     "ts": [
@@ -20451,7 +20451,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Django Documentation",
+    "s": "Django (2.2)",
     "d": "docs.djangoproject.com",
     "t": "djlts",
     "ts": [
@@ -20590,7 +20590,7 @@
     "sc": "Tools"
   },
   {
-    "s": "D Language (Kagi Search)",
+    "s": "D Language (Kagi)",
     "d": "kagi.com",
     "ad": "dlang.org",
     "t": "dlang",
@@ -20626,7 +20626,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Diccionario de la lengua española, 23.ª Edición, RAE",
+    "s": "DLE (RAE)",
     "d": "dle.rae.es",
     "t": "dle",
     "ts": [
@@ -20637,7 +20637,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "DeepL",
+    "s": "DeepL (auto-es)",
     "d": "www.deepl.com",
     "t": "dles",
     "u": "https://www.deepl.com/translator#au/es/{{{s}}}",
@@ -20665,7 +20665,7 @@
     "sc": "General"
   },
   {
-    "s": "dlive",
+    "s": "DLive",
     "d": "dlive.tv",
     "t": "dlive",
     "u": "https://dlive.tv/s/search/{{{s}}}",
@@ -20689,7 +20689,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "dict.leo.org (german-english)",
+    "s": "LEO (de-en)",
     "d": "dict.leo.org",
     "t": "dlo",
     "u": "https://dict.leo.org/german-english/{{{s}}}",
@@ -20697,7 +20697,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Priberam - Conjugar",
+    "s": "Priberam (Conjugar)",
     "d": "www.priberam.pt",
     "t": "dlpoc",
     "u": "https://www.priberam.pt/dlpo/Conjugar/{{{s}}}",
@@ -20724,7 +20724,7 @@
     "sc": "Academic"
   },
   {
-    "s": "dmaciasblog",
+    "s": "Dmaciasblog",
     "d": "dmaciasblog.com",
     "t": "dmaciasblog",
     "u": "https://dmaciasblog.com/?s={{{s}}}",
@@ -20740,7 +20740,7 @@
     "sc": "Maps"
   },
   {
-    "s": "MXToolbox DMARC",
+    "s": "MXToolbox (DMARC)",
     "d": "mxtoolbox.com",
     "t": "dmarc",
     "u": "https://mxtoolbox.com/SuperTool.aspx?action=dmarc:{{{s}}}&run=networktools",
@@ -20756,7 +20756,7 @@
     "sc": "Online"
   },
   {
-    "s": "DMM英会話なんてuKnow?",
+    "s": "DMM Eikaiwa (uKnow)",
     "d": "eikaiwa.dmm.com",
     "t": "dme",
     "u": "https://eikaiwa.dmm.com/uknow/search/?keyword={{{s}}}",
@@ -20783,7 +20783,7 @@
     "sc": "Weather"
   },
   {
-    "s": "Deb Multimedia (Kagi Search)",
+    "s": "Deb Multimedia (Kagi)",
     "d": "kagi.com",
     "ad": "deb-multimedia.org/pool/",
     "t": "dmo",
@@ -20792,7 +20792,7 @@
     "sc": "Sysadmin (debian)"
   },
   {
-    "s": ".NET API Browser",
+    "s": "Microsoft (.NET API)",
     "d": "learn.microsoft.com",
     "t": "dnab",
     "ts": [
@@ -20820,7 +20820,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Dict-Na'vi.com",
+    "s": "Dict-Na'vi (de)",
     "d": "dict-navi.com",
     "t": "dnde",
     "u": "https://dict-navi.com/de/dictionary/list/?type=search&search_term={{{s}}}",
@@ -20860,7 +20860,7 @@
     "sc": "Academic"
   },
   {
-    "s": "MXToolbox (dns)",
+    "s": "MXToolbox (DNS)",
     "d": "mxtoolbox.com",
     "t": "dns",
     "u": "https://mxtoolbox.com/SuperTool.aspx?action=a:{{{s}}}&run=toolpage",
@@ -20884,7 +20884,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Diccionari Normatiu Valencià",
+    "s": "AVL (Diccionari Normatiu Valencià)",
     "d": "www.avl.gva.es",
     "t": "dnv",
     "u": "https://www.avl.gva.es/lexicval/dnv?paraula={{{s}}}",
@@ -20967,7 +20967,7 @@
     "sc": "Forum"
   },
   {
-    "s": "Docs.rs",
+    "s": "Docs.rs (Releases)",
     "d": "docs.rs",
     "t": "docsrs",
     "ts": [
@@ -20978,7 +20978,7 @@
     "sc": "Languages (other)"
   },
   {
-    "s": "Scribd.com",
+    "s": "Scribd",
     "d": "www.scribd.com",
     "t": "docs",
     "ts": [
@@ -21005,7 +21005,7 @@
     "sc": "Law"
   },
   {
-    "s": "Ubuntu FR Docs (Kagi Search)",
+    "s": "Ubuntu FR Docs (Kagi)",
     "d": "kagi.com",
     "ad": "doc.ubuntu-fr.org",
     "t": "docubufr",
@@ -21153,7 +21153,7 @@
     "sc": "Domains"
   },
   {
-    "s": "domainsbot.com",
+    "s": "DomainsBot",
     "d": "domainsbot.com",
     "t": "domainsbot",
     "u": "https://domainsbot.com/?q={{{s}}}",
@@ -21169,7 +21169,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "Mozilla Developer Network (API)",
+    "s": "MDN Web Docs (API)",
     "d": "developer.mozilla.org",
     "t": "dom",
     "u": "https://developer.mozilla.org/en-US/search?topic=api&q={{{s}}}",
@@ -21264,7 +21264,7 @@
     "sc": "Books"
   },
   {
-    "s": "Teamliquid Wiki",
+    "s": "Liquipedia (Dota 2)",
     "d": "wiki.teamliquid.net",
     "t": "dota2",
     "ts": [
@@ -21300,7 +21300,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Microsoft Docs",
+    "s": "Microsoft (Docs)",
     "d": "learn.microsoft.com",
     "t": "md",
     "ts": [
@@ -21322,7 +21322,7 @@
     "sc": "Reference"
   },
   {
-    "s": "niconico douga bypass",
+    "s": "Niconico (English Bypass)",
     "d": "en.niconico.sarashi.com",
     "t": "douga",
     "u": "https://en.niconico.sarashi.com/?{{{s}}}",
@@ -21386,7 +21386,7 @@
     "sc": "Movies"
   },
   {
-    "s": "PC Soft Docs (Kagi Search)",
+    "s": "PC Soft Docs (Kagi)",
     "d": "kagi.com",
     "ad": "doc.pcsoft.fr",
     "t": "dpcs",
@@ -21411,7 +21411,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "DPD Online Tracking",
+    "s": "DPD (Tracking)",
     "d": "tracking.dpd.de",
     "t": "dpdt",
     "u": "https://tracking.dpd.de/cgi-bin/delistrack?typ=1&pknr={{{s}}}",
@@ -21427,7 +21427,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Dogpile Images",
+    "s": "Dogpile (Images)",
     "d": "www.dogpile.com",
     "t": "dpi",
     "u": "https://www.dogpile.com/search/images?q={{{s}}}",
@@ -21483,7 +21483,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Dogpile News",
+    "s": "Dogpile (News)",
     "d": "www.dogpile.com",
     "t": "dpn",
     "u": "https://www.dogpile.com/search/news?q={{{s}}}",
@@ -21518,7 +21518,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Dogpile Video",
+    "s": "Dogpile (Video)",
     "d": "www.dogpile.com",
     "t": "dpv",
     "u": "https://www.dogpile.com/search/video?q={{{s}}}",
@@ -21526,7 +21526,7 @@
     "sc": "Search"
   },
   {
-    "s": "Dogpile Web",
+    "s": "Dogpile (Web)",
     "d": "www.dogpile.com",
     "t": "dpw",
     "u": "https://www.dogpile.com/search/web?q={{{s}}}",
@@ -21582,7 +21582,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Dicionario da Real Academia Galega",
+    "s": "Real Academia Galega (Dictionary)",
     "d": "academia.gal",
     "t": "drag",
     "u": "https://academia.gal/dicionario_rag/searchNoun.do?nounTitle={{{s}}}",
@@ -21614,7 +21614,7 @@
     "sc": "Health"
   },
   {
-    "s": "Dynamic Range Database (album)",
+    "s": "Dynamic Range DB (Album)",
     "d": "dr.loudness-war.info",
     "t": "drdba",
     "ts": [
@@ -21625,7 +21625,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Dynamic Range Database",
+    "s": "Dynamic Range DB",
     "d": "dr.loudness-war.info",
     "t": "drdb",
     "ts": [
@@ -21811,7 +21811,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Docs.rs - Documentation for Rust packages",
+    "s": "Docs.rs",
     "d": "docs.rs",
     "t": "drs",
     "ts": [
@@ -21886,7 +21886,7 @@
     "sc": "Downloads (add-ons)"
   },
   {
-    "s": "drupal",
+    "s": "Drupal (Projects)",
     "d": "drupal.org",
     "t": "drupp",
     "u": "https://drupal.org/project/{{{s}}}",
@@ -21980,7 +21980,7 @@
     "sc": "Newspaper (intl)"
   },
   {
-    "s": "Datenschutz-Wiki.de (DSGVO)",
+    "s": "Datenschutz-Wiki (DSGVO)",
     "d": "www.datenschutz-wiki.de",
     "t": "dsgvo",
     "u": "https://www.datenschutz-wiki.de/index.php?search={{{s}}}&ns3000=1",
@@ -22007,7 +22007,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Debian Code Search",
+    "s": "Debian (Code)",
     "d": "codesearch.debian.net",
     "t": "dsource",
     "u": "https://codesearch.debian.net/search?q={{{s}}}",
@@ -22023,7 +22023,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Dota 2 subreddit",
+    "s": "Reddit (/r/DotA2)",
     "d": "www.reddit.com",
     "t": "dsr",
     "u": "https://www.reddit.com/r/DotA2/search?q={{{s}}}&restrict_sr=on&sort=relevance&t=all",
@@ -22031,7 +22031,7 @@
     "sc": "Forum"
   },
   {
-    "s": "Disroot Search",
+    "s": "Disroot",
     "d": "search.disroot.org",
     "t": "dsrt",
     "u": "https://search.disroot.org/?q={{{s}}}",
@@ -22039,7 +22039,7 @@
     "sc": "Search"
   },
   {
-    "s": "snapshot.debian.org",
+    "s": "Debian Snapshot (Source)",
     "d": "snapshot.debian.org",
     "t": "dssrc",
     "u": "https://snapshot.debian.org/package/?src={{{s}}}",
@@ -22063,7 +22063,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "StGB - dejure.org",
+    "s": "Dejure (StGB)",
     "d": "dejure.org",
     "t": "dstgb",
     "u": "https://dejure.org/gesetze/StGB/{{{s}}}.html",
@@ -22087,7 +22087,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "Datenschutz-Wiki.de",
+    "s": "Datenschutz-Wiki",
     "d": "www.datenschutz-wiki.de",
     "t": "dswiki",
     "u": "https://www.datenschutz-wiki.de/index.php?search={{{s}}}",
@@ -22171,7 +22171,7 @@
     "sc": "Languages (d)"
   },
   {
-    "s": "dubizzle.com",
+    "s": "Dubizzle (Dubai)",
     "d": "dubai.dubizzle.com",
     "t": "dubizzle",
     "u": "https://dubai.dubizzle.com/search/?keywords={{{s}}}&is_basic_search_widget=1&is_search=1",
@@ -22198,7 +22198,7 @@
     "sc": "Social"
   },
   {
-    "s": "Duck Duck Go Español",
+    "s": "DuckDuckGo (Spain, Spanish UI)",
     "d": "duckduckgo.com",
     "t": "duckgoes",
     "u": "https://duckduckgo.com/?q={{{s}}}&kp=-1&k5=1&kah=wt-wt&kl=xl-es&kad=es_ES",
@@ -22238,7 +22238,7 @@
     "sc": "Companies"
   },
   {
-    "s": "DuckDuckGo UK",
+    "s": "DuckDuckGo (UK)",
     "d": "duckduckgo.com",
     "t": "duk",
     "ts": [
@@ -22372,7 +22372,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "dwarf fortress wiki",
+    "s": "Dwarf Fortress Wiki",
     "d": "dwarffortresswiki.org",
     "t": "dwarf",
     "u": "https://dwarffortresswiki.org/index.php?search={{{s}}}",
@@ -22380,7 +22380,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Deutsches Wörterbuch von Jacob Grimm und Wilhelm Grimm",
+    "s": "Wörterbuchnetz (DWB)",
     "d": "woerterbuchnetz.de",
     "t": "dwb",
     "u": "https://woerterbuchnetz.de/DWB/?lemma={{{s}}}",
@@ -22436,7 +22436,7 @@
     "sc": "Images"
   },
   {
-    "s": "Dark-World.ru",
+    "s": "Dark-World",
     "d": "dark-world.ru",
     "t": "dwru",
     "u": "https://dark-world.ru/search/?q={{{s}}}",
@@ -22463,7 +22463,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Mozilla DXR Code Search",
+    "s": "Mozilla DXR",
     "d": "dxr.mozilla.org",
     "t": "dxr",
     "ts": [
@@ -22506,7 +22506,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google Translate (English to Czech)",
+    "s": "Google Translate (en-cs)",
     "d": "translate.google.com",
     "t": "e2c",
     "u": "https://translate.google.com/#en/cs/{{{s}}}",
@@ -22546,7 +22546,7 @@
     "sc": "Images"
   },
   {
-    "s": "Effective Altruism (Kagi Search)",
+    "s": "Effective Altruism (Kagi)",
     "d": "kagi.com",
     "ad": "effective-altruism.com",
     "t": "eaf",
@@ -22563,7 +22563,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Earth911.com",
+    "s": "Earth911",
     "d": "search.earth911.com",
     "t": "earth911",
     "ts": [
@@ -22652,7 +22652,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Ebay Austria",
+    "s": "eBay (Austria)",
     "d": "www.ebay.at",
     "t": "e.at",
     "ts": [
@@ -22687,7 +22687,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Ebay Australia",
+    "s": "eBay (Australia)",
     "d": "www.ebay.com.au",
     "t": "e.au",
     "u": "https://www.ebay.com.au/sch/?_nkw={{{s}}}&_sacat=0",
@@ -22938,7 +22938,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "ebay (Canada)",
+    "s": "eBay (Canada)",
     "d": "www.ebay.ca",
     "t": "ebc",
     "u": "https://www.ebay.ca/sch/{{{s}}}",
@@ -22997,7 +22997,7 @@
     "sc": "Online"
   },
   {
-    "s": "ebooki.swiatczytnikow.pl",
+    "s": "Świat Czytników (Ebooki)",
     "d": "ebooki.swiatczytnikow.pl",
     "t": "ebooki",
     "u": "https://ebooki.swiatczytnikow.pl/szukaj/{{{s}}}",
@@ -23021,7 +23021,7 @@
     "sc": "Books"
   },
   {
-    "s": "eBay Seller",
+    "s": "eBay (Seller)",
     "d": "www.ebay.com",
     "t": "ebseller",
     "u": "https://www.ebay.com/sch/{{{s}}}/m.html",
@@ -23029,7 +23029,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "eBay Sold",
+    "s": "eBay (Sold)",
     "d": "ebay.com",
     "t": "ebsold",
     "u": "https://ebay.com/sch/i.html?isRefine=true&_nkw={{{s}}}&LH_Sold=1",
@@ -23061,7 +23061,7 @@
     "sc": "Sysadmin (Gentoo)"
   },
   {
-    "s": "ebuka okories blog",
+    "s": "Ebuka Okorie's Blog",
     "d": "ebukaokorie.blogspot.com",
     "t": "ebukaokoriesblog",
     "u": "https://ebukaokorie.blogspot.com/search?q={{{s}}}",
@@ -23077,7 +23077,7 @@
     "sc": "Tech"
   },
   {
-    "s": "eBay Records",
+    "s": "eBay (Records)",
     "d": "www.ebay.com",
     "t": "ebyrec",
     "u": "https://www.ebay.com/sch/176985/i.html?_nkw={{{s}}}",
@@ -23129,7 +23129,7 @@
     "sc": "Online"
   },
   {
-    "s": "Ecosia Image Search",
+    "s": "Ecosia (Images)",
     "d": "www.ecosia.org",
     "t": "ecim",
     "ts": [
@@ -23148,7 +23148,7 @@
     "sc": "Online"
   },
   {
-    "s": "Curia",
+    "s": "Curia (ECLI)",
     "d": "curia.europa.eu",
     "t": "ecli",
     "u": "https://curia.europa.eu/juris/liste.jsf?critereEcli={{{s}}}",
@@ -23204,7 +23204,7 @@
     "sc": "Government"
   },
   {
-    "s": "ecomes.org",
+    "s": "Ecomes",
     "d": "ecomes.org",
     "t": "ecomes",
     "u": "https://ecomes.org/?s={{{s}}}",
@@ -23284,7 +23284,7 @@
     "sc": "Broadcast"
   },
   {
-    "s": "exploit-db.com",
+    "s": "Exploit-DB (Text)",
     "d": "www.exploit-db.com",
     "t": "edbc",
     "u": "https://www.exploit-db.com/search/?action=search&text={{{s}}}",
@@ -23292,7 +23292,7 @@
     "sc": "Downloads (code)"
   },
   {
-    "s": "Exploits Database by Offensive Security (exploit-db.com)",
+    "s": "Exploit-DB (Description)",
     "d": "www.exploit-db.com",
     "t": "edb",
     "u": "https://www.exploit-db.com/search/?action=search&description={{{s}}}",
@@ -23324,7 +23324,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Ebay Germany",
+    "s": "eBay (Germany)",
     "d": "www.ebay.de",
     "t": "e.de",
     "u": "https://www.ebay.de/sch/i.html?_nkw={{{s}}}",
@@ -23356,7 +23356,7 @@
     "sc": "Government"
   },
   {
-    "s": "Edgar",
+    "s": "SEC EDGAR (Ticker)",
     "d": "www.sec.gov",
     "t": "edgart",
     "u": "https://www.sec.gov/cgi-bin/browse-edgar?company=&match=&CIK={{{s}}}&filenum=&State=&Country=&SIC=&owner=exclude&Find=Find+Companies&action=getcompany",
@@ -23404,7 +23404,7 @@
     "sc": "Local"
   },
   {
-    "s": "edmofy.com",
+    "s": "EDMofy",
     "d": "edmofy.com",
     "t": "edm",
     "u": "https://edmofy.com/?s={{{s}}}",
@@ -23428,7 +23428,7 @@
     "sc": "Newspaper (intl)"
   },
   {
-    "s": "Educalingo Français",
+    "s": "Educalingo (FR)",
     "d": "educalingo.com",
     "t": "educalingofr",
     "u": "https://educalingo.com/fr/dic-fr/{{{s}}}",
@@ -23436,7 +23436,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "edutalk.id",
+    "s": "EduTalk",
     "d": "edutalk.id",
     "t": "edutalk",
     "u": "https://edutalk.id/?s={{{s}}}",
@@ -23492,7 +23492,7 @@
     "sc": "Programming"
   },
   {
-    "s": "EllisLab Forums (Kagi Search)",
+    "s": "EllisLab Forums (Kagi)",
     "d": "kagi.com",
     "ad": "ellislab.com/forums/",
     "t": "elab",
@@ -23541,7 +23541,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Epguides (Kagi Search)",
+    "s": "Epguides (Kagi)",
     "d": "kagi.com",
     "ad": "epguides.com",
     "t": "eg",
@@ -23553,7 +23553,7 @@
     "sc": "TV"
   },
   {
-    "s": "Eurogamer Forums (Kagi Search)",
+    "s": "Eurogamer Forums (Kagi)",
     "d": "kagi.com",
     "ad": "eurogamer.net/forums",
     "t": "egforums",
@@ -23669,7 +23669,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Econ Job Rumors (Kagi Search)",
+    "s": "Econ Job Rumors (Kagi)",
     "d": "kagi.com",
     "ad": "econjobrumors.com",
     "t": "ejmr",
@@ -23710,7 +23710,7 @@
     "sc": "Academic"
   },
   {
-    "s": "ebay Kleinanzeigen Aachen",
+    "s": "eBay Kleinanzeigen (Aachen)",
     "d": "www.ebay-kleinanzeigen.de",
     "t": "ekac",
     "u": "https://www.ebay-kleinanzeigen.de/s-aachen/{{{s}}}/k0l1921",
@@ -23734,7 +23734,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "eBay Kleinanzeigen Hamburg",
+    "s": "eBay Kleinanzeigen (Hamburg)",
     "d": "www.ebay-kleinanzeigen.de",
     "t": "ekh",
     "u": "https://www.ebay-kleinanzeigen.de/s-hamburg/{{{s}}}/k0l9409",
@@ -23742,7 +23742,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Kleinanzeigen Hannover",
+    "s": "eBay Kleinanzeigen (Hannover)",
     "d": "www.ebay-kleinanzeigen.de",
     "t": "ekhr",
     "u": "https://www.ebay-kleinanzeigen.de/s-hannover/{{{s}}}/k0l3155",
@@ -23750,7 +23750,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "ebay Kleinanzeigen Köln",
+    "s": "eBay Kleinanzeigen (Köln)",
     "d": "www.ebay-kleinanzeigen.de",
     "t": "ekk",
     "u": "https://www.ebay-kleinanzeigen.de/s-koeln/{{{s}}}/k0l945",
@@ -23758,7 +23758,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "eBay Kleinanzeigen Leipzig",
+    "s": "eBay Kleinanzeigen (Leipzig)",
     "d": "www.ebay-kleinanzeigen.de",
     "t": "ekl",
     "u": "https://www.ebay-kleinanzeigen.de/s-leipzig/{{{s}}}/k0l4233",
@@ -23766,7 +23766,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "eBay Kleinanzeigen München",
+    "s": "eBay Kleinanzeigen (München)",
     "d": "www.ebay-kleinanzeigen.de",
     "t": "ekm",
     "u": "https://www.ebay-kleinanzeigen.de/s-muenchen/{{{s}}}/k0l6411",
@@ -23835,7 +23835,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Bibleserver (ELB)",
+    "s": "BibleServer (ELB)",
     "d": "www.bibleserver.com",
     "t": "elb",
     "u": "https://www.bibleserver.com/text/ELB/{{{s}}}",
@@ -23843,7 +23843,7 @@
     "sc": "Topical"
   },
   {
-    "s": "El Comercio Perú",
+    "s": "El Comercio (Peru)",
     "d": "elcomercio.pe",
     "t": "elcomercio",
     "ts": [
@@ -23870,7 +23870,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "electron.atom.io",
+    "s": "Electron (Apps)",
     "d": "electron.atom.io",
     "t": "electron",
     "u": "https://electron.atom.io/apps/?q={{{s}}}",
@@ -23886,7 +23886,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Google translate el-en",
+    "s": "Google Translate (el-en)",
     "d": "translate.google.com",
     "t": "elen",
     "u": "https://translate.google.com/#el/en/{{{s}}}",
@@ -23894,7 +23894,7 @@
     "sc": "Google"
   },
   {
-    "s": "www.eleymcqueen.blogspot.in",
+    "s": "Eley McQueen",
     "d": "eleymcqueen.blogspot.in",
     "t": "eley",
     "u": "https://eleymcqueen.blogspot.in/search?q={{{s}}}",
@@ -23942,7 +23942,7 @@
     "sc": "Search"
   },
   {
-    "s": "Elhuyar Hiztegia EN-->EU",
+    "s": "Elhuyar Hiztegia (en-eu)",
     "d": "hiztegiak.elhuyar.eus",
     "t": "elheneu",
     "u": "https://hiztegiak.elhuyar.eus/en_eu/{{{s}}}",
@@ -23950,7 +23950,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Elhuyar Hiztegia ES-->EU",
+    "s": "Elhuyar Hiztegia (es-eu)",
     "d": "hiztegiak.elhuyar.eus",
     "t": "elheseu",
     "u": "https://hiztegiak.elhuyar.eus/es_eu/{{{s}}}",
@@ -23958,7 +23958,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Elhuyar Hiztegia EU-->EN",
+    "s": "Elhuyar Hiztegia (eu-en)",
     "d": "hiztegiak.elhuyar.eus",
     "t": "elheuen",
     "u": "https://hiztegiak.elhuyar.eus/eu_en/{{{s}}}",
@@ -23966,7 +23966,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Elhuyar Hiztegia EU-->ES",
+    "s": "Elhuyar Hiztegia (eu-es)",
     "d": "hiztegiak.elhuyar.eus",
     "t": "elheues",
     "u": "https://hiztegiak.elhuyar.eus/eu_es/{{{s}}}",
@@ -23974,7 +23974,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Elhuyar Hiztegia EU-->FR",
+    "s": "Elhuyar Hiztegia (eu-fr)",
     "d": "hiztegiak.elhuyar.eus",
     "t": "elheufr",
     "u": "https://hiztegiak.elhuyar.eus/eu_fr/{{{s}}}",
@@ -23982,7 +23982,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Elhuyar Hiztegia FR-->EU",
+    "s": "Elhuyar Hiztegia (fr-eu)",
     "d": "hiztegiak.elhuyar.eus",
     "t": "elhfreu",
     "u": "https://hiztegiak.elhuyar.eus/fr_eu/{{{s}}}",
@@ -23990,7 +23990,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Reddit ELI5",
+    "s": "Reddit (/r/explainlikeimfive)",
     "d": "www.reddit.com",
     "t": "eli5",
     "u": "https://www.reddit.com/r/explainlikeimfive/search?q={{{s}}}&restrict_sr=on&sort=relevance&t=all",
@@ -24006,7 +24006,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "EliteProspects",
+    "s": "Elite Prospects (Player)",
     "d": "www.eliteprospects.com",
     "t": "elite",
     "ts": [
@@ -24017,7 +24017,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Elite Prospects",
+    "s": "Elite Prospects (Team)",
     "d": "www.eliteprospects.com",
     "t": "eliteprospects",
     "u": "https://www.eliteprospects.com/search/team?q={{{s}}}",
@@ -24033,7 +24033,7 @@
     "sc": "Docs"
   },
   {
-    "s": "Elixir Docs (Kagi Search)",
+    "s": "Elixir Docs (Kagi)",
     "d": "kagi.com",
     "ad": "elixir-lang.org/docs",
     "t": "elixir-docs",
@@ -24042,7 +24042,7 @@
     "sc": "Languages (other)"
   },
   {
-    "s": "Elixir Documentation",
+    "s": "HexDocs (Elixir)",
     "d": "hexdocs.pm",
     "t": "elixir",
     "u": "https://hexdocs.pm/elixir/search.html?q={{{s}}}",
@@ -24050,7 +24050,7 @@
     "sc": "Languages (other)"
   },
   {
-    "s": "elixirforum.com",
+    "s": "Elixir Forum",
     "d": "elixirforum.com",
     "t": "elixirforum",
     "u": "https://elixirforum.com/search?q={{{s}}}",
@@ -24166,7 +24166,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Emacs Wiki (Kagi Search)",
+    "s": "Emacs Wiki (Kagi)",
     "d": "kagi.com",
     "ad": "emacswiki.org",
     "t": "emacs",
@@ -24210,7 +24210,7 @@
     "sc": "Online"
   },
   {
-    "s": "Ember API (Kagi Search)",
+    "s": "Ember.js API (Kagi)",
     "d": "kagi.com",
     "ad": "api.emberjs.com",
     "t": "ember",
@@ -24262,7 +24262,7 @@
     "sc": "Misc"
   },
   {
-    "s": "emojipedia",
+    "s": "Emojipedia",
     "d": "emojipedia.org",
     "t": "emoji",
     "u": "https://emojipedia.org/search/?q={{{s}}}",
@@ -24318,7 +24318,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "Jobillico Montréal",
+    "s": "Jobillico (Montréal)",
     "d": "www.jobillico.com",
     "t": "emploismtl",
     "u": "https://www.jobillico.com/recherche-emploi?skwd={{{s}}}&scty=Montréal, QC&icty=6185&ipc=0&sil=&sjdpl=&sdl=&imc1=0&imc2=0&flat=45.509828&flng=-73.6715&mfil=byCity&ipg=1&clr=1",
@@ -24358,7 +24358,7 @@
     "sc": "Google"
   },
   {
-    "s": "Translate English to Danish",
+    "s": "Google Translate (en-da)",
     "d": "translate.google.com",
     "t": "en2da",
     "ts": [
@@ -24385,7 +24385,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Google translate En to Fa",
+    "s": "Google Translate (en-fa)",
     "d": "translate.google.com",
     "t": "en2fa",
     "u": "https://translate.google.com/#en/fa/{{{s}}}",
@@ -24393,7 +24393,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Traduction",
+    "s": "Google Translate (en-fr)",
     "d": "translate.google.com",
     "t": "en2fr",
     "ts": [
@@ -24405,7 +24405,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Google Translate English to Hindi",
+    "s": "Google Translate (en-hi)",
     "d": "translate.google.com",
     "t": "en2hi",
     "u": "https://translate.google.com/#view=home&op=translate&sl=en&tl=hi&text={{{s}}}",
@@ -24413,7 +24413,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate en-nl",
+    "s": "Google Translate (en-nl)",
     "d": "translate.google.com",
     "t": "en2nl",
     "ts": [
@@ -24424,7 +24424,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Google Translate English to Tagalog",
+    "s": "Google Translate (en-tl)",
     "d": "translate.google.com",
     "t": "en2tl",
     "u": "https://translate.google.com/#view=home&op=translate&sl=en&tl=tl&text={{{s}}}",
@@ -24440,7 +24440,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (en2zh)",
+    "s": "Google Translate (en-zh-CN)",
     "d": "translate.google.com",
     "t": "en2zh",
     "u": "https://translate.google.com/#en/zh-CN/{{{s}}}",
@@ -24448,7 +24448,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate Englsih to Arabic",
+    "s": "Google Translate (en-ar)",
     "d": "translate.google.com",
     "t": "enar",
     "u": "https://translate.google.com/#view=home&op=translate&sl=en&tl=ar&text={{{s}}}",
@@ -24464,7 +24464,7 @@
     "sc": "General"
   },
   {
-    "s": "Google Translator",
+    "s": "Google Translate (en-pt)",
     "d": "translate.google.com",
     "t": "enbr",
     "ts": [
@@ -24513,7 +24513,7 @@
     "sc": "Search (Private)"
   },
   {
-    "s": "encyc",
+    "s": "Encyc",
     "d": "encyc.org",
     "t": "encyc",
     "u": "https://encyc.org/wiki/{{{s}}}",
@@ -24532,7 +24532,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Google Translate - English to Welsh",
+    "s": "Google Translate (en-cy)",
     "d": "translate.google.com",
     "t": "ency",
     "u": "https://translate.google.com/#en/cy/{{{s}}}",
@@ -24540,7 +24540,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (en2de)",
+    "s": "Google Translate (en-de)",
     "d": "translate.google.com",
     "t": "ende",
     "u": "https://translate.google.com/#en/de/{{{s}}}",
@@ -24556,7 +24556,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "endless-sphere",
+    "s": "Endless Sphere",
     "d": "endless-sphere.com",
     "t": "endlessphere",
     "u": "https://endless-sphere.com/forums/?q{{{s}}}",
@@ -24572,7 +24572,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Google translate en-el",
+    "s": "Google Translate (en-el)",
     "d": "translate.google.com",
     "t": "enel",
     "u": "https://translate.google.com/#en/el/{{{s}}}",
@@ -24600,7 +24600,7 @@
     "sc": "Government"
   },
   {
-    "s": "Google translate en-es",
+    "s": "Google Translate (en-es)",
     "d": "translate.google.com",
     "t": "enes",
     "ts": [
@@ -24619,7 +24619,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Google Translate to Finnish",
+    "s": "Google Translate (en-fi)",
     "d": "translate.google.com",
     "t": "enfi",
     "u": "https://translate.google.com/#en/fi/{{{s}}}",
@@ -24649,7 +24649,7 @@
     "sc": "Online"
   },
   {
-    "s": "Engadget en español",
+    "s": "Engadget (Spanish)",
     "d": "es.engadget.com",
     "t": "enges",
     "u": "https://es.engadget.com/search/?q={{{s}}}",
@@ -24716,7 +24716,7 @@
     "sc": "Design"
   },
   {
-    "s": "Google Translate (en2iw)",
+    "s": "Google Translate (en-he)",
     "d": "translate.google.com",
     "t": "enhe",
     "u": "https://translate.google.com/#en/iw/{{{s}}}",
@@ -24724,7 +24724,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate en-hu",
+    "s": "Google Translate (en-hu)",
     "d": "translate.google.com",
     "t": "enhu",
     "u": "https://translate.google.com/#en/hu/{{{s}}}",
@@ -24732,7 +24732,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (en2id)",
+    "s": "Google Translate (en-id)",
     "d": "translate.google.com",
     "t": "enid",
     "u": "https://translate.google.com/translate#en/id/{{{s}}}",
@@ -24762,7 +24762,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Google translate en-it",
+    "s": "Google Translate (en-it)",
     "d": "translate.google.com",
     "t": "enit",
     "ts": [
@@ -24781,7 +24781,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Google Translate English-Korean",
+    "s": "Google Translate (en-ko)",
     "d": "translate.google.com",
     "t": "enkr",
     "u": "https://translate.google.com/#en/ko/{{{s}}}",
@@ -24797,7 +24797,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Google Translate English to Lithuanian",
+    "s": "Google Translate (en-lt)",
     "d": "translate.google.com",
     "t": "enlt",
     "u": "https://translate.google.com/#en/lt/{{{s}}}",
@@ -24813,7 +24813,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Google Translate en-no",
+    "s": "Google Translate (en-no)",
     "d": "translate.google.com",
     "t": "enno",
     "u": "https://translate.google.com/#view=home&op=translate&sl=en&tl=no&text={{{s}}}",
@@ -24821,7 +24821,7 @@
     "sc": "Google"
   },
   {
-    "s": "The Ojibwe People's Dictionary (English)",
+    "s": "Ojibwe People's Dictionary (English)",
     "d": "ojibwe.lib.umn.edu",
     "t": "enoj",
     "u": "https://ojibwe.lib.umn.edu/search?utf8=%E2%9C%93&q={{{s}}}&commit=Search&type=english",
@@ -24829,7 +24829,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Google Translate (English to Polish)",
+    "s": "Google Translate (en-pl)",
     "d": "translate.google.com",
     "t": "enpl",
     "u": "https://translate.google.com/#en/pl/{{{s}}}",
@@ -24837,7 +24837,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Google Translate (en2ru)",
+    "s": "Google Translate (en-ru)",
     "d": "translate.google.com",
     "t": "enru",
     "ts": [
@@ -24870,7 +24870,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Google Translate en-sl",
+    "s": "Google Translate (en-sl)",
     "d": "translate.google.com",
     "t": "ensl",
     "u": "https://translate.google.com/#en/sl/{{{s}}}",
@@ -24878,7 +24878,7 @@
     "sc": "Google"
   },
   {
-    "s": "la sutsis",
+    "s": "Sutsis",
     "d": "mw.lojban.org",
     "t": "en-sutsis",
     "u": "https://mw.lojban.org/extensions/ilmentufa/i/en/#sisku/{{{s}}}",
@@ -24886,7 +24886,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Google Translator (English -> Swedish)",
+    "s": "Google Translate (en-sv)",
     "d": "translate.google.com",
     "t": "ensv",
     "u": "https://translate.google.com/#en/sv/{{{s}}}",
@@ -24902,7 +24902,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google Translate (EN-TH)",
+    "s": "Google Translate (en-th)",
     "d": "translate.google.com",
     "t": "enth",
     "ts": [
@@ -24929,7 +24929,7 @@
     "sc": "Government"
   },
   {
-    "s": "Google Translate (en2tr)",
+    "s": "Google Translate (en-tr)",
     "d": "translate.google.com",
     "t": "entr",
     "u": "https://translate.google.com/#en/tr/{{{s}}}",
@@ -24937,7 +24937,7 @@
     "sc": "Tools"
   },
   {
-    "s": "enumquery.com",
+    "s": "EnumQuery",
     "d": "enumquery.com",
     "t": "enum",
     "u": "https://enumquery.com/lookup?e164={{{s}}}",
@@ -24953,7 +24953,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "English WIkinews",
+    "s": "Wikinews (English)",
     "d": "en.wikinews.org",
     "t": "enwn",
     "u": "https://en.wikinews.org/w/index.php?search={{{s}}}",
@@ -24961,7 +24961,7 @@
     "sc": "International"
   },
   {
-    "s": "glosbe eo › en",
+    "s": "Glosbe (eo-en)",
     "d": "glosbe.com",
     "t": "eo2en",
     "u": "https://glosbe.com/eo/en/{{{s}}}",
@@ -24977,7 +24977,7 @@
     "sc": "Reference (science)"
   },
   {
-    "s": "Google Translate (eo2en)",
+    "s": "Google Translate (eo-en)",
     "d": "translate.google.com",
     "t": "eoen",
     "u": "https://translate.google.com/#eo/en/{{{s}}}",
@@ -25008,7 +25008,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "eune.OP.GG",
+    "s": "OP.GG (EUNE)",
     "d": "eune.op.gg",
     "t": "eop",
     "u": "https://eune.op.gg/summoner/userName={{{s}}}",
@@ -25032,7 +25032,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Base de données d'Éorzéa",
+    "s": "Eorzea Database (France)",
     "d": "fr.finalfantasyxiv.com",
     "t": "eorfr",
     "u": "https://fr.finalfantasyxiv.com/lodestone/playguide/db/search/?q={{{s}}}",
@@ -25093,7 +25093,7 @@
     "sc": "Academic"
   },
   {
-    "s": "EPFL Directory",
+    "s": "EPFL (Directory)",
     "d": "search.epfl.ch",
     "t": "epfldir",
     "u": "https://search.epfl.ch/psearch.action?q={{{s}}}&f=directory&lang=en&pageSize=10&sort=",
@@ -25168,7 +25168,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Kagi Unix Time converter",
+    "s": "Kagi (Unix Time Converter)",
     "d": "kagi.com",
     "ad": "",
     "t": "epoch",
@@ -25257,7 +25257,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Equestria Daily (Kagi Search)",
+    "s": "Equestria Daily (Kagi)",
     "d": "kagi.com",
     "ad": "equestriadaily.com",
     "t": "equestriadaily",
@@ -25301,7 +25301,7 @@
     "sc": "Government"
   },
   {
-    "s": "Erlang (Kagi Search)",
+    "s": "Erlang (Kagi)",
     "d": "kagi.com",
     "ad": "erlang.org",
     "t": "erlang",
@@ -25310,7 +25310,7 @@
     "sc": "Languages (other)"
   },
   {
-    "s": "Erlang Docs",
+    "s": "Erlang (Docs)",
     "d": "erlang.org",
     "t": "erl",
     "u": "https://erlang.org/doc/search/?q={{{s}}}",
@@ -25318,7 +25318,7 @@
     "sc": "Languages (erlang)"
   },
   {
-    "s": "Erlang Module Documentation",
+    "s": "Erlang (Modules)",
     "d": "erlang.org",
     "t": "erlm",
     "u": "https://erlang.org/doc/man/{{{s}}}.html",
@@ -25358,7 +25358,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Word Reference Definicion",
+    "s": "WordReference (Spanish Definition)",
     "d": "www.wordreference.com",
     "t": "esdef",
     "ts": [
@@ -25371,7 +25371,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Google Translate es - de",
+    "s": "Google Translate (es-de)",
     "d": "translate.google.de",
     "t": "esde",
     "u": "https://translate.google.de/#view=home&op=translate&sl=es&tl=de&text={{{s}}}",
@@ -25403,7 +25403,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Google translate es-en",
+    "s": "Google Translate (es-en)",
     "d": "translate.google.com",
     "t": "esen",
     "u": "https://translate.google.com/#es/en/{{{s}}}",
@@ -25419,7 +25419,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Google translate es-fr",
+    "s": "Google Translate (es-fr)",
     "d": "translate.google.com",
     "t": "esfr",
     "u": "https://translate.google.com/#es/fr/{{{s}}}",
@@ -25448,7 +25448,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google Translate es-hu",
+    "s": "Google Translate (es-hu)",
     "d": "translate.google.hu",
     "t": "eshu",
     "u": "https://translate.google.hu/#es/hu/{{{s}}}",
@@ -25456,7 +25456,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google translate es-it",
+    "s": "Google Translate (es-it)",
     "d": "translate.google.com",
     "t": "esit",
     "u": "https://translate.google.com/#es/it/{{{s}}}",
@@ -25528,7 +25528,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Google Translate Spanish-Portuguese",
+    "s": "Google Translate (es-pt)",
     "d": "translate.google.com",
     "t": "espt",
     "u": "https://translate.google.com/#es/pt/{{{s}}}",
@@ -25573,7 +25573,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Word Reference Sinonimos",
+    "s": "WordReference (Spanish Synonyms)",
     "d": "www.wordreference.com",
     "t": "essin",
     "ts": [
@@ -25781,7 +25781,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Live Music Archive",
+    "s": "Internet Archive (Live Music)",
     "d": "archive.org",
     "t": "etree",
     "ts": [
@@ -25843,7 +25843,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Ebay UK",
+    "s": "eBay (UK)",
     "d": "www.ebay.co.uk",
     "t": "e.uk",
     "u": "https://www.ebay.co.uk/sch/i.html?_nkw={{{s}}}",
@@ -25859,7 +25859,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "XE (eur2brl)",
+    "s": "XE (EUR-BRL)",
     "d": "www.xe.com",
     "t": "eur2brl",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=EUR&To=BRL",
@@ -25867,7 +25867,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "XE (eur2cny)",
+    "s": "XE (EUR-CNY)",
     "d": "www.xe.com",
     "t": "eur2cny",
     "u": "https://www.xe.com/currencyconverter/convert/?From=EUR&To=CNY&Amount={{{s}}}",
@@ -25875,7 +25875,7 @@
     "sc": "Tools"
   },
   {
-    "s": "XE (eur2usd)",
+    "s": "XE (EUR-USD)",
     "d": "www.xe.com",
     "t": "eur2usd",
     "u": "https://www.xe.com/currencyconverter/convert/?From=EUR&To=USD&Amount={{{s}}}",
@@ -25899,7 +25899,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Eurogamer.net",
+    "s": "Eurogamer",
     "d": "www.eurogamer.net",
     "t": "eurogamer",
     "u": "https://www.eurogamer.net/search.php?q={{{s}}}",
@@ -25955,7 +25955,7 @@
     "sc": "Food"
   },
   {
-    "s": "op.gg",
+    "s": "OP.GG (EUW)",
     "d": "euw.op.gg",
     "t": "euw.op",
     "ts": [
@@ -25991,7 +25991,7 @@
     "sc": "Reference (fun)"
   },
   {
-    "s": "Eve University",
+    "s": "EVE University",
     "d": "wiki.eveuniversity.org",
     "t": "eve",
     "u": "https://wiki.eveuniversity.org/index.php?search={{{s}}}",
@@ -26055,7 +26055,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "EveryMac.com",
+    "s": "EveryMac",
     "d": "www.everymac.com",
     "t": "everymac",
     "ts": [
@@ -26066,7 +26066,7 @@
     "sc": "Reference"
   },
   {
-    "s": "EVE Search",
+    "s": "EVE",
     "d": "eve-search.com",
     "t": "evesearch",
     "u": "https://eve-search.com/search/{{{s}}}",
@@ -26114,7 +26114,7 @@
     "sc": "Health"
   },
   {
-    "s": "Estante Virtual (by author and/or title)",
+    "s": "Estante Virtual (Author and Title)",
     "d": "www.estantevirtual.com.br",
     "t": "evirtat",
     "u": "https://www.estantevirtual.com.br/q/{{{s}}}",
@@ -26122,7 +26122,7 @@
     "sc": "Books"
   },
   {
-    "s": "Estante Virtual (by author)",
+    "s": "Estante Virtual (Author)",
     "d": "www.estantevirtual.com.br",
     "t": "evirtau",
     "u": "https://www.estantevirtual.com.br/qau/{{{s}}}",
@@ -26130,7 +26130,7 @@
     "sc": "Books"
   },
   {
-    "s": "Estante Virtual (description)",
+    "s": "Estante Virtual (Description)",
     "d": "www.estantevirtual.com.br",
     "t": "evirtdes",
     "u": "https://www.estantevirtual.com.br/qdes/{{{s}}}",
@@ -26138,7 +26138,7 @@
     "sc": "Books"
   },
   {
-    "s": "Estante Virtual (by publisher)",
+    "s": "Estante Virtual (Publisher)",
     "d": "www.estantevirtual.com.br",
     "t": "evirted",
     "u": "https://www.estantevirtual.com.br/qed/{{{s}}}",
@@ -26146,7 +26146,7 @@
     "sc": "Books"
   },
   {
-    "s": "Estante Virtual (all)",
+    "s": "Estante Virtual (All)",
     "d": "www.estantevirtual.com.br",
     "t": "evirt",
     "u": "https://www.estantevirtual.com.br/qt/{{{s}}}",
@@ -26154,7 +26154,7 @@
     "sc": "Books"
   },
   {
-    "s": "Estante Virtual (by title)",
+    "s": "Estante Virtual (Title)",
     "d": "www.estantevirtual.com.br",
     "t": "evirttit",
     "u": "https://www.estantevirtual.com.br/qtit/{{{s}}}",
@@ -26186,7 +26186,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Eternal Warcry: Cards",
+    "s": "Eternal Warcry (Cards)",
     "d": "eternalwarcry.com",
     "t": "ewc",
     "u": "https://eternalwarcry.com/cards?query={{{s}}}",
@@ -26194,7 +26194,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Entertainment Weekly (Kagi Search)",
+    "s": "Entertainment Weekly (Kagi)",
     "d": "kagi.com",
     "ad": "ew.com",
     "t": "ew",
@@ -26289,7 +26289,7 @@
     "sc": "Online"
   },
   {
-    "s": "εxodus Privacy",
+    "s": "Exodus Privacy (Reports)",
     "d": "reports.exodus-privacy.eu.org",
     "t": "exodus",
     "u": "https://reports.exodus-privacy.eu.org/reports/search/{{{s}}}",
@@ -26337,7 +26337,7 @@
     "sc": "Events"
   },
   {
-    "s": "exploit-db",
+    "s": "Exploit-DB",
     "d": "www.exploit-db.com",
     "t": "exploitdb",
     "u": "https://www.exploit-db.com/search?q={{{s}}}",
@@ -26444,7 +26444,7 @@
     "sc": "Broadcast"
   },
   {
-    "s": "Fallout 3 NexusMods",
+    "s": "Nexus Mods (Fallout 3)",
     "d": "www.nexusmods.com",
     "t": "f3nm",
     "u": "https://www.nexusmods.com/fallout3/search/?gsearch={{{s}}}&gsearchtype=mods",
@@ -26471,7 +26471,7 @@
     "sc": "Forum"
   },
   {
-    "s": "Google translate Fa to En",
+    "s": "Google Translate (fa-en)",
     "d": "translate.google.com",
     "t": "fa2en",
     "u": "https://translate.google.com/#fa/en/{{{s}}}",
@@ -26495,7 +26495,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Fabric.com",
+    "s": "Fabric",
     "d": "www.fabric.com",
     "t": "fabric",
     "u": "https://www.fabric.com/SearchResults2.aspx?SearchText={{{s}}}",
@@ -26515,7 +26515,7 @@
     "sc": "Social"
   },
   {
-    "s": "Google (facephoto)",
+    "s": "Google (Face Photos)",
     "d": "www.google.com",
     "t": "facephoto",
     "u": "https://www.google.com/search?q=\"{{{s}}}\"&tbm=isch&tbs=ic:color,isz:lt,itp:face,isg:to&filter=0&safe=off&pws=0&tbs=rl:0",
@@ -26547,7 +26547,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "Factor Number Calculator",
+    "s": "Calculator.net (Factor)",
     "d": "www.calculator.net",
     "t": "factor",
     "u": "https://www.calculator.net/factor-calculator.html?cvar={{{s}}}&x=Calculate",
@@ -26588,7 +26588,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Filmaffinity",
+    "s": "FilmAffinity (Spanish, Advanced Search)",
     "d": "www.filmaffinity.com",
     "t": "faf",
     "u": "https://www.filmaffinity.com/es/advsearch2.php?q={{{s}}}:",
@@ -26609,7 +26609,7 @@
     "sc": "Design"
   },
   {
-    "s": "Faillissementen.com",
+    "s": "Faillissementen",
     "d": "www.faillissementen.com",
     "t": "failliet",
     "u": "https://www.faillissementen.com/insolventies/nederlandse-insolventies/?q={{{s}}}",
@@ -26693,7 +26693,7 @@
     "sc": "Images"
   },
   {
-    "s": "Fanart.tv (Music)",
+    "s": "fanart.tv (Music)",
     "d": "fanart.tv",
     "t": "fanartm",
     "u": "https://fanart.tv/?s={{{s}}}&sect=2",
@@ -26835,7 +26835,7 @@
     "sc": "Online"
   },
   {
-    "s": "Fark.com",
+    "s": "Fark",
     "d": "www.fark.com",
     "t": "fark",
     "u": "https://www.fark.com/hlsearch?&qq={{{s}}}",
@@ -26926,7 +26926,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Fass allmänhet",
+    "s": "Fass (Allmänhet)",
     "d": "www.fass.se",
     "t": "fass",
     "u": "https://www.fass.se/m/sok/{{{s}}}/public",
@@ -26934,7 +26934,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Fass Vårdpersonal",
+    "s": "Fass (Vårdpersonal)",
     "d": "www.fass.se",
     "t": "fassv",
     "u": "https://www.fass.se/LIF/result?userType=0&query={{{s}}}",
@@ -26942,7 +26942,7 @@
     "sc": "Reference"
   },
   {
-    "s": "fast.ai forums",
+    "s": "fast.ai (Forums)",
     "d": "forums.fast.ai",
     "t": "fastai",
     "u": "https://forums.fast.ai/search?q={{{s}}}",
@@ -26966,7 +26966,7 @@
     "sc": "Food"
   },
   {
-    "s": "Faucet.com",
+    "s": "Faucet",
     "d": "www.faucet.com",
     "t": "faucet",
     "u": "https://www.faucet.com/index.cfm?page=search:browse&term={{{s}}}",
@@ -27032,7 +27032,7 @@
     "sc": "Social"
   },
   {
-    "s": "Footballguys (Kagi Search)",
+    "s": "Footballguys (Kagi)",
     "d": "kagi.com",
     "ad": "footballguys.com",
     "t": "fbg",
@@ -27049,7 +27049,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Facebook Messages",
+    "s": "Facebook (Messages)",
     "d": "www.facebook.com",
     "t": "fbm",
     "u": "https://www.facebook.com/messages/search?action=search-snippet&mquery={{{s}}}",
@@ -27057,7 +27057,7 @@
     "sc": "Social"
   },
   {
-    "s": "Facebook Pages",
+    "s": "Facebook (Pages)",
     "d": "www.facebook.com",
     "t": "fbp",
     "u": "https://www.facebook.com/search/top/?q={{{s}}}&type=pages",
@@ -27174,7 +27174,7 @@
     "sc": "Forum"
   },
   {
-    "s": "FreeCAD (Kagi Search)",
+    "s": "FreeCAD (Kagi)",
     "d": "kagi.com",
     "ad": "freecadweb.org",
     "t": "fc",
@@ -27199,7 +27199,7 @@
     "sc": "Tools"
   },
   {
-    "s": "WordReference (fr-conj)",
+    "s": "WordReference (French Conjugation)",
     "d": "www.wordreference.com",
     "t": "fconj",
     "ts": [
@@ -27258,7 +27258,7 @@
     "sc": "Movies"
   },
   {
-    "s": "fddb.info",
+    "s": "FDDB",
     "d": "fddb.info",
     "t": "fddb",
     "u": "https://fddb.info/db/de/suche/?udd=0&cat=site-de&search={{{s}}}",
@@ -27266,7 +27266,7 @@
     "sc": "Food"
   },
   {
-    "s": "Freshdesk forums",
+    "s": "Freshdesk (Forums)",
     "d": "support.freshdesk.com",
     "t": "fdf",
     "u": "https://support.freshdesk.com/support/search/topics?term={{{s}}}",
@@ -27321,7 +27321,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "www.thefederalist.com",
+    "s": "The Federalist",
     "d": "thefederalist.com",
     "t": "fdrlst",
     "u": "https://thefederalist.com/?s={{{s}}}",
@@ -27329,7 +27329,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "F-Droid search",
+    "s": "F-Droid",
     "d": "search.f-droid.org",
     "t": "fdroid",
     "u": "https://search.f-droid.org/?q={{{s}}}",
@@ -27337,7 +27337,7 @@
     "sc": "Downloads (apps)"
   },
   {
-    "s": "Freshdesk solutions",
+    "s": "Freshdesk (Solutions)",
     "d": "support.freshdesk.com",
     "t": "fds",
     "u": "https://support.freshdesk.com/support/search/solutions?term={{{s}}}",
@@ -27359,7 +27359,7 @@
     "u": "https://www.fedex.com/fedextrack/?trknbr={{{s}}}"
   },
   {
-    "s": "Fedora: Koji package search",
+    "s": "Fedora Koji (Packages)",
     "d": "koji.fedoraproject.org",
     "t": "fedkojip",
     "ts": [
@@ -27386,7 +27386,7 @@
     "sc": "Sysadmin (Fedora)"
   },
   {
-    "s": "fedoramagazine.org",
+    "s": "Fedora Magazine",
     "d": "fedoramagazine.org",
     "t": "fedoramagazine",
     "u": "https://fedoramagazine.org/?s={{{s}}}",
@@ -27590,7 +27590,7 @@
     "sc": "Movies"
   },
   {
-    "s": "admin.ch - Feuille fédérale",
+    "s": "admin.ch (Feuille fédérale)",
     "d": "www.admin.ch",
     "t": "ffch",
     "u": "https://www.admin.ch/opc/search/?lang=fr&language[]=fr&product[]=fg&text={{{s}}}&lang=fr",
@@ -27606,7 +27606,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Finder.fi",
+    "s": "Finder (Finland)",
     "d": "www.finder.fi",
     "t": "ffi",
     "u": "https://www.finder.fi/search?what={{{s}}}",
@@ -27676,7 +27676,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Fanfiction.net Writers",
+    "s": "FanFiction (Writers)",
     "d": "www.fanfiction.net",
     "t": "ffw",
     "u": "https://www.fanfiction.net/search.php?type=writer&keywords={{{s}}}&match=title&sort=0&genreid=0&subgenreid=0&characterid=0&subcharacterid=0&words=0&ready=1&categoryid=0#",
@@ -27719,7 +27719,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Gentoo Forums (Kagi Search)",
+    "s": "Gentoo Forums (Kagi)",
     "d": "kagi.com",
     "ad": "forums.gentoo.org",
     "t": "fgentoo",
@@ -27799,7 +27799,7 @@
     "sc": "Downloads"
   },
   {
-    "s": "FiberCables.com",
+    "s": "Fiber Cables",
     "d": "www.fibercables.com",
     "t": "fibercables",
     "u": "https://www.fibercables.com/search?q={{{s}}}",
@@ -27807,7 +27807,7 @@
     "sc": "Tech"
   },
   {
-    "s": "ficly",
+    "s": "Ficly",
     "d": "ficly.com",
     "t": "ficly",
     "u": "https://ficly.com/search?query={{{s}}}",
@@ -27824,7 +27824,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Fide - World Chess Federation",
+    "s": "FIDE (World Chess Federation)",
     "d": "ratings.fide.com",
     "t": "fide",
     "u": "https://ratings.fide.com/search.phtml?search={{{s}}}",
@@ -27848,7 +27848,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Google Translate (fi2en)",
+    "s": "Google Translate (fi-en)",
     "d": "translate.google.com",
     "t": "fien",
     "u": "https://translate.google.com/#fi/en/{{{s}}}",
@@ -27880,7 +27880,7 @@
     "sc": "Online"
   },
   {
-    "s": "File-Extensions.org",
+    "s": "File-Extensions",
     "d": "www.file-extensions.org",
     "t": "fileext",
     "u": "https://www.file-extensions.org/search/?searchstring={{{s}}}",
@@ -27904,7 +27904,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "filmaffinity españa",
+    "s": "FilmAffinity (Spain)",
     "d": "m.filmaffinity.com",
     "t": "filmaffinityes",
     "u": "https://m.filmaffinity.com/es/search.php?stext={{{s}}}",
@@ -27936,7 +27936,7 @@
     "sc": "Movies"
   },
   {
-    "s": "filmaffinity",
+    "s": "FilmAffinity (Spanish)",
     "d": "www.filmaffinity.com",
     "t": "film",
     "u": "https://www.filmaffinity.com/es/search.php?stext={{{s}}}",
@@ -27944,7 +27944,7 @@
     "sc": "Video"
   },
   {
-    "s": "Film.nl",
+    "s": "Film",
     "d": "www.film.nl",
     "t": "filmnl",
     "u": "https://www.film.nl/?q={{{s}}}",
@@ -27992,7 +27992,7 @@
     "sc": "Movies"
   },
   {
-    "s": "FilmTV.it",
+    "s": "FilmTV",
     "d": "www.filmtv.it",
     "t": "filmtv",
     "u": "https://www.filmtv.it/cerca/?q={{{s}}}",
@@ -28011,7 +28011,7 @@
     "sc": "Movies"
   },
   {
-    "s": "FimFiction.net",
+    "s": "Fimfiction",
     "d": "www.fimfiction.net",
     "t": "fimfic",
     "ts": [
@@ -28074,7 +28074,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Fineli English",
+    "s": "Fineli (English)",
     "d": "fineli.fi",
     "t": "finelien",
     "u": "https://fineli.fi/fineli/en/elintarvikkeet?q={{{s}}}",
@@ -28090,7 +28090,7 @@
     "sc": "Food"
   },
   {
-    "s": "Fineli Swedish",
+    "s": "Fineli (Swedish)",
     "d": "fineli.fi",
     "t": "finelisv",
     "u": "https://fineli.fi/fineli/sv/elintarvikkeet?q={{{s}}}",
@@ -28098,7 +28098,7 @@
     "sc": "Food"
   },
   {
-    "s": "Finf-Forum (Forum des Fachrats Informatik der Leibniz Universität Hannover)",
+    "s": "Finf Forum",
     "d": "forum.finf.uni-hannover.de",
     "t": "finf",
     "u": "https://forum.finf.uni-hannover.de/index.php?form=Search&q={{{s}}}",
@@ -28138,7 +28138,7 @@
     "sc": "Law"
   },
   {
-    "s": "Finna.fi",
+    "s": "Finna",
     "d": "finna.fi",
     "t": "finna",
     "u": "https://finna.fi/Search/Results?lookfor={{{s}}}",
@@ -28146,7 +28146,7 @@
     "sc": "Search"
   },
   {
-    "s": "Finn.no",
+    "s": "FINN",
     "d": "www.finn.no",
     "t": "finn",
     "u": "https://www.finn.no/globalsearchlander?q={{{s}}}",
@@ -28154,7 +28154,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Finn.no Torget",
+    "s": "FINN (Marketplace)",
     "d": "www.finn.no",
     "t": "finntorget",
     "ts": [
@@ -28165,7 +28165,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Finn.no Jobb",
+    "s": "FINN (Jobs)",
     "d": "www.finn.no",
     "t": "finnjobb",
     "u": "https://www.finn.no/job/fulltime/search.html?q={{{s}}}",
@@ -28229,7 +28229,7 @@
     "sc": "Search"
   },
   {
-    "s": "Firmy.cz",
+    "s": "Firmy",
     "d": "www.firmy.cz",
     "t": "firmy",
     "u": "https://www.firmy.cz/?q={{{s}}}",
@@ -28269,7 +28269,7 @@
     "sc": "Companies"
   },
   {
-    "s": "fishshell.com",
+    "s": "fish shell",
     "d": "fishshell.com",
     "t": "fish",
     "u": "https://fishshell.com/docs/current/commands.html#{{{s}}}",
@@ -28337,7 +28337,7 @@
     "sc": "Online"
   },
   {
-    "s": "fkk-freunde",
+    "s": "FKK-Freunde",
     "d": "fkk-freunde.info",
     "t": "fkk",
     "u": "https://fkk-freunde.info/search.php?keywords={{{s}}}",
@@ -28345,7 +28345,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Flagpoles (Kagi Search)",
+    "s": "Flagpoles (Kagi)",
     "d": "kagi.com",
     "ad": "flagpoles.com.au",
     "t": "flag",
@@ -28422,7 +28422,7 @@
     "sc": "International"
   },
   {
-    "s": "DocCheck Flexikon",
+    "s": "DocCheck (Flexikon)",
     "d": "flexikon.doccheck.com",
     "t": "fle",
     "u": "https://flexikon.doccheck.com/de/Spezial:Suche?q={{{s}}}",
@@ -28458,7 +28458,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Flickr (All Creative Commons)",
+    "s": "Flickr (Creative Commons)",
     "d": "www.flickr.com",
     "t": "flickrcc",
     "u": "https://www.flickr.com/search/?text={{{s}}}&license=2,3,4,5,6,9",
@@ -28466,7 +28466,7 @@
     "sc": "Images"
   },
   {
-    "s": "Flickr (comm/deriv)",
+    "s": "Flickr (Commercial/Derivative)",
     "d": "www.flickr.com",
     "t": "flickrc",
     "u": "https://www.flickr.com/search/?q={{{s}}}&l=commderiv",
@@ -28482,7 +28482,7 @@
     "sc": "Images"
   },
   {
-    "s": "Flicks.co.nz",
+    "s": "Flicks",
     "d": "www.flicks.co.nz",
     "t": "flicks",
     "u": "https://www.flicks.co.nz/search/?q={{{s}}}",
@@ -28542,7 +28542,7 @@
     "sc": "Learning"
   },
   {
-    "s": "FluidLang subreddit",
+    "s": "Reddit (/r/FluidLang)",
     "d": "www.reddit.com",
     "t": "flr",
     "u": "https://www.reddit.com/r/FluidLang/search?q={{{s}}}&restrict_sr=on",
@@ -28649,7 +28649,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Fnac.es",
+    "s": "Fnac (Spain)",
     "d": "busqueda.fnac.es",
     "t": "fnaces",
     "u": "https://busqueda.fnac.es/Search/SearchResult.aspx?SCat=0!1&Search={{{s}}}&sft=1&submitbtn=OK",
@@ -28657,7 +28657,7 @@
     "sc": "Online"
   },
   {
-    "s": "fnac",
+    "s": "Fnac",
     "d": "recherche.fnac.com",
     "t": "fnac",
     "u": "https://recherche.fnac.com/SearchResult/ResultList.aspx?Search={{{s}}}",
@@ -28705,7 +28705,7 @@
     "sc": "Food"
   },
   {
-    "s": "Reddit Fortnite BR",
+    "s": "Reddit (/r/FortNiteBR)",
     "d": "www.reddit.com",
     "t": "fnite",
     "u": "https://www.reddit.com/r/FortNiteBR/search/?q={{{s}}}&restrict_sr=1",
@@ -28721,7 +28721,7 @@
     "sc": "Online"
   },
   {
-    "s": "Fallout New Vegas NexusMods",
+    "s": "Nexus Mods (Fallout New Vegas)",
     "d": "www.nexusmods.com",
     "t": "fnvnm",
     "u": "https://www.nexusmods.com/newvegas/search/?gsearch={{{s}}}&gsearchtype=mods",
@@ -28729,7 +28729,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "File.org",
+    "s": "File",
     "d": "file.org",
     "t": "fo",
     "u": "https://file.org/extension/{{{s}}}",
@@ -28876,7 +28876,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Food.com",
+    "s": "Food",
     "d": "www.food.com",
     "t": "food",
     "u": "https://www.food.com/recipe-finder/all/{{{s}}}",
@@ -28908,7 +28908,7 @@
     "sc": "Food"
   },
   {
-    "s": "Fool.com",
+    "s": "Motley Fool",
     "d": "www.fool.com",
     "t": "fool",
     "u": "https://www.fool.com/search/index.aspx?go=1&site=USMF&q={{{s}}}&source=ifltnvsnq0000001&mbbid=BoardID&mbmid=MessageID",
@@ -29090,7 +29090,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Martin Fowler (Kagi Search)",
+    "s": "Martin Fowler (Kagi)",
     "d": "kagi.com",
     "ad": "martinfowler.com",
     "t": "fowler",
@@ -29131,7 +29131,7 @@
     "sc": "Online"
   },
   {
-    "s": "PCSoft Forum (Kagi Search)",
+    "s": "PCSoft Forum (Kagi)",
     "d": "kagi.com",
     "ad": "forum.pcsoft.fr",
     "t": "fpcs",
@@ -29175,7 +29175,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Google Translate (fr2de)",
+    "s": "Google Translate (fr-de)",
     "d": "translate.google.com",
     "t": "fr2de",
     "u": "https://translate.google.com/#view=home&op=translate&sl=fr&tl=de&text={{{s}}}",
@@ -29183,7 +29183,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate fr-en",
+    "s": "Google Translate (fr-en)",
     "d": "translate.google.com",
     "t": "fr2en",
     "ts": [
@@ -29194,7 +29194,7 @@
     "sc": "Google"
   },
   {
-    "s": "Frack.nl Hackerspace",
+    "s": "Frack Hackerspace",
     "d": "frack.nl",
     "t": "frack",
     "u": "https://frack.nl/w/index.php?title=Special:Search&search={{{s}}}",
@@ -29266,7 +29266,7 @@
     "sc": "Academic"
   },
   {
-    "s": "FreeCollocation.com",
+    "s": "FreeCollocation",
     "d": "www.freecollocation.com",
     "t": "freecol",
     "u": "https://www.freecollocation.com/search?word={{{s}}}",
@@ -29290,7 +29290,7 @@
     "sc": "International"
   },
   {
-    "s": "freeGROUP",
+    "s": "Free",
     "d": "free.com.tw",
     "t": "freeg",
     "ts": [
@@ -29407,7 +29407,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Google translate fr-es",
+    "s": "Google Translate (fr-es)",
     "d": "translate.google.com",
     "t": "fres",
     "u": "https://translate.google.com/#fr/es/{{{s}}}",
@@ -29415,7 +29415,7 @@
     "sc": "Google"
   },
   {
-    "s": "Amazon Fresh",
+    "s": "Amazon (Fresh)",
     "d": "www.amazon.com",
     "t": "fresh",
     "u": "https://www.amazon.com/s?url=search-alias=amazonfresh&field-keywords={{{s}}}",
@@ -29423,7 +29423,7 @@
     "sc": "Online"
   },
   {
-    "s": "Freshdesk Support Home",
+    "s": "Freshdesk (Support)",
     "d": "support.freshdesk.com",
     "t": "freshdesk",
     "u": "https://support.freshdesk.com/support/search?term={{{s}}}",
@@ -29439,7 +29439,7 @@
     "sc": "Downloads (software)"
   },
   {
-    "s": "Reverso (frge)",
+    "s": "Reverso (fr-de)",
     "d": "dictionnaire.reverso.net",
     "t": "frge",
     "ts": [
@@ -29458,7 +29458,7 @@
     "sc": "Online"
   },
   {
-    "s": "Frida fooddata.dk",
+    "s": "FRIDA",
     "d": "frida.fooddata.dk",
     "t": "frida",
     "u": "https://frida.fooddata.dk/food/search?lang=en&q={{{s}}}",
@@ -29514,7 +29514,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google Translate French to Italian",
+    "s": "Google Translate (fr-it)",
     "d": "translate.google.com",
     "t": "frit",
     "u": "https://translate.google.com/#fr/it/{{{s}}}",
@@ -29530,7 +29530,7 @@
     "sc": "Local"
   },
   {
-    "s": "Reverse (frjp)",
+    "s": "Reverso (fr-ja)",
     "d": "dictionnaire.reverso.net",
     "t": "frjp",
     "u": "https://dictionnaire.reverso.net/francais-japonais/{{{s}}}",
@@ -29538,7 +29538,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Larousse French Dictionary",
+    "s": "Larousse (French)",
     "d": "www.larousse.fr",
     "t": "dict-fr",
     "ts": [
@@ -29572,7 +29572,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Reverso (frpl)",
+    "s": "Reverso (fr-pl)",
     "d": "dictionnaire.reverso.net",
     "t": "frpl",
     "u": "https://dictionnaire.reverso.net/francais-polonais/{{{s}}}",
@@ -29580,7 +29580,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Google Translate FR-RU",
+    "s": "Google Translate (fr-ru)",
     "d": "translate.google.com",
     "t": "frru",
     "u": "https://translate.google.com/#fr/ru/{{{s}}}",
@@ -29620,7 +29620,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Wiktionary Français",
+    "s": "Wiktionary (Français)",
     "d": "fr.wiktionary.org",
     "t": "fr.wiktionary",
     "ts": [
@@ -29637,7 +29637,7 @@
     ]
   },
   {
-    "s": "Food Standards Agency - Food Hygiene Ratings",
+    "s": "Food Standards Agency (Food Hygiene Ratings)",
     "d": "ratings.food.gov.uk",
     "t": "fsarating",
     "u": "https://ratings.food.gov.uk/business-search?business-name-search={{{s}}}&business_type=-1&country_or_la=all&hygiene_rating=all&range=Equal&hygiene_status=all",
@@ -29661,7 +29661,7 @@
     "sc": "TV"
   },
   {
-    "s": "Factual News Search",
+    "s": "Factual News",
     "d": "factualsearch.news",
     "t": "fs",
     "u": "https://factualsearch.news/#/&gsc.q={{{s}}}",
@@ -29888,7 +29888,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "FilmUP.com",
+    "s": "FilmUP",
     "d": "filmup.com",
     "t": "fup",
     "u": "https://filmup.com/cgi-bin/search.cgi?ps=10&fmt=long&sy=0&q={{{s}}}",
@@ -30110,7 +30110,7 @@
     "sc": "Audio"
   },
   {
-    "s": "FZ Sweden (Kagi Search)",
+    "s": "FZ Sweden (Kagi)",
     "d": "kagi.com",
     "ad": "fz.se",
     "t": "fz",
@@ -30119,7 +30119,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Google Search 100 English Results",
+    "s": "Google (100 English Results)",
     "d": "www.google.com",
     "t": "g100en",
     "u": "https://www.google.com/search?q={{{s}}}&tbo=1&num=100&lr=lang_en",
@@ -30127,7 +30127,7 @@
     "sc": "Search"
   },
   {
-    "s": "Google Search 100 Results",
+    "s": "Google (100 Results)",
     "d": "www.google.com",
     "t": "g100",
     "u": "https://www.google.com/search?q={{{s}}}&tbo=1&num=100",
@@ -30146,7 +30146,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Latest",
+    "s": "Google (Latest)",
     "d": "www.google.com",
     "t": "glatest",
     "u": "https://www.google.com/search?q={{{s}}}&tbs=rltm:1",
@@ -30173,7 +30173,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google ( Past 2 Years)",
+    "s": "Google (Past 2 Years)",
     "d": "www.google.com",
     "t": "g2year",
     "u": "https://www.google.com/search?tbs=qdr:y2&q={{{s}}}&safe=off&ie=utf-8&oe=utf-8",
@@ -30181,7 +30181,7 @@
     "sc": "Google"
   },
   {
-    "s": "games4you.rs",
+    "s": "Games4You",
     "d": "games4you.rs",
     "t": "g4y",
     "u": "https://games4you.rs/search-glavni?search_api_views_fulltext={{{s}}}",
@@ -30213,7 +30213,7 @@
     "sc": "Social"
   },
   {
-    "s": "Google Accessible",
+    "s": "Google (Accessible)",
     "d": "www.google.com",
     "t": "gaccess",
     "u": "https://www.google.com/cse?ie=UTF-8&cx=000183394137052953072:zc1orsc6mbq&q={{{s}}}t&btnG=Search",
@@ -30269,7 +30269,7 @@
     "sc": "Google"
   },
   {
-    "s": "Fóclair.ie New English-Irish Dictionary",
+    "s": "Foclóir (Spellcheck)",
     "d": "www.focloir.ie",
     "t": "gael",
     "u": "https://www.focloir.ie/en/spellcheck/ei/?q={{{s}}}",
@@ -30277,7 +30277,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Google Translate (ga2en)",
+    "s": "Google Translate (ga-en)",
     "d": "translate.google.com",
     "t": "gaen",
     "u": "https://translate.google.com/#ga/en/{{{s}}}",
@@ -30309,7 +30309,7 @@
     "sc": "Events"
   },
   {
-    "s": "Google Australia",
+    "s": "Google (Australia)",
     "d": "www.google.com.au",
     "t": "ga",
     "ts": [
@@ -30339,7 +30339,7 @@
     "sc": "Social"
   },
   {
-    "s": "Galaxus.ch",
+    "s": "Galaxus",
     "d": "www.galaxus.ch",
     "t": "galaxus",
     "u": "https://www.galaxus.ch/de/Search?searchSectors=0&q={{{s}}}",
@@ -30347,7 +30347,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "google alerts",
+    "s": "Google Alerts",
     "d": "www.google.com",
     "t": "galerts",
     "u": "https://www.google.com/alerts?q={{{s}}}"
@@ -30474,7 +30474,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "GameRankings.com",
+    "s": "GameRankings",
     "d": "www.gamerankings.com",
     "t": "gamerankings",
     "u": "https://www.gamerankings.com/browse.html?search={{{s}}}",
@@ -30586,7 +30586,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Kobo UK",
+    "s": "Kobo (United Kingdom)",
     "d": "www.kobo.com",
     "t": "kobouk",
     "u": "https://www.kobo.com/gb/en/search?Query={{{s}}}",
@@ -30605,7 +30605,7 @@
     "sc": "Online"
   },
   {
-    "s": "Gandi.net",
+    "s": "Gandi",
     "d": "www.gandi.net",
     "t": "gandi",
     "u": "https://www.gandi.net/domain/suggest?domain_list={{{s}}}",
@@ -30621,7 +30621,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Google Play Store",
+    "s": "Google Play",
     "d": "play.google.com",
     "t": "gapp",
     "ts": [
@@ -30652,7 +30652,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Garden-en.com",
+    "s": "Garden (en)",
     "d": "www.garden-en.com",
     "t": "garden",
     "u": "https://www.garden-en.com/s/en/?type=sfd&query={{{s}}}",
@@ -30660,7 +30660,7 @@
     "sc": "Images"
   },
   {
-    "s": "Glosbe (Arabic-English)",
+    "s": "Glosbe (ar-en)",
     "d": "glosbe.com",
     "t": "garen",
     "u": "https://glosbe.com/ar/en/{{{s}}}",
@@ -30716,7 +30716,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Austria",
+    "s": "Google (Austria)",
     "d": "www.google.at",
     "t": "g.at",
     "u": "https://www.google.at/#q={{{s}}}",
@@ -30768,7 +30768,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Gmail by account",
+    "s": "Gmail (Account)",
     "d": "mail.google.com",
     "t": "gba",
     "u": "https://mail.google.com/mail/u/{{{s}}}",
@@ -30800,7 +30800,7 @@
     "sc": "Google"
   },
   {
-    "s": "Glosbe (eneo)",
+    "s": "Glosbe (en-eo)",
     "d": "en.glosbe.com",
     "t": "gbeo",
     "u": "https://en.glosbe.com/en/eo/{{{s}}}",
@@ -30816,7 +30816,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Google BG",
+    "s": "Google (Bulgaria)",
     "d": "www.google.bg",
     "t": "гбг",
     "ts": [
@@ -30878,7 +30878,7 @@
     "sc": "Reference"
   },
   {
-    "s": "XE (gbp2brl)",
+    "s": "XE (GBP-BRL)",
     "d": "www.xe.com",
     "t": "gbp2brl",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=GBP&To=BRL",
@@ -30886,7 +30886,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "xe.com",
+    "s": "XE (GBP-EUR)",
     "d": "www.xe.com",
     "t": "gbp2eur",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=GBP&To=EUR",
@@ -30894,7 +30894,7 @@
     "sc": "Tools"
   },
   {
-    "s": "XE (gbp2nzd)",
+    "s": "XE (GBP-NZD)",
     "d": "www.xe.com",
     "t": "gbp2nzd",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=GBP&To=NZD",
@@ -30902,7 +30902,7 @@
     "sc": "Tools"
   },
   {
-    "s": "XE (gbp2usd)",
+    "s": "XE (GBP-USD)",
     "d": "www.xe.com",
     "t": "gbp2usd",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=GBP&To=USD",
@@ -31001,7 +31001,7 @@
     "sc": "Search"
   },
   {
-    "s": "Google CL",
+    "s": "Google (CL)",
     "d": "www.google.cl",
     "t": "gcl",
     "u": "https://www.google.cl/search?q={{{s}}}&meta=&aq=f&aqi=g10&aql=&gs_rfai=",
@@ -31076,7 +31076,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Google Cuba",
+    "s": "Google (Cuba)",
     "d": "www.google.com",
     "t": "gcu",
     "u": "https://www.google.com/search?q={{{s}}}&tbs=ctr:countryCU&cr=countryCU",
@@ -31116,7 +31116,7 @@
     "sc": "Google"
   },
   {
-    "s": "GDB Manual (Kagi Search)",
+    "s": "GDB Manual (Kagi)",
     "d": "kagi.com",
     "ad": "sourceware.org/gdb/current/onlinedocs/gdb/",
     "t": "gdb",
@@ -31125,7 +31125,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Godot Engine Documentation",
+    "s": "Godot (Latest)",
     "d": "docs.godotengine.org",
     "t": "gdd",
     "u": "https://docs.godotengine.org/en/latest/search.html?q={{{s}}}&check_keywords=yes&area=default",
@@ -31133,7 +31133,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Google Translate de->en",
+    "s": "Google Translate (de-en)",
     "d": "translate.google.com",
     "t": "gdeen",
     "u": "https://translate.google.com/#de/en/{{{s}}}",
@@ -31141,7 +31141,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google define",
+    "s": "Google (Define)",
     "d": "www.google.com",
     "t": "gdef",
     "u": "https://www.google.com/search?hl=en&q=define+{{{s}}}",
@@ -31149,7 +31149,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google DE",
+    "s": "Google (DE)",
     "d": "www.google.de",
     "t": "gde",
     "u": "https://www.google.de/search?q={{{s}}}&meta=&aq=f&aqi=g10&aql=&gs_rfai=",
@@ -31157,7 +31157,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Germany",
+    "s": "Google (Germany)",
     "d": "www.google.de",
     "t": "g.de",
     "u": "https://www.google.de/#q={{{s}}}",
@@ -31173,7 +31173,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Google Developers",
+    "s": "Google (Developers)",
     "d": "developers.google.com",
     "t": "gdevs",
     "u": "https://developers.google.com/s/results/?q={{{s}}}",
@@ -31200,7 +31200,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Google Safe Browsing Diagnostic Page",
+    "s": "Google (Safe Browsing Diagnostic)",
     "d": "google.com",
     "t": "gdiag",
     "u": "https://google.com/safebrowsing/diagnostic?site={{{s}}}",
@@ -31224,7 +31224,7 @@
     "sc": "Academic"
   },
   {
-    "s": "高德地图",
+    "s": "Amap",
     "d": "ditu.amap.com",
     "t": "gdmaps",
     "u": "https://ditu.amap.com/search?query={{{s}}}",
@@ -31278,7 +31278,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Google Docs viewer",
+    "s": "Google Docs (Viewer)",
     "d": "docs.google.com",
     "t": "gdv",
     "ts": [
@@ -31298,7 +31298,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "Gbase.com",
+    "s": "Gbase",
     "d": "www.gbase.com",
     "t": "gear",
     "u": "https://www.gbase.com/gear?q={{{s}}}",
@@ -31381,7 +31381,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Google Translate German to English",
+    "s": "Google Translate (ge-en)",
     "d": "translate.google.com",
     "t": "geen",
     "u": "https://translate.google.com/#ge/en/{{{s}}}",
@@ -31408,7 +31408,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Google Encrypted",
+    "s": "Google (Encrypted)",
     "d": "google.com",
     "t": "ge",
     "u": "https://google.com/#q={{{s}}}",
@@ -31487,7 +31487,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "GenBank Database",
+    "s": "GenBank",
     "d": "www.ncbi.nlm.nih.gov",
     "t": "genbank",
     "u": "https://www.ncbi.nlm.nih.gov/nuccore/?term={{{s}}}",
@@ -31591,7 +31591,7 @@
     "sc": "Music (Lyrics)"
   },
   {
-    "s": "Glosbe (enhu)",
+    "s": "Glosbe (en-hu)",
     "d": "en.glosbe.com",
     "t": "genhu",
     "u": "https://en.glosbe.com/en/hu/{{{s}}}",
@@ -31638,7 +31638,7 @@
     "sc": "Blogs (intl)"
   },
   {
-    "s": "Geocaching.com",
+    "s": "Geocaching",
     "d": "www.geocaching.com",
     "t": "geocache",
     "ts": [
@@ -31705,7 +31705,7 @@
     "sc": "Downloads"
   },
   {
-    "s": "Zeno.org - Georges 1913",
+    "s": "zeno.org (Georges 1913)",
     "d": "www.zeno.org",
     "t": "georges",
     "u": "https://www.zeno.org/Zeno/0/Suche?q={{{s}}}&k=Georges-1913",
@@ -31745,7 +31745,7 @@
     "sc": "Topical"
   },
   {
-    "s": "Getchu.com",
+    "s": "Getchu",
     "d": "www.getchu.com",
     "t": "getchu",
     "u": "https://www.getchu.com/php/nsearch.phtml?search_keyword={{{s}}}",
@@ -31753,7 +31753,7 @@
     "sc": "Online"
   },
   {
-    "s": "glosbe (estonian - finnish)",
+    "s": "Glosbe (et-fi)",
     "d": "glosbe.com",
     "t": "getfi",
     "u": "https://glosbe.com/et/fi/{{{s}}}",
@@ -31807,7 +31807,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Persian Google",
+    "s": "Google (Persian)",
     "d": "www.google.com",
     "t": "gfa",
     "u": "https://www.google.com/search?hl=fa&q={{{s}}}",
@@ -31831,7 +31831,7 @@
     "sc": "General"
   },
   {
-    "s": "greatfirewallofchina.org",
+    "s": "Great Firewall of China",
     "d": "greatfirewallofchina.org",
     "t": "gfc",
     "u": "https://greatfirewallofchina.org/index.php?siteurl={{{s}}}",
@@ -31878,7 +31878,7 @@
     "sc": "Business"
   },
   {
-    "s": "glosbe (finnish - estonian)",
+    "s": "Glosbe (fi-et)",
     "d": "glosbe.com",
     "t": "gfiet",
     "u": "https://glosbe.com/fi/et/{{{s}}}",
@@ -31967,7 +31967,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "/r/GfycatDepot",
+    "s": "Reddit (/r/GfycatDepot)",
     "d": "www.reddit.com",
     "t": "gfycatdepot",
     "u": "https://www.reddit.com/r/GfycatDepot/search?q={{{s}}}&restrict_sr=on&sort=relevance&t=all",
@@ -32045,7 +32045,7 @@
     "u": "https://www.google.com/search?q={{{s}}}"
   },
   {
-    "s": "Goo Jisho",
+    "s": "goo辞書",
     "d": "dictionary.goo.ne.jp",
     "t": "gooj",
     "u": "https://dictionary.goo.ne.jp/srch/all/{{{s}}}/m0u/",
@@ -32064,7 +32064,7 @@
     "sc": "Google"
   },
   {
-    "s": "gulden röttger rechtsanwälte - wir schätzen die Kraft achtsamer Kommunikation in Wort und Bild",
+    "s": "Gulden Röttger Rechtsanwälte",
     "d": "ggr-law.com",
     "t": "ggrlaw",
     "u": "https://ggr-law.com/suche/?id=1843&tx_kesearch_pi1[sword]={{{s}}}",
@@ -32100,7 +32100,7 @@
     "sc": "Programming"
   },
   {
-    "s": "GitHub User",
+    "s": "GitHub (User)",
     "d": "github.com",
     "t": "ghus",
     "u": "https://github.com/{{{s}}}/",
@@ -32108,7 +32108,7 @@
     "sc": "Programming"
   },
   {
-    "s": "GitHub User Search",
+    "s": "GitHub (Users)",
     "d": "github.com",
     "t": "ghuser",
     "u": "https://github.com/search?type=Users&q={{{s}}}",
@@ -32116,7 +32116,7 @@
     "sc": "Programming"
   },
   {
-    "s": "GitHub Stars",
+    "s": "GitHub (Stars)",
     "d": "github.com",
     "t": "githubstars",
     "u": "https://github.com/stars?q={{{s}}}",
@@ -32124,7 +32124,7 @@
     "sc": "Programming"
   },
   {
-    "s": "GitHub Notifications",
+    "s": "GitHub (Notifications)",
     "d": "github.com",
     "t": "ghn",
     "u": "https://github.com/notifications?query={{{s}}}",
@@ -32136,7 +32136,7 @@
     ]
   },
   {
-    "s": "GitHub Code",
+    "s": "GitHub (Code)",
     "d": "github.com",
     "t": "ghc",
     "ts": [
@@ -32147,7 +32147,7 @@
     "sc": "Programming"
   },
   {
-    "s": "GitHub JavaScript Code",
+    "s": "GitHub (JavaScript)",
     "d": "github.com",
     "t": "ghjs",
     "u": "https://github.com/search?l=JavaScript&o=desc&q={{{s}}}&s=indexed&type=Code",
@@ -32155,7 +32155,7 @@
     "sc": "Languages (javascript)"
   },
   {
-    "s": "GitHub Private Search",
+    "s": "GitHub (Private)",
     "d": "github.com",
     "t": "ghp",
     "u": "https://github.com/search?q=is:private+{{{s}}}",
@@ -32163,7 +32163,7 @@
     "sc": "Downloads (code)"
   },
   {
-    "s": "GitHub Repo",
+    "s": "GitHub (Repo)",
     "d": "github.com",
     "t": "ghrepo",
     "ts": [
@@ -32177,7 +32177,7 @@
     ]
   },
   {
-    "s": "GitHub Trending",
+    "s": "GitHub (Trending)",
     "d": "github.com",
     "t": "ght",
     "u": "https://github.com/trending/{{{s}}}",
@@ -32185,7 +32185,7 @@
     "sc": "Programming"
   },
   {
-    "s": "GitHub Topic",
+    "s": "GitHub (Topic)",
     "d": "github.com",
     "t": "ghtopic",
     "u": "https://github.com/topic/{{{s}}}",
@@ -32234,7 +32234,7 @@
     "sc": "Programming"
   },
   {
-    "s": "EIPs GitHub Issues",
+    "s": "GitHub (Ethereum EIPs)",
     "d": "github.com",
     "t": "eips",
     "u": "https://github.com/ethereum/EIPs/issues?q={{{s}}}",
@@ -32250,7 +32250,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Geizhals (de)",
+    "s": "Geizhals (DE)",
     "d": "geizhals.de",
     "t": "ghde",
     "u": "https://geizhals.de/?fs={{{s}}}",
@@ -32274,7 +32274,7 @@
     "sc": "Search"
   },
   {
-    "s": "Google Past Hour Search",
+    "s": "Google (Past Hour)",
     "d": "www.google.com",
     "t": "ghour",
     "u": "https://www.google.com/search?q={{{s}}}&tbs=qdr:h",
@@ -32282,7 +32282,7 @@
     "sc": "Google"
   },
   {
-    "s": "Glosbe (huen)",
+    "s": "Glosbe (hu-en)",
     "d": "en.glosbe.com",
     "t": "ghuen",
     "u": "https://en.glosbe.com/hu/en/{{{s}}}",
@@ -32333,7 +32333,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Google Images Australia",
+    "s": "Google Images (Australia)",
     "d": "www.google.com.au",
     "t": "giau",
     "u": "https://www.google.com.au/search?tbm=isch&q={{{s}}}&tbs=imgo:1",
@@ -32365,7 +32365,7 @@
     "sc": "Images"
   },
   {
-    "s": "Google Images Classic",
+    "s": "Google Images (Classic)",
     "d": "www.google.com",
     "t": "gic",
     "u": "https://www.google.com/search?q={{{s}}}&tbm=isch&sout=1",
@@ -32413,7 +32413,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Google: I'm Feeling Lucky",
+    "s": "Google (I'm Feeling Lucky)",
     "d": "google.com",
     "t": "gifl",
     "u": "https://google.com/search?btnI=1&q={{{s}}}",
@@ -32464,7 +32464,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Google Images",
+    "s": "Google (Images)",
     "d": "google.com",
     "t": "gi",
     "ts": [
@@ -32495,7 +32495,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Israel",
+    "s": "Google (Israel)",
     "d": "www.google.co.il",
     "t": "gil",
     "ts": [
@@ -32517,7 +32517,7 @@
     "sc": "Google"
   },
   {
-    "s": "Glosbe (itpl)",
+    "s": "Glosbe (it-pl)",
     "d": "glosbe.com",
     "t": "gip",
     "u": "https://glosbe.com/it/pl/{{{s}}}",
@@ -32560,7 +32560,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Image Search",
+    "s": "Google Images",
     "d": "www.google.com",
     "t": "gis",
     "u": "https://www.google.com/search?site=imghp&tbm=isch&q={{{s}}}",
@@ -32579,7 +32579,7 @@
     "sc": "Programming"
   },
   {
-    "s": "libgit2 documentation",
+    "s": "libgit2 (Docs)",
     "d": "libgit2.github.io",
     "t": "git2",
     "u": "https://libgit2.github.io/libgit2/#HEAD/search/{{{s}}}",
@@ -32606,7 +32606,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Google Maps (French)",
+    "s": "Google Maps (France, Directions)",
     "d": "www.google.fr",
     "t": "giti",
     "u": "https://www.google.fr/maps/dir/{{{s}}}",
@@ -32625,7 +32625,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Google IT",
+    "s": "Google (Italy)",
     "d": "www.google.it",
     "t": "gitl",
     "u": "https://www.google.it/search?q={{{s}}}&meta=&aq=f&aqi=g10&aql=&gs_rfai=",
@@ -32633,7 +32633,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Images UK",
+    "s": "Google Images (UK)",
     "d": "www.google.co.uk",
     "t": "giuk",
     "u": "https://www.google.co.uk/search?tbm=isch&q={{{s}}}&tbs=imgo:1",
@@ -32649,7 +32649,7 @@
     "sc": "Search"
   },
   {
-    "s": "Gizmodo en español",
+    "s": "Gizmodo (Spanish)",
     "d": "es.gizmodo.com",
     "t": "gizes",
     "u": "https://es.gizmodo.com/search?q={{{s}}}",
@@ -32684,7 +32684,7 @@
     "sc": "Services"
   },
   {
-    "s": "Google Japan",
+    "s": "Google (Japan)",
     "d": "www.google.co.jp",
     "t": "gj",
     "ts": [
@@ -32703,7 +32703,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google KR",
+    "s": "Google (KR)",
     "d": "www.google.co.kr",
     "t": "gkr",
     "u": "https://www.google.co.kr/search?q={{{s}}}&meta=&aq=f&aqi=g10&aql=&gs_rfai=",
@@ -32722,7 +32722,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "Google (link)",
+    "s": "Google (Link)",
     "d": "www.google.com",
     "t": "glink",
     "u": "https://www.google.com/search?as_lq={{{s}}}&hl=en&btnG=Search",
@@ -32792,7 +32792,7 @@
     "sc": "Online"
   },
   {
-    "s": "GloboEsporte.com",
+    "s": "GloboEsporte",
     "d": "globoesporte.globo.com",
     "t": "globoesporte",
     "u": "https://globoesporte.globo.com/busca/?q={{{s}}}",
@@ -32819,7 +32819,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Gloria.tv",
+    "s": "Gloria",
     "d": "gloria.tv",
     "t": "gloriatv",
     "u": "https://gloria.tv/?search={{{s}}}",
@@ -32827,7 +32827,7 @@
     "sc": "Video"
   },
   {
-    "s": "Interglot EN -> ES",
+    "s": "Interglot (en-es)",
     "d": "www.interglot.com",
     "t": "glotenes",
     "u": "https://www.interglot.com/dictionary/en/es/search?q={{{s}}}",
@@ -32835,7 +32835,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Interglot",
+    "s": "Interglot (en-nl)",
     "d": "www.interglot.com",
     "t": "glotennl",
     "u": "https://www.interglot.com/dictionary/en/nl/search?q={{{s}}}",
@@ -32843,7 +32843,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Interglot ES -> EN",
+    "s": "Interglot (es-en)",
     "d": "www.interglot.com",
     "t": "glotesen",
     "u": "https://www.interglot.com/dictionary/es/en/search?q={{{s}}}",
@@ -32996,7 +32996,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google Maps Austria",
+    "s": "Google Maps (Austria)",
     "d": "www.google.at",
     "t": "gmat",
     "u": "https://www.google.at/maps/search/{{{s}}}",
@@ -33004,7 +33004,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Maps Australia",
+    "s": "Google Maps (Australia)",
     "d": "www.google.com.au",
     "t": "gmau",
     "u": "https://www.google.com.au/maps/search/{{{s}}}",
@@ -33020,7 +33020,7 @@
     "sc": "Maps"
   },
   {
-    "s": "Google Maps Classic",
+    "s": "Google Maps (Classic)",
     "d": "www.google.com",
     "t": "gmc",
     "u": "https://www.google.com/maps?q={{{s}}}&output=classic",
@@ -33028,7 +33028,7 @@
     "sc": "Maps"
   },
   {
-    "s": "Google Maps Chile",
+    "s": "Google Maps (Chile)",
     "d": "www.google.cl",
     "t": "gmcl",
     "u": "https://www.google.cl/maps/place/{{{s}}}",
@@ -33036,7 +33036,7 @@
     "sc": "Maps"
   },
   {
-    "s": "Google Maps DE",
+    "s": "Google Maps (DE)",
     "d": "www.google.de",
     "t": "gmde",
     "ts": [
@@ -33048,7 +33048,7 @@
     "sc": "Maps"
   },
   {
-    "s": "Google Maps Directions With Two Addresses",
+    "s": "Google Maps (Directions)",
     "d": "www.google.com",
     "t": "gmd",
     "ts": [
@@ -33059,7 +33059,7 @@
     "sc": "Maps"
   },
   {
-    "s": "Google Maps Directions",
+    "s": "Google Maps (Directions To)",
     "d": "www.google.com",
     "t": "gmdir",
     "u": "https://www.google.com/maps/dir//{{{s}}}",
@@ -33094,7 +33094,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google Maps Israel",
+    "s": "Google Maps (Israel)",
     "d": "www.google.co.il",
     "t": "gmil",
     "u": "https://www.google.co.il/maps/search/{{{s}}}/?hl=iw",
@@ -33102,7 +33102,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Maps (it)",
+    "s": "Google Maps (Italy)",
     "d": "www.google.it",
     "t": "gmit",
     "u": "https://www.google.it/maps?q={{{s}}}",
@@ -33110,7 +33110,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Maps JP",
+    "s": "Google Maps (Japan)",
     "d": "www.google.co.jp",
     "t": "gmjp",
     "u": "https://www.google.co.jp/maps/place/{{{s}}}",
@@ -33126,7 +33126,7 @@
     "sc": "Books"
   },
   {
-    "s": "Google (mobile site viewer)",
+    "s": "Google (Mobile)",
     "d": "www.google.com",
     "t": "gmob",
     "u": "https://www.google.com/gwt/x?u={{{s}}}",
@@ -33166,7 +33166,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Google Maps SI",
+    "s": "Google Maps (SI)",
     "d": "www.google.si",
     "t": "gmsi",
     "u": "https://www.google.si/maps/search/{{{s}}}/",
@@ -33174,7 +33174,7 @@
     "sc": "Maps"
   },
   {
-    "s": "Google map (Taiwan)",
+    "s": "Google Maps (Taiwan)",
     "d": "www.google.com.tw",
     "t": "gmtw",
     "u": "https://www.google.com.tw/maps?hl=zh-TW&q={{{s}}}",
@@ -33182,7 +33182,7 @@
     "sc": "Maps"
   },
   {
-    "s": "Google Maps (uk)",
+    "s": "Google Maps (UK)",
     "d": "www.google.co.uk",
     "t": "gmuk",
     "u": "https://www.google.co.uk/maps?q={{{s}}}",
@@ -33206,7 +33206,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google News Austria",
+    "s": "Google News (Austria)",
     "d": "www.google.at",
     "t": "gnat",
     "u": "https://www.google.at/#q={{{s}}}&tbm=nws",
@@ -33214,7 +33214,7 @@
     "sc": "International"
   },
   {
-    "s": "Google News Australia",
+    "s": "Google News (Australia)",
     "d": "news.google.com",
     "t": "gnau",
     "u": "https://news.google.com/search?q={{{s}}}&hl=en-AU&gl=AU&ceid=AU:en",
@@ -33230,7 +33230,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Bibleserver Gute Nachricht Bibel",
+    "s": "BibleServer (GNB)",
     "d": "www.bibleserver.com",
     "t": "gnb",
     "u": "https://www.bibleserver.com/search/GNB/{{{s}}}/1",
@@ -33238,7 +33238,7 @@
     "sc": "Search"
   },
   {
-    "s": "Google news België",
+    "s": "Google News (Belgium)",
     "d": "news.google.com",
     "t": "gnbe",
     "u": "https://news.google.com/news/search/section/q/{{{s}}}/?gl=BE&ned=nl_be&hl=nl",
@@ -33254,7 +33254,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "Google No Country Redirect",
+    "s": "Google (No Country Redirect)",
     "d": "www.google.com",
     "t": "gncr",
     "u": "https://www.google.com/search?gws_rd=cr&gl=us&hl=en&num=20&q={{{s}}}",
@@ -33270,7 +33270,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Google News Germany",
+    "s": "Google News (Germany)",
     "d": "news.google.com",
     "t": "gnde",
     "u": "https://news.google.com/news/search/section/q/{{{s}}}?hl=de&ned=de",
@@ -33278,7 +33278,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "Google News Spain",
+    "s": "Google News (Spain)",
     "d": "www.google.com",
     "t": "gns",
     "ts": [
@@ -33289,7 +33289,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "Google News French",
+    "s": "Google News (France)",
     "d": "www.google.fr",
     "t": "gnfr",
     "u": "https://www.google.fr/search?aq=f&hl=fr&gl=fr&tbm=nws&btnmeta_news_search=1&q={{{s}}}",
@@ -33309,7 +33309,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "Google News Italian",
+    "s": "Google News (Italy)",
     "d": "www.google.it",
     "t": "gnit",
     "u": "https://www.google.it/search?q={{{s}}}&hl=it&tbm=nws",
@@ -33333,7 +33333,7 @@
     "sc": "Newspaper (intl)"
   },
   {
-    "s": "Google News (mobile)",
+    "s": "Google News (Mobile)",
     "d": "www.google.com",
     "t": "gnm",
     "u": "https://www.google.com/m/search?site=news&q={{{s}}}",
@@ -33341,7 +33341,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google News Nederland",
+    "s": "Google News (Netherlands)",
     "d": "www.google.com",
     "t": "gnnl",
     "u": "https://www.google.com/search?hl=nl&gl=nl&tbm=nws&q={{{s}}}",
@@ -33389,7 +33389,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Google News RU",
+    "s": "Google News (Russia)",
     "d": "www.google.ru",
     "t": "gnru",
     "u": "https://www.google.ru/search?q={{{s}}}&tbm=nws&cad=h",
@@ -33397,7 +33397,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "Google News Sweden",
+    "s": "Google News (Sweden)",
     "d": "news.google.com",
     "t": "gnse",
     "u": "https://news.google.com/search?q={{{s}}}&hl=sv&gl=SE&ceid=SE:sv",
@@ -33413,7 +33413,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Google News UK",
+    "s": "Google News (UK)",
     "d": "www.google.co.uk",
     "t": "gnuk",
     "u": "https://www.google.co.uk/search?hl=en&gl=uk&tbm=nws&authuser=0&q={{{s}}}",
@@ -33453,7 +33453,7 @@
     "sc": "Comics"
   },
   {
-    "s": "Gocompare.com",
+    "s": "GoCompare",
     "d": "www.gocompare.com",
     "t": "gocompare",
     "u": "https://www.gocompare.com/searchresults/?q={{{s}}}",
@@ -33501,7 +33501,7 @@
     "sc": "Languages (go)"
   },
   {
-    "s": "Godot Docs",
+    "s": "Godot (Stable)",
     "d": "docs.godotengine.org",
     "t": "godot",
     "u": "https://docs.godotengine.org/en/stable/search.html?q={{{s}}}&check_keywords=yes&area=default",
@@ -33565,7 +33565,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "GOG.com",
+    "s": "GOG",
     "d": "www.gog.com",
     "t": "gog",
     "u": "https://www.gog.com/games?query={{{s}}}",
@@ -33592,7 +33592,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "gokifu.com",
+    "s": "Gokifu",
     "d": "gokifu.com",
     "t": "gokifu",
     "u": "https://gokifu.com/index.php?q={{{s}}}",
@@ -33612,7 +33612,7 @@
     "sc": "Languages (go)"
   },
   {
-    "s": "golden.com",
+    "s": "Golden",
     "d": "golden.com",
     "t": "golden",
     "u": "https://golden.com/search/{{{s}}}",
@@ -33636,7 +33636,7 @@
     "sc": "Reference (science)"
   },
   {
-    "s": "Golem.de",
+    "s": "Golem",
     "d": "suche.golem.de",
     "t": "golem",
     "u": "https://suche.golem.de/search.php?l=10&q={{{s}}}",
@@ -33716,7 +33716,7 @@
     "sc": "Books"
   },
   {
-    "s": "Goodreads Lists",
+    "s": "Goodreads (Lists)",
     "d": "www.goodreads.com",
     "t": "goodreadslist",
     "u": "https://www.goodreads.com/search?search_type=lists&q={{{s}}}",
@@ -33724,7 +33724,7 @@
     "sc": "Books"
   },
   {
-    "s": "Google Belgium",
+    "s": "Google (Belgium)",
     "d": "www.google.be",
     "t": "googlebe",
     "u": "https://www.google.be/#q={{{s}}}",
@@ -33751,7 +33751,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google France",
+    "s": "Google (France)",
     "d": "www.google.fr",
     "t": "googlefr",
     "u": "https://www.google.fr/#q={{{s}}}",
@@ -33775,7 +33775,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Poland",
+    "s": "Google (Poland)",
     "d": "www.google.pl",
     "t": "googlepl",
     "u": "https://www.google.pl/#q={{{s}}}",
@@ -33826,7 +33826,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "Google Turkey",
+    "s": "Google (Turkey)",
     "d": "www.google.com.tr",
     "t": "googletr",
     "u": "https://www.google.com.tr/search?q={{{s}}}",
@@ -33834,7 +33834,7 @@
     "sc": "General"
   },
   {
-    "s": "Google UK",
+    "s": "Google (UK)",
     "d": "www.google.co.uk",
     "t": "guk",
     "ts": [
@@ -33854,7 +33854,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Goo国語辞典検索",
+    "s": "goo国語辞典",
     "d": "dictionary.goo.ne.jp",
     "t": "gookokugo",
     "u": "https://dictionary.goo.ne.jp/srch/jn/{{{s}}}/m0u/",
@@ -33950,7 +33950,7 @@
     "sc": "Companies"
   },
   {
-    "s": "gothere.sg",
+    "s": "GoThere",
     "d": "gothere.sg",
     "t": "gothere",
     "u": "https://gothere.sg/maps#q:{{{s}}}",
@@ -34039,7 +34039,7 @@
     "sc": "Online"
   },
   {
-    "s": "Greenpeace Africa",
+    "s": "Greenpeace (Africa)",
     "d": "www.greenpeace.org",
     "t": "gpafrica",
     "u": "https://www.greenpeace.org/africa/en/Search-results/?all={{{s}}}",
@@ -34047,7 +34047,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Google Play Apps",
+    "s": "Google Play (Apps)",
     "d": "play.google.com",
     "t": "gpa",
     "u": "https://play.google.com/store/search?q={{{s}}}&c=apps",
@@ -34066,7 +34066,7 @@
     "sc": "Law"
   },
   {
-    "s": "Greenpeace Australia",
+    "s": "Greenpeace (Australia)",
     "d": "www.greenpeace.org",
     "t": "gpau",
     "u": "https://www.greenpeace.org/australia/en/System-templates/Site-Settings-Pages/Search/?all={{{s}}}",
@@ -34074,7 +34074,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Google Play Books",
+    "s": "Google Play (Books)",
     "d": "play.google.com",
     "t": "gpb",
     "u": "https://play.google.com/store/search?c=books&q={{{s}}}",
@@ -34082,7 +34082,7 @@
     "sc": "Online"
   },
   {
-    "s": "Greenpeace Canada (French)",
+    "s": "Greenpeace (Canada French)",
     "d": "www.greenpeace.org",
     "t": "gpcanfr",
     "u": "https://www.greenpeace.org/canada/fr/System-templates/Site-Settings-Pages/Recherche/?all={{{s}}}",
@@ -34090,7 +34090,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Greenpeace Canada",
+    "s": "Greenpeace (Canada)",
     "d": "www.greenpeace.org",
     "t": "gpcan",
     "u": "https://www.greenpeace.org/canada/en/System-templates/Site-Settings-Pages/Search/?all={{{s}}}",
@@ -34106,7 +34106,7 @@
     "sc": "Law"
   },
   {
-    "s": "gpodder.net",
+    "s": "gPodder",
     "d": "gpodder.net",
     "t": "gpdr",
     "u": "https://gpodder.net/search/?q={{{s}}}",
@@ -34114,7 +34114,7 @@
     "sc": "Broadcast"
   },
   {
-    "s": "Greenpeace East Asia",
+    "s": "Greenpeace (East Asia)",
     "d": "www.greenpeace.org",
     "t": "gpea",
     "u": "https://www.greenpeace.org/eastasia/system-templates/search-results/?all={{{s}}}",
@@ -34138,7 +34138,7 @@
     "sc": "Online"
   },
   {
-    "s": "Greenpeace EU Unit",
+    "s": "Greenpeace (EU Unit)",
     "d": "www.greenpeace.org",
     "t": "gpeu",
     "u": "https://www.greenpeace.org/eu-unit/en/System-templates/such-resultate/?all={{{s}}}",
@@ -34146,7 +34146,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "OpenPGP Key Search",
+    "s": "OpenPGP Key",
     "d": "keys.openpgp.org",
     "t": "gpg",
     "u": "https://keys.openpgp.org/search?q={{{s}}}",
@@ -34178,7 +34178,7 @@
     "sc": "Images"
   },
   {
-    "s": "Glosbe (plit)",
+    "s": "Glosbe (pl-it)",
     "d": "glosbe.com",
     "t": "gpi",
     "u": "https://glosbe.com/pl/it/{{{s}}}",
@@ -34186,7 +34186,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Greenpeace India",
+    "s": "Greenpeace (India)",
     "d": "www.greenpeace.org",
     "t": "gpindia",
     "u": "https://www.greenpeace.org/india/en/System-templates/Search-results/?all={{{s}}}",
@@ -34202,7 +34202,7 @@
     "sc": "Google"
   },
   {
-    "s": "Greenpeace New Zealand",
+    "s": "Greenpeace (New Zealand)",
     "d": "www.greenpeace.org",
     "t": "gpnz",
     "u": "https://www.greenpeace.org/new-zealand/en/System-templates/Search-results/?all={{{s}}}",
@@ -34210,7 +34210,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Greenpeace Philippines",
+    "s": "Greenpeace (Philippines)",
     "d": "www.greenpeace.org",
     "t": "gpphilip",
     "u": "https://www.greenpeace.org/seasia/ph/System-templates/Search-results/?all={{{s}}}",
@@ -34226,7 +34226,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Greenpeace Southeast Asia",
+    "s": "Greenpeace (Southeast Asia)",
     "d": "www.greenpeace.org",
     "t": "gpseasia",
     "u": "https://www.greenpeace.org/seasia/System-templates/Search-results/?all={{{s}}}",
@@ -34234,7 +34234,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Google Product Search",
+    "s": "Google (Products)",
     "d": "www.google.com",
     "t": "gps",
     "u": "https://www.google.com/search?hl=en&tbm=shop&q={{{s}}}",
@@ -34274,7 +34274,7 @@
     "sc": "Magazine (fashion)"
   },
   {
-    "s": "en Guayaquil",
+    "s": "En Guayaquil",
     "d": "enguayaquil.com",
     "t": "gquil",
     "u": "https://enguayaquil.com/?s={{{s}}}",
@@ -34347,7 +34347,7 @@
     "sc": "Academic"
   },
   {
-    "s": "gramota.ru",
+    "s": "Gramota",
     "d": "gramota.ru",
     "t": "gramota",
     "u": "https://gramota.ru/slovari/dic/?word={{{s}}}&all=x",
@@ -34379,7 +34379,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Grateful Dead Concerts",
+    "s": "Internet Archive (Grateful Dead)",
     "d": "archive.org",
     "t": "gratefuldead",
     "u": "https://archive.org/search.php?query={{{s}}} AND collection:GratefulDead",
@@ -34435,7 +34435,7 @@
     "sc": "General"
   },
   {
-    "s": "Reddit on Google",
+    "s": "Google (Reddit)",
     "d": "www.google.com",
     "t": "greddit",
     "u": "https://www.google.com/search?q=site:reddit.com+{{{s}}}",
@@ -34483,7 +34483,7 @@
     "sc": "Health"
   },
   {
-    "s": "goblinrefuge.com",
+    "s": "GoblinRefuge",
     "d": "goblinrefuge.com",
     "t": "grf",
     "u": "https://goblinrefuge.com/mediagoblin/search/?query={{{s}}}",
@@ -34499,7 +34499,7 @@
     "sc": "Books"
   },
   {
-    "s": "Google Reverse Image Search",
+    "s": "Google Lens",
     "d": "lens.google.com",
     "t": "gri",
     "ts": [
@@ -34526,7 +34526,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Le Grog (Kagi Search)",
+    "s": "Le Grog (Kagi)",
     "d": "kagi.com",
     "ad": "legrog.org",
     "t": "grog",
@@ -34543,7 +34543,7 @@
     "sc": "Google"
   },
   {
-    "s": "Groovy Documentation (Kagi Search)",
+    "s": "Groovy Documentation (Kagi)",
     "d": "kagi.com",
     "ad": "docs.groovy-lang.org",
     "t": "groovy",
@@ -34632,7 +34632,7 @@
     "sc": "Google"
   },
   {
-    "s": "Game Grumps",
+    "s": "YouTube (Game Grumps)",
     "d": "www.youtube.com",
     "t": "grumps",
     "u": "https://www.youtube.com/user/GameGrumps/search?query={{{s}}}",
@@ -34648,7 +34648,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Google (all&safe)",
+    "s": "Google (SafeSearch)",
     "d": "www.google.com",
     "t": "gsafe",
     "u": "https://www.google.com/search?hl=all&safe=on&pws=0&q={{{s}}}",
@@ -34664,7 +34664,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google Shopping Australia",
+    "s": "Google Shopping (Australia)",
     "d": "www.google.com.au",
     "t": "gsau",
     "u": "https://www.google.com.au/search?tbm=shop&q={{{s}}}",
@@ -34704,7 +34704,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Shopping",
+    "s": "Google (Shopping)",
     "d": "www.google.com",
     "t": "gs",
     "ts": [
@@ -34716,7 +34716,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Spreadsheets",
+    "s": "Google Sheets",
     "d": "docs.google.com",
     "t": "gsheet",
     "ts": [
@@ -34729,7 +34729,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google SI",
+    "s": "Google (SI)",
     "d": "www.google.si",
     "t": "gsi",
     "u": "https://www.google.si/search?q={{{s}}}",
@@ -34737,7 +34737,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Shopping IT",
+    "s": "Google Shopping (Italy)",
     "d": "www.google.it",
     "t": "gsit",
     "u": "https://www.google.it/search?hl=it&tbm=shop&q={{{s}}}",
@@ -34789,7 +34789,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google over StackOverflow",
+    "s": "Google (Stack Overflow)",
     "d": "www.google.com",
     "t": "gso",
     "u": "https://www.google.com/search?q=+[inurl:http://stackoverflow.com]+{{{s}}}",
@@ -34797,7 +34797,7 @@
     "sc": "Programming"
   },
   {
-    "s": "gspace",
+    "s": "GSpace",
     "d": "glammingspace.blogspot.com",
     "t": "gspace",
     "u": "https://glammingspace.blogspot.com/search?q={{{s}}}",
@@ -34829,7 +34829,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Google Shopping UK",
+    "s": "Google Shopping (UK)",
     "d": "www.google.co.uk",
     "t": "gsuk",
     "u": "https://www.google.co.uk/search?q={{{s}}}&tbm=shop",
@@ -34837,7 +34837,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google Shopping US",
+    "s": "Google (Shopping, US)",
     "d": "www.google.com",
     "t": "gsus",
     "u": "https://www.google.com/search?tbm=shop&q={{{s}}}&gws_rd=cr",
@@ -34845,7 +34845,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google Swedish",
+    "s": "Google (Sweden)",
     "d": "google.com",
     "t": "gsv",
     "u": "https://google.com/search?hl=sv&q={{{s}}}",
@@ -34861,7 +34861,7 @@
     "sc": "Languages (javascript)"
   },
   {
-    "s": "Google Shopping Express",
+    "s": "Google (Shopping Express)",
     "d": "www.google.com",
     "t": "gsx",
     "u": "https://www.google.com/shopping/express/#SearchResultsPlace:s=0&c=24&q={{{s}}}",
@@ -34869,7 +34869,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google Translate (to Afrikaans)",
+    "s": "Google Translate (auto-af)",
     "d": "translate.google.com",
     "t": "gtaf",
     "ts": [
@@ -34881,7 +34881,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Albanian)",
+    "s": "Google Translate (auto-sq)",
     "d": "translate.google.com",
     "t": "gt-albanian",
     "ts": [
@@ -34893,7 +34893,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Arabic)",
+    "s": "Google Translate (auto-ar)",
     "d": "translate.google.com",
     "t": "gt-arabic",
     "ts": [
@@ -34905,7 +34905,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Armenian)",
+    "s": "Google Translate (auto-hy)",
     "d": "translate.google.com",
     "t": "gt-armenian",
     "ts": [
@@ -34917,7 +34917,7 @@
     "sc": "Google"
   },
   {
-    "s": "Gumtree Australia",
+    "s": "Gumtree (Australia)",
     "d": "www.gumtree.com.au",
     "t": "gtau",
     "ts": [
@@ -34937,7 +34937,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Google Translate (to Azerbaijani)",
+    "s": "Google Translate (auto-az)",
     "d": "translate.google.com",
     "t": "gtaz",
     "ts": [
@@ -34949,7 +34949,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Basque)",
+    "s": "Google Translate (auto-eu)",
     "d": "translate.google.com",
     "t": "gt-basque",
     "ts": [
@@ -34961,7 +34961,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Belarusian)",
+    "s": "Google Translate (auto-be)",
     "d": "translate.google.com",
     "t": "gtbe",
     "ts": [
@@ -34973,7 +34973,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Bengali)",
+    "s": "Google Translate (auto-bn)",
     "d": "translate.google.com",
     "t": "gt-bengali",
     "ts": [
@@ -34985,7 +34985,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Bulgarian)",
+    "s": "Google Translate (auto-bg)",
     "d": "translate.google.com",
     "t": "gtbg",
     "ts": [
@@ -34997,7 +34997,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Bosnian)",
+    "s": "Google Translate (auto-bs)",
     "d": "translate.google.com",
     "t": "gt-bosnian",
     "ts": [
@@ -35009,7 +35009,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Catalan)",
+    "s": "Google Translate (auto-ca)",
     "d": "translate.google.com",
     "t": "gtca",
     "ts": [
@@ -35021,7 +35021,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Cebuano)",
+    "s": "Google Translate (auto-ceb)",
     "d": "translate.google.com",
     "t": "gtceb",
     "ts": [
@@ -35033,7 +35033,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Chichewa)",
+    "s": "Google Translate (auto-ny)",
     "d": "translate.google.com",
     "t": "gt-chichewa",
     "ts": [
@@ -35045,7 +35045,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Chinese)",
+    "s": "Google Translate (auto-zh-CN)",
     "d": "translate.google.com",
     "t": "gt-chinese",
     "ts": [
@@ -35057,7 +35057,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Croatian)",
+    "s": "Google Translate (auto-hr)",
     "d": "translate.google.com",
     "t": "gt-croatian",
     "ts": [
@@ -35069,7 +35069,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Czech)",
+    "s": "Google Translate (auto-cs)",
     "d": "translate.google.com",
     "t": "gtcs",
     "ts": [
@@ -35082,7 +35082,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Welsh)",
+    "s": "Google Translate (auto-cy)",
     "d": "translate.google.com",
     "t": "gtcy",
     "ts": [
@@ -35094,7 +35094,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Danish)",
+    "s": "Google Translate (auto-da)",
     "d": "translate.google.com",
     "t": "gtda",
     "ts": [
@@ -35114,7 +35114,7 @@
     "sc": "Games (offline)"
   },
   {
-    "s": "Google Translate (to German)",
+    "s": "Google Translate (auto-de)",
     "d": "translate.google.com",
     "t": "gtde",
     "ts": [
@@ -35127,7 +35127,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Dutch)",
+    "s": "Google Translate (auto-nl)",
     "d": "translate.google.com",
     "t": "gt-dutch",
     "ts": [
@@ -35142,7 +35142,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (greek)",
+    "s": "Google Translate (auto-el)",
     "d": "translate.google.com",
     "t": "gtel",
     "ts": [
@@ -35155,7 +35155,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to English)",
+    "s": "Google Translate (auto-en)",
     "d": "translate.google.com",
     "t": "gten",
     "ts": [
@@ -35169,7 +35169,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate en-ga",
+    "s": "Google Translate (en-ga)",
     "d": "translate.google.com",
     "t": "gtenga",
     "u": "https://translate.google.com/#en/ga/{{{s}}}",
@@ -35177,7 +35177,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Esperanto)",
+    "s": "Google Translate (auto-eo)",
     "d": "translate.google.com",
     "t": "gteo",
     "ts": [
@@ -35189,7 +35189,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Spanish)",
+    "s": "Google Translate (auto-es)",
     "d": "translate.google.com",
     "t": "gtes",
     "ts": [
@@ -35201,7 +35201,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Estonian)",
+    "s": "Google Translate (auto-et)",
     "d": "translate.google.com",
     "t": "gt-estonian",
     "ts": [
@@ -35213,7 +35213,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Persian)",
+    "s": "Google Translate (auto-fa)",
     "d": "translate.google.com",
     "t": "gtfa",
     "ts": [
@@ -35233,7 +35233,7 @@
     "sc": "Forum"
   },
   {
-    "s": "Google Translate (to Finnish)",
+    "s": "Google Translate (auto-fi)",
     "d": "translate.google.com",
     "t": "gtfi",
     "ts": [
@@ -35245,7 +35245,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Filipino)",
+    "s": "Google Translate (auto-tl)",
     "d": "translate.google.com",
     "t": "gt-filipino",
     "ts": [
@@ -35257,7 +35257,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to French)",
+    "s": "Google Translate (auto-fr)",
     "d": "translate.google.com",
     "t": "gtfr",
     "ts": [
@@ -35270,7 +35270,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Irish)",
+    "s": "Google Translate (auto-ga)",
     "d": "translate.google.com",
     "t": "gtga",
     "ts": [
@@ -35282,7 +35282,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Galician)",
+    "s": "Google Translate (auto-gl)",
     "d": "translate.google.com",
     "t": "gt-galician",
     "ts": [
@@ -35294,7 +35294,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Georgian)",
+    "s": "Google Translate (auto-ka)",
     "d": "translate.google.com",
     "t": "gt-georgian",
     "ts": [
@@ -35306,7 +35306,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Gujarati)",
+    "s": "Google Translate (auto-gu)",
     "d": "translate.google.com",
     "t": "gtgu",
     "ts": [
@@ -35318,7 +35318,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Hausa)",
+    "s": "Google Translate (auto-ha)",
     "d": "translate.google.com",
     "t": "gtha",
     "ts": [
@@ -35330,7 +35330,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Haitian Creole)",
+    "s": "Google Translate (auto-ht)",
     "d": "translate.google.com",
     "t": "gthaitiancreole",
     "ts": [
@@ -35341,7 +35341,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Hebrew)",
+    "s": "Google Translate (auto-iw)",
     "d": "translate.google.com",
     "t": "gt-hebrew",
     "ts": [
@@ -35361,7 +35361,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Hindi)",
+    "s": "Google Translate (auto-hi)",
     "d": "translate.google.com",
     "t": "gthi",
     "ts": [
@@ -35373,7 +35373,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Hmong)",
+    "s": "Google Translate (auto-hmn)",
     "d": "translate.google.com",
     "t": "gthmn",
     "ts": [
@@ -35385,7 +35385,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Hungarian)",
+    "s": "Google Translate (auto-hu)",
     "d": "translate.google.com",
     "t": "gthu",
     "ts": [
@@ -35397,7 +35397,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Icelandic)",
+    "s": "Google Translate (auto-is)",
     "d": "translate.google.com",
     "t": "gt-icelandic",
     "ts": [
@@ -35409,7 +35409,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Indonesian)",
+    "s": "Google Translate (auto-id)",
     "d": "translate.google.com",
     "t": "gtid",
     "ts": [
@@ -35421,7 +35421,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Igbo)",
+    "s": "Google Translate (auto-ig)",
     "d": "translate.google.com",
     "t": "gt-igbo",
     "ts": [
@@ -35433,7 +35433,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Italian)",
+    "s": "Google Translate (auto-it)",
     "d": "translate.google.com",
     "t": "gt-italian",
     "ts": [
@@ -35445,7 +35445,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate it->en",
+    "s": "Google Translate (it-en)",
     "d": "translate.google.com",
     "t": "gtiten",
     "ts": [
@@ -35456,7 +35456,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Japanese)",
+    "s": "Google Translate (auto-ja)",
     "d": "translate.google.com",
     "t": "gtja",
     "ts": [
@@ -35469,7 +35469,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Javanese)",
+    "s": "Google Translate (auto-jw)",
     "d": "translate.google.com",
     "t": "gt-javanese",
     "ts": [
@@ -35481,7 +35481,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Kannada)",
+    "s": "Google Translate (auto-kn)",
     "d": "translate.google.com",
     "t": "gt-kannada",
     "ts": [
@@ -35493,7 +35493,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Kazakh)",
+    "s": "Google Translate (auto-kk)",
     "d": "translate.google.com",
     "t": "gt-kazakh",
     "ts": [
@@ -35505,7 +35505,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Khmer)",
+    "s": "Google Translate (auto-km)",
     "d": "translate.google.com",
     "t": "gt-khmer",
     "ts": [
@@ -35517,7 +35517,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Korean)",
+    "s": "Google Translate (auto-ko)",
     "d": "translate.google.com",
     "t": "gtko",
     "ts": [
@@ -35530,7 +35530,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Latin)",
+    "s": "Google Translate (auto-la)",
     "d": "translate.google.com",
     "t": "gtla",
     "ts": [
@@ -35542,7 +35542,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (lanl)",
+    "s": "Google Translate (la-nl)",
     "d": "translate.google.com",
     "t": "gtlanl",
     "u": "https://translate.google.com/#la/nl/{{{s}}}",
@@ -35550,7 +35550,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Lao)",
+    "s": "Google Translate (auto-lo)",
     "d": "translate.google.com",
     "t": "gt-lao",
     "ts": [
@@ -35561,7 +35561,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Latvian)",
+    "s": "Google Translate (auto-lv)",
     "d": "translate.google.com",
     "t": "gt-latvian",
     "ts": [
@@ -35581,7 +35581,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Google Translate (to Lithuanian)",
+    "s": "Google Translate (auto-lt)",
     "d": "translate.google.com",
     "t": "gt-lithuanian",
     "ts": [
@@ -35593,7 +35593,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Macedonian)",
+    "s": "Google Translate (auto-mk)",
     "d": "translate.google.com",
     "t": "gt-macedonian",
     "ts": [
@@ -35605,7 +35605,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Malagasy)",
+    "s": "Google Translate (auto-mg)",
     "d": "translate.google.com",
     "t": "gt-malagasy",
     "ts": [
@@ -35617,7 +35617,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Malayalam)",
+    "s": "Google Translate (auto-ml)",
     "d": "translate.google.com",
     "t": "gt-malayalam",
     "ts": [
@@ -35629,7 +35629,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Malay)",
+    "s": "Google Translate (auto-ms)",
     "d": "translate.google.com",
     "t": "gt-malay",
     "ts": [
@@ -35641,7 +35641,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Maltese)",
+    "s": "Google Translate (auto-mt)",
     "d": "translate.google.com",
     "t": "gt-maltese",
     "ts": [
@@ -35653,7 +35653,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Maori)",
+    "s": "Google Translate (auto-mi)",
     "d": "translate.google.com",
     "t": "gt-maori",
     "ts": [
@@ -35665,7 +35665,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Marathi)",
+    "s": "Google Translate (auto-mr)",
     "d": "translate.google.com",
     "t": "gt-marathi",
     "ts": [
@@ -35685,7 +35685,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Google Translate (to Mongolian)",
+    "s": "Google Translate (auto-mn)",
     "d": "translate.google.com",
     "t": "gtmn",
     "ts": [
@@ -35697,7 +35697,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Myanmar (Burmese))",
+    "s": "Google Translate (auto-my)",
     "d": "translate.google.com",
     "t": "gt-myanmar",
     "ts": [
@@ -35717,7 +35717,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Google Translate (to Nepali)",
+    "s": "Google Translate (auto-ne)",
     "d": "translate.google.com",
     "t": "gtne",
     "ts": [
@@ -35745,7 +35745,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Norwegian)",
+    "s": "Google Translate (auto-no)",
     "d": "translate.google.com",
     "t": "gtno",
     "ts": [
@@ -35757,7 +35757,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Punjabi)",
+    "s": "Google Translate (auto-pa)",
     "d": "translate.google.com",
     "t": "gtpa",
     "ts": [
@@ -35769,7 +35769,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Polish)",
+    "s": "Google Translate (auto-pl)",
     "d": "translate.google.com",
     "t": "gtpl",
     "ts": [
@@ -35781,7 +35781,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Portuguese)",
+    "s": "Google Translate (auto-pt)",
     "d": "translate.google.com",
     "t": "gt-portuguese",
     "ts": [
@@ -35812,7 +35812,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Romanian)",
+    "s": "Google Translate (auto-ro)",
     "d": "translate.google.com",
     "t": "gtro",
     "ts": [
@@ -35824,7 +35824,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Russian)",
+    "s": "Google Translate (auto-ru)",
     "d": "translate.google.com",
     "t": "gtru",
     "ts": [
@@ -35836,7 +35836,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Serbian)",
+    "s": "Google Translate (auto-sr)",
     "d": "translate.google.com",
     "t": "gt-serbian",
     "ts": [
@@ -35848,7 +35848,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Sesotho)",
+    "s": "Google Translate (auto-st)",
     "d": "translate.google.com",
     "t": "gt-sesotho",
     "ts": [
@@ -35860,7 +35860,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Sinhala)",
+    "s": "Google Translate (auto-si)",
     "d": "translate.google.com",
     "t": "gtsi",
     "ts": [
@@ -35872,7 +35872,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Slovak)",
+    "s": "Google Translate (auto-sk)",
     "d": "translate.google.com",
     "t": "gtsk",
     "ts": [
@@ -35884,7 +35884,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Slovenian)",
+    "s": "Google Translate (auto-sl)",
     "d": "translate.google.com",
     "t": "gtsl",
     "ts": [
@@ -35896,7 +35896,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Somali)",
+    "s": "Google Translate (auto-so)",
     "d": "translate.google.com",
     "t": "gtso",
     "ts": [
@@ -35908,7 +35908,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Sundanese)",
+    "s": "Google Translate (auto-su)",
     "d": "translate.google.com",
     "t": "gtsu",
     "ts": [
@@ -35920,7 +35920,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Swedish)",
+    "s": "Google Translate (auto-sv)",
     "d": "translate.google.com",
     "t": "gtsv",
     "ts": [
@@ -35932,7 +35932,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Swahili)",
+    "s": "Google Translate (auto-sw)",
     "d": "translate.google.com",
     "t": "gt-swahili",
     "ts": [
@@ -35944,7 +35944,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Tamil)",
+    "s": "Google Translate (auto-ta)",
     "d": "translate.google.com",
     "t": "gtta",
     "ts": [
@@ -35956,7 +35956,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Tajik)",
+    "s": "Google Translate (auto-tg)",
     "d": "translate.google.com",
     "t": "gt-tajik",
     "ts": [
@@ -35968,7 +35968,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Telugu)",
+    "s": "Google Translate (auto-te)",
     "d": "translate.google.com",
     "t": "gtte",
     "ts": [
@@ -35980,7 +35980,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Thai)",
+    "s": "Google Translate (auto-th)",
     "d": "translate.google.com",
     "t": "gt-thai",
     "ts": [
@@ -35992,7 +35992,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Turkish)",
+    "s": "Google Translate (auto-tr)",
     "d": "translate.google.com",
     "t": "gttr",
     "ts": [
@@ -36012,7 +36012,7 @@
     "sc": "Search"
   },
   {
-    "s": "Google Translate (to Ukrainian)",
+    "s": "Google Translate (auto-uk)",
     "d": "translate.google.com",
     "t": "gtuk",
     "ts": [
@@ -36024,7 +36024,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Urdu)",
+    "s": "Google Translate (auto-ur)",
     "d": "translate.google.com",
     "t": "gtur",
     "ts": [
@@ -36036,7 +36036,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate URL",
+    "s": "Google Translate (URL)",
     "d": "translate.google.com",
     "t": "gturl",
     "u": "https://translate.google.com/translate?sl=auto&tl=en&u={{{s}}}",
@@ -36044,7 +36044,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Uzbek)",
+    "s": "Google Translate (auto-uz)",
     "d": "translate.google.com",
     "t": "gt-uzbek",
     "ts": [
@@ -36056,7 +36056,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Vietnamese)",
+    "s": "Google Translate (auto-vi)",
     "d": "translate.google.com",
     "t": "gtvi",
     "ts": [
@@ -36068,7 +36068,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google TW",
+    "s": "Google (Taiwan)",
     "d": "www.google.com.tw",
     "t": "gtw",
     "u": "https://www.google.com.tw/search?q={{{s}}}&meta=&aq=f&aqi=g10&aql=&gs_rfai=",
@@ -36084,7 +36084,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Google Translate (to Yiddish)",
+    "s": "Google Translate (auto-yi)",
     "d": "translate.google.com",
     "t": "gt-yiddish",
     "ts": [
@@ -36096,7 +36096,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Yoruba)",
+    "s": "Google Translate (auto-yo)",
     "d": "translate.google.com",
     "t": "gtyo",
     "ts": [
@@ -36108,7 +36108,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to traditional Chinese)",
+    "s": "Google Translate (auto-zh-TW)",
     "d": "translate.google.com",
     "t": "gtzh-tw",
     "u": "https://translate.google.com/#auto/zh-TW/{{{s}}}",
@@ -36116,7 +36116,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate (to Zulu)",
+    "s": "Google Translate (auto-zu)",
     "d": "translate.google.com",
     "t": "gtzu",
     "ts": [
@@ -36211,7 +36211,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Guitaa.com",
+    "s": "Guitaa",
     "d": "www.guitaa.com",
     "t": "guitaa",
     "u": "https://www.guitaa.com/search?q={{{s}}}",
@@ -36219,7 +36219,7 @@
     "sc": "Music (Lyrics)"
   },
   {
-    "s": "GuitarTabsExplorer.com",
+    "s": "GuitarTabsExplorer",
     "d": "www.guitartabsexplorer.com",
     "t": "guitartabs",
     "u": "https://www.guitartabsexplorer.com/search.php?search={{{s}}}",
@@ -36243,7 +36243,7 @@
     "sc": "TV"
   },
   {
-    "s": "gmtr",
+    "s": "Gumtree (Melbourne)",
     "d": "www.gumtree.com.au",
     "t": "gumtree",
     "u": "https://www.gumtree.com.au/s-melbourne/{{{s}}}/k0l3001317",
@@ -36283,7 +36283,7 @@
     "sc": "TV"
   },
   {
-    "s": "gun.deals",
+    "s": "Gun Deals",
     "d": "gun.deals",
     "t": "gundeals",
     "u": "https://gun.deals/search/apachesolr_search/{{{s}}}",
@@ -36323,7 +36323,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Gurtbandlager.de",
+    "s": "Gurtbandlager",
     "d": "www.gurtbandlager.de",
     "t": "gurtband",
     "u": "https://www.gurtbandlager.de/search?sSearch={{{s}}}",
@@ -36331,7 +36331,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google US",
+    "s": "Google (US)",
     "d": "www.google.com",
     "t": "gus",
     "u": "https://www.google.com/search?q={{{s}}}&meta=&aq=f&aqi=g10&aql=&gs_rfai=",
@@ -36367,7 +36367,7 @@
     "sc": "Books"
   },
   {
-    "s": "The Guardian (Kagi Search)",
+    "s": "The Guardian (Kagi)",
     "d": "kagi.com",
     "ad": "www.theguardian.com",
     "t": "gu",
@@ -36376,7 +36376,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Gutscheine.de",
+    "s": "Gutscheine",
     "d": "www.gutscheine.de",
     "t": "gutschein",
     "u": "https://www.gutscheine.de/suche?search={{{s}}}",
@@ -36384,7 +36384,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Google Search Verbatim 100 English Results",
+    "s": "Google (Verbatim, 100 Results, English)",
     "d": "www.google.com",
     "t": "gv100en",
     "u": "https://www.google.com/search?q={{{s}}}&tbo=1&num=100&tbs=li:1&lr=lang_en",
@@ -36392,7 +36392,7 @@
     "sc": "Search"
   },
   {
-    "s": "Google Search Verbatim 100 Results",
+    "s": "Google (Verbatim, 100 Results)",
     "d": "www.google.com",
     "t": "gv100",
     "u": "https://www.google.com/search?q={{{s}}}&tbo=1&num=100&tbs=li:1",
@@ -36400,7 +36400,7 @@
     "sc": "Search"
   },
   {
-    "s": "Google Videos Australia",
+    "s": "Google Videos (Australia)",
     "d": "www.google.com.au",
     "t": "gvau",
     "u": "https://www.google.com.au/search?tbm=vid&q={{{s}}}",
@@ -36408,7 +36408,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Verbatim",
+    "s": "Google (Verbatim)",
     "d": "google.com",
     "t": "gvb",
     "u": "https://google.com/search?&tbs=li:1&q={{{s}}}",
@@ -36424,7 +36424,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Video",
+    "s": "Google (Video)",
     "d": "www.google.com",
     "t": "gv",
     "u": "https://www.google.com/search?tbm=vid&q={{{s}}}",
@@ -36671,7 +36671,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Simplified Chinese",
+    "s": "Google (Simplified Chinese)",
     "d": "www.google.com",
     "t": "gzc",
     "u": "https://www.google.com/search?q={{{s}}}&lr=lang_zh-CN",
@@ -36748,7 +36748,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "habrahabr.ru",
+    "s": "Habrahabr",
     "d": "habrahabr.ru",
     "t": "habra",
     "u": "https://habrahabr.ru/search/?q={{{s}}}",
@@ -36850,7 +36850,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Search-Hadoop",
+    "s": "Hadoop",
     "d": "search-hadoop.com",
     "t": "hadoop",
     "u": "https://search-hadoop.com/?q={{{s}}}",
@@ -36858,7 +36858,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Hafele.nl",
+    "s": "Hafele (Netherlands)",
     "d": "www.hafele.nl",
     "t": "hafelenl",
     "u": "https://www.hafele.nl/INTERSHOP/web/WFS/Haefele-HNL-Site/nl_NL/-/EUR/ViewParametricSearch-SimpleOfferSearch?SearchType=all&SearchTerm={{{s}}}",
@@ -36978,7 +36978,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "hanziDB",
+    "s": "HanziDB",
     "d": "hanzidb.org",
     "t": "hanzidb",
     "u": "https://hanzidb.org/character/{{{s}}}",
@@ -37058,7 +37058,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Twitter Hashtags",
+    "s": "X (Hashtags)",
     "d": "x.com",
     "t": "hashtag",
     "u": "https://x.com/search?q=\\#{{{s}}}",
@@ -37122,7 +37122,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Hornbach.at",
+    "s": "Hornbach (Austria)",
     "d": "www.hornbach.at",
     "t": "hbat",
     "u": "https://www.hornbach.at/shop/suche/sortiment/{{{s}}}",
@@ -37130,7 +37130,7 @@
     "sc": "Online"
   },
   {
-    "s": "Humblebundle",
+    "s": "Humble Bundle",
     "d": "www.humblebundle.com",
     "t": "hb",
     "ts": [
@@ -37208,7 +37208,7 @@
     "sc": "Academic"
   },
   {
-    "s": "FindACode.com",
+    "s": "FindACode",
     "d": "www.findacode.com",
     "t": "hcpcs",
     "u": "https://www.findacode.com/code.php?set=HCPCS&c={{{s}}}",
@@ -37216,7 +37216,7 @@
     "sc": "Health"
   },
   {
-    "s": "Hockeydb.com",
+    "s": "HockeyDB",
     "d": "www.hockeydb.com",
     "t": "hdb",
     "u": "https://www.hockeydb.com/ihdb/stats/find_player.php?full_name={{{s}}}",
@@ -37267,7 +37267,7 @@
     "sc": "Downloads (software)"
   },
   {
-    "s": "LES MISCELLANÉES NUMÉRIQUES",
+    "s": "Les Miscellanées Numériques",
     "d": "hdrapin.com",
     "t": "hdrapin",
     "u": "https://hdrapin.com/?s={{{s}}}",
@@ -37283,7 +37283,7 @@
     "sc": "Tech"
   },
   {
-    "s": "HDtracks.com",
+    "s": "HDtracks",
     "d": "www.hdtracks.com",
     "t": "hdt",
     "u": "https://www.hdtracks.com/catalogsearch/result/?q={{{s}}}",
@@ -37397,7 +37397,7 @@
     "sc": "Online"
   },
   {
-    "s": "HEEZA - L'Univers du Cartoon",
+    "s": "HEEZA",
     "d": "www.heeza.fr",
     "t": "heeza",
     "u": "https://www.heeza.fr/fr/recherche?orderby=position&orderway=desc&search_query={{{s}}}&submit_search=Rechercher",
@@ -37477,7 +37477,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "thehendonmob.com",
+    "s": "The Hendon Mob",
     "d": "www.thehendonmob.com",
     "t": "hendon",
     "u": "https://www.thehendonmob.com/search/?q={{{s}}}",
@@ -37599,7 +37599,7 @@
     "sc": "Online"
   },
   {
-    "s": "ZDF heute",
+    "s": "ZDF (heute)",
     "d": "www.zdf.de",
     "t": "heute",
     "u": "https://www.zdf.de/suche?q={{{s}}}&synth=true&sender=heute.de&from=&to=&attrs=",
@@ -37607,7 +37607,7 @@
     "sc": "International"
   },
   {
-    "s": "Hex Docs",
+    "s": "HexDocs",
     "d": "hexdocs.pm",
     "t": "hexdocs",
     "u": "https://hexdocs.pm/{{{s}}}",
@@ -37634,7 +37634,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "LinuxFR (Kagi Search)",
+    "s": "LinuxFR (Kagi)",
     "d": "kagi.com",
     "ad": "linuxfr.org",
     "t": "hfr",
@@ -37724,7 +37724,7 @@
     "sc": "Health"
   },
   {
-    "s": "hgpu.org",
+    "s": "HGPU",
     "d": "hgpu.org",
     "t": "hgpu",
     "u": "https://hgpu.org/?s={{{s}}}",
@@ -37756,7 +37756,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google translate English to Hindi",
+    "s": "Google Translate (hi-en)",
     "d": "translate.google.com",
     "t": "hi2en",
     "u": "https://translate.google.com/#view=home&op=translate&sl=hi&tl=en&text={{{s}}}",
@@ -37796,7 +37796,7 @@
     "sc": "Services"
   },
   {
-    "s": "Hikr.org",
+    "s": "Hikr",
     "d": "www.hikr.org",
     "t": "hikr",
     "u": "https://www.hikr.org/cse.php?q={{{s}}}",
@@ -37831,7 +37831,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Hi-News.ru",
+    "s": "Hi-News",
     "d": "hi-news.ru",
     "t": "hinews",
     "u": "https://hi-news.ru/?s={{{s}}}",
@@ -37839,7 +37839,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Hinta.fi",
+    "s": "Hinta",
     "d": "hinta.fi",
     "t": "hintafi",
     "u": "https://hinta.fi/haku?q={{{s}}}",
@@ -37863,7 +37863,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Hackaday.io",
+    "s": "Hackaday",
     "d": "hackaday.io",
     "t": "hio",
     "u": "https://hackaday.io/search?term={{{s}}}",
@@ -37879,7 +37879,7 @@
     "sc": "Misc"
   },
   {
-    "s": "historicum",
+    "s": "Historicum",
     "d": "historicum.net",
     "t": "hcum",
     "ts": [
@@ -37914,7 +37914,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Hitta.se",
+    "s": "Hitta",
     "d": "www.hitta.se",
     "t": "hitta",
     "u": "https://www.hitta.se/sök?vad={{{s}}}",
@@ -38071,7 +38071,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "HLTV.org",
+    "s": "HLTV",
     "d": "www.hltv.org",
     "t": "hltv",
     "u": "https://www.hltv.org/search?query={{{s}}}",
@@ -38103,7 +38103,7 @@
     "sc": "Audio"
   },
   {
-    "s": "Hacker News (sort by date)",
+    "s": "Hacker News (By Date)",
     "d": "hn.algolia.com",
     "ad": "news.ycombinator.com",
     "t": "hnd",
@@ -38120,7 +38120,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "hackernoon",
+    "s": "HackerNoon",
     "d": "hackernoon.com",
     "t": "hno",
     "u": "https://hackernoon.com/search?q={{{s}}}",
@@ -38264,7 +38264,7 @@
     "sc": "Real Estate"
   },
   {
-    "s": "Homestuck.com",
+    "s": "Homestuck",
     "d": "www.homestuck.com",
     "t": "homestuck",
     "u": "https://www.homestuck.com/search?search={{{s}}}",
@@ -38304,7 +38304,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Hood.de - Auktionen und Online Shopping",
+    "s": "Hood",
     "d": "www.hood.de",
     "t": "hood",
     "u": "https://www.hood.de/suchergebnisse.htm?q={{{s}}}",
@@ -38570,7 +38570,7 @@
     "sc": "Books"
   },
   {
-    "s": "Housepets! Forums",
+    "s": "Housepets! (Forums)",
     "d": "www.housepetscomic.com",
     "t": "hpcf",
     "ts": [
@@ -38597,7 +38597,7 @@
     "sc": "Companies"
   },
   {
-    "s": "HyperPhysics (Kagi Search)",
+    "s": "HyperPhysics (Kagi)",
     "d": "kagi.com",
     "ad": "hyperphysics.phy-astr.gsu.edu",
     "t": "hphys",
@@ -38681,7 +38681,7 @@
     "sc": "Academic"
   },
   {
-    "s": "soblexx",
+    "s": "Soblexx",
     "d": "soblexx.de",
     "t": "hsb",
     "u": "https://soblexx.de/?cmd=search_soblex&p_w={{{s}}}",
@@ -38756,7 +38756,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Html2Txt",
+    "s": "W3C (Html2Txt)",
     "d": "www.w3.org",
     "t": "html2txt",
     "u": "https://www.w3.org/services/html2txt?url={{{s}}}",
@@ -38788,7 +38788,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Kagi Search (no JS)",
+    "s": "Kagi (No JS)",
     "d": "kagi.com",
     "ad": "",
     "t": "html",
@@ -38865,7 +38865,7 @@
     "sc": "Law"
   },
   {
-    "s": "Google Translate hu-de",
+    "s": "Google Translate (hu-de)",
     "d": "translate.google.com",
     "t": "hude",
     "u": "https://translate.google.com/#hu/de/{{{s}}}",
@@ -38879,7 +38879,7 @@
     "u": "https://hud.summon.serialssolutions.com/search?ho=t&l=en&fvf=ContentType,Book+Review,t&q={{{s}}}&limit=everything"
   },
   {
-    "s": "Google Translate hu-en",
+    "s": "Google Translate (hu-en)",
     "d": "translate.google.com",
     "t": "huen",
     "u": "https://translate.google.com/#hu/en/{{{s}}}",
@@ -38887,7 +38887,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate hu-es",
+    "s": "Google Translate (hu-es)",
     "d": "translate.google.hu",
     "t": "hues",
     "u": "https://translate.google.hu/#hu/es/{{{s}}}",
@@ -38930,7 +38930,7 @@
     "sc": "Social (intl)"
   },
   {
-    "s": "Google Translate hu-it",
+    "s": "Google Translate (hu-it)",
     "d": "translate.google.com",
     "t": "huit",
     "u": "https://translate.google.com/#hu/it/{{{s}}}",
@@ -38965,7 +38965,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Humble Bundle",
+    "s": "Humble Bundle (Deals)",
     "d": "www.humblebundle.com",
     "t": "humbledeals",
     "u": "https://www.humblebundle.com/store/search?sort=discount&search={{{s}}}",
@@ -38997,7 +38997,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Google Translate: Hungarian to Serbian",
+    "s": "Google Translate (hu-sr)",
     "d": "translate.google.com",
     "t": "husr",
     "u": "https://translate.google.com/#hu/sr/{{{s}}}",
@@ -39013,7 +39013,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "HVG.hu",
+    "s": "HVG",
     "d": "hvg.hu",
     "t": "hvg",
     "u": "https://hvg.hu/kereses?term={{{s}}}&x=0&y=0",
@@ -39096,7 +39096,7 @@
     "sc": "TV"
   },
   {
-    "s": "Google Map (Hybrid)",
+    "s": "Google Maps (Hybrid)",
     "d": "maps.google.com",
     "t": "hybrid",
     "u": "https://maps.google.com/maps?t=h&q={{{s}}}",
@@ -39112,7 +39112,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Hymnary.org",
+    "s": "Hymnary",
     "d": "hymnary.org",
     "t": "hymnary",
     "u": "https://hymnary.org/search?qu={{{s}}}",
@@ -39401,7 +39401,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Indiebound.org",
+    "s": "IndieBound",
     "d": "www.indiebound.org",
     "t": "ib",
     "u": "https://www.indiebound.org/search/book?keys={{{s}}}",
@@ -39457,7 +39457,7 @@
     "sc": "Topical"
   },
   {
-    "s": "ICA - Recept",
+    "s": "ICA (Recept)",
     "d": "www.ica.se",
     "t": "icarecept",
     "u": "https://www.ica.se/recept/?q={{{s}}}",
@@ -39473,7 +39473,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "ICD10Data.com",
+    "s": "ICD10Data",
     "d": "www.icd10data.com",
     "t": "icd10",
     "u": "https://www.icd10data.com/Search.aspx?search={{{s}}}",
@@ -39481,7 +39481,7 @@
     "sc": "Health"
   },
   {
-    "s": "ICD9Data.com",
+    "s": "ICD9Data",
     "d": "www.icd9data.com",
     "t": "icd9",
     "u": "https://www.icd9data.com/Search/?q={{{s}}}",
@@ -39659,7 +39659,7 @@
     "sc": "Music (Lyrics)"
   },
   {
-    "s": "IdealWorld.tv",
+    "s": "Ideal World",
     "d": "www.idealworld.tv",
     "t": "ideal",
     "u": "https://www.idealworld.tv/navigation/?q={{{s}}}",
@@ -39679,7 +39679,7 @@
     "sc": "Online"
   },
   {
-    "s": "Idealo.es",
+    "s": "Idealo (Spain)",
     "d": "www.idealo.es",
     "t": "idealoes",
     "ts": [
@@ -39821,7 +39821,7 @@
     "sc": "Domains"
   },
   {
-    "s": "IE Search (Kagi Search)",
+    "s": "IE (Kagi)",
     "d": "kagi.com",
     "ad": "ie",
     "t": "ie",
@@ -39878,7 +39878,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Inglise-eesti",
+    "s": "EKI (en-et)",
     "d": "www.eki.ee",
     "t": "ies",
     "u": "https://www.eki.ee/dict/ies/index.cgi?Q={{{s}}}",
@@ -39974,7 +39974,7 @@
     "sc": "Services"
   },
   {
-    "s": "IGDB - Internet Game Database",
+    "s": "IGDB",
     "d": "www.igdb.com",
     "t": "igdb",
     "u": "https://www.igdb.com/search?q={{{s}}}",
@@ -40001,7 +40001,7 @@
     "sc": "Tools (fundraising)"
   },
   {
-    "s": "Imgur — gifs",
+    "s": "Imgur (GIFs)",
     "d": "imgur.com",
     "t": "igif",
     "u": "https://imgur.com/search/score?q=ext:gif+{{{s}}}",
@@ -40114,7 +40114,7 @@
     "sc": "Law"
   },
   {
-    "s": "IKEA Austria",
+    "s": "IKEA (Austria)",
     "d": "www.ikea.com",
     "t": "ikeaat",
     "u": "https://www.ikea.com/at/de/search/products/?q={{{s}}}",
@@ -40122,7 +40122,7 @@
     "sc": "Online"
   },
   {
-    "s": "IKEA Australia",
+    "s": "IKEA (Australia)",
     "d": "www.ikea.com",
     "t": "ikeaau",
     "u": "https://www.ikea.com/au/en/search/?query={{{s}}}",
@@ -40130,7 +40130,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Ikea Belgium",
+    "s": "IKEA (Belgium)",
     "d": "www.ikea.com",
     "t": "ikeabe",
     "u": "https://www.ikea.com/be/nl/search/?query={{{s}}}",
@@ -40138,7 +40138,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Ikea Canada",
+    "s": "IKEA (Canada)",
     "d": "www.ikea.com",
     "t": "ikeaca",
     "u": "https://www.ikea.com/ca/en/search/products/?q={{{s}}}",
@@ -40146,7 +40146,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "ikea.ch",
+    "s": "IKEA (Switzerland)",
     "d": "www.ikea.com",
     "t": "ikeach",
     "u": "https://www.ikea.com/ch/de/search/?query={{{s}}}",
@@ -40154,7 +40154,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Ikea Czech Republic",
+    "s": "IKEA (Czechia)",
     "d": "www.ikea.com",
     "t": "ikeacs",
     "u": "https://www.ikea.com/cz/cs/search/?query={{{s}}}",
@@ -40162,7 +40162,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Ikea Germany",
+    "s": "IKEA (Germany)",
     "d": "www.ikea.com",
     "t": "ikeade",
     "u": "https://www.ikea.com/de/de/search/products/?q={{{s}}}",
@@ -40170,7 +40170,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Ikea Spain",
+    "s": "IKEA (Spain)",
     "d": "www.ikea.com",
     "t": "ikeaes",
     "u": "https://www.ikea.com/es/es/search/products/?q={{{s}}}",
@@ -40178,7 +40178,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Ikea FR",
+    "s": "IKEA (France)",
     "d": "www.ikea.com",
     "t": "ikeafr",
     "u": "https://www.ikea.com/fr/fr/search/?query={{{s}}}",
@@ -40186,7 +40186,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Ikea Ireland",
+    "s": "IKEA (Ireland)",
     "d": "www.ikea.com",
     "t": "ikeaie",
     "u": "https://www.ikea.com/ie/en/search/?query={{{s}}}",
@@ -40194,7 +40194,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Ikea",
+    "s": "IKEA",
     "d": "www.ikea.com",
     "t": "ikea",
     "u": "https://www.ikea.com/us/en/search/?query={{{s}}}",
@@ -40202,7 +40202,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Ikea (Italia)",
+    "s": "IKEA (Italy)",
     "d": "www.ikea.com",
     "t": "ikeait",
     "u": "https://www.ikea.com/it/it/search/?query={{{s}}}",
@@ -40210,7 +40210,7 @@
     "sc": "Online"
   },
   {
-    "s": "IKEA Nederland",
+    "s": "IKEA (Netherlands)",
     "d": "www.ikea.com",
     "t": "ikeanl",
     "u": "https://www.ikea.com/nl/nl/search/?q={{{s}}}",
@@ -40218,7 +40218,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "ikea.pl",
+    "s": "IKEA (Poland)",
     "d": "www.ikea.com",
     "t": "ikeapl",
     "u": "https://www.ikea.com/pl/pl/search/?query={{{s}}}",
@@ -40226,7 +40226,7 @@
     "sc": "Online"
   },
   {
-    "s": "IKEA UK",
+    "s": "IKEA (UK)",
     "d": "www.ikea.com",
     "t": "ikeauk",
     "u": "https://www.ikea.com/gb/en/search/products/?q={{{s}}}",
@@ -40258,7 +40258,7 @@
     "sc": "Music (Lyrics)"
   },
   {
-    "s": "DuckDuckGo Large Images",
+    "s": "DuckDuckGo (Large Images)",
     "d": "duckduckgo.com",
     "t": "ddg-il",
     "u": "https://duckduckgo.com/?q={{{s}}}&ia=images&iax=images&iaf=size:imagesize-large",
@@ -40422,7 +40422,7 @@
     "sc": "Academic"
   },
   {
-    "s": "IMDb (Internet Movie Database)",
+    "s": "IMDb (People)",
     "d": "www.imdb.com",
     "t": "imdba",
     "u": "https://www.imdb.com/find?q={{{s}}}&s=nm",
@@ -40430,7 +40430,7 @@
     "sc": "Movies"
   },
   {
-    "s": "IMDB TV Episodes",
+    "s": "IMDb (TV Episodes)",
     "d": "www.imdb.com",
     "t": "imdbep",
     "u": "https://www.imdb.com/find?&q={{{s}}}&s=ep",
@@ -40446,7 +40446,7 @@
     "sc": "Movies"
   },
   {
-    "s": "IMDb Keywords",
+    "s": "IMDb (Keywords)",
     "d": "www.imdb.com",
     "t": "imdbk",
     "u": "https://www.imdb.com/find?s=kw&q={{{s}}}",
@@ -40462,7 +40462,7 @@
     "sc": "Movies"
   },
   {
-    "s": "IMDB name",
+    "s": "IMDb (Names)",
     "d": "www.imdb.com",
     "t": "imdbn",
     "u": "https://www.imdb.com/find?s=nm&q={{{s}}}",
@@ -40486,7 +40486,7 @@
     "sc": "Movies"
   },
   {
-    "s": "IMDb TV",
+    "s": "IMDb (TV Series)",
     "d": "www.imdb.com",
     "t": "imdbtv",
     "u": "https://www.imdb.com/search/title?title={{{s}}}&title_type=tv_series",
@@ -40529,7 +40529,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Google Image Search - Creative Commons",
+    "s": "Google Images (Creative Commons)",
     "d": "www.google.com",
     "t": "imgrwm",
     "u": "https://www.google.com/search?q={{{s}}}&udm=2&source=lnt&tbs=sur:cl",
@@ -40545,7 +40545,7 @@
     "sc": "Images"
   },
   {
-    "s": "Upload to imgur",
+    "s": "Imgur (Upload)",
     "d": "imgur.com",
     "t": "imgurul",
     "u": "https://imgur.com/api/upload/?url={{{s}}}",
@@ -40577,7 +40577,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Impericon(de)",
+    "s": "Impericon (DE)",
     "d": "www.impericon.com",
     "t": "impericonde",
     "u": "https://www.impericon.com/de/advancedsearch/result/?q={{{s}}}",
@@ -40585,7 +40585,7 @@
     "sc": "Online"
   },
   {
-    "s": "Impericon(uk)",
+    "s": "Impericon (UK)",
     "d": "www.impericon.com",
     "t": "impericonuk",
     "u": "https://www.impericon.com/uk/advancedsearch/result/?q={{{s}}}",
@@ -40609,7 +40609,7 @@
     "sc": "Music"
   },
   {
-    "s": "Annuaire in2p3 - CNRS",
+    "s": "IN2P3 (Annuaire)",
     "d": "annuaire.in2p3.fr",
     "t": "in2p3",
     "u": "https://annuaire.in2p3.fr/search/{{{s}}}",
@@ -40617,7 +40617,7 @@
     "sc": "Academic"
   },
   {
-    "s": "INeedaBargain.com",
+    "s": "I Need a Bargain",
     "d": "www.ineedabargain.com",
     "t": "inab",
     "u": "https://www.ineedabargain.com/deals/search?q={{{s}}}",
@@ -40748,7 +40748,7 @@
     "sc": "Books"
   },
   {
-    "s": "India.com",
+    "s": "India",
     "d": "www.india.com",
     "t": "ind",
     "u": "https://www.india.com/searchresult/?q={{{s}}}",
@@ -40858,7 +40858,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Inhaltsangabe.de",
+    "s": "Inhaltsangabe",
     "d": "www.inhaltsangabe.de",
     "t": "inhalt",
     "u": "https://www.inhaltsangabe.de/?s={{{s}}}",
@@ -40866,7 +40866,7 @@
     "sc": "Learning"
   },
   {
-    "s": "initium wiki",
+    "s": "Initium Wiki",
     "d": "initium.fandom.com",
     "t": "initium",
     "u": "https://initium.fandom.com/wiki/Special:Search?query={{{s}}}",
@@ -40906,7 +40906,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Inktweb.nl",
+    "s": "Inktweb",
     "d": "www.inktweb.nl",
     "t": "inktweb",
     "u": "https://www.inktweb.nl/search.php?search={{{s}}}",
@@ -40938,7 +40938,7 @@
     "sc": "Online"
   },
   {
-    "s": "Israel National News - Arutz Sheva 7",
+    "s": "Israel National News (Arutz Sheva 7)",
     "d": "www.israelnationalnews.com",
     "t": "inn",
     "u": "https://www.israelnationalnews.com/Search.aspx?string={{{s}}}",
@@ -40970,7 +40970,7 @@
     "sc": "Search"
   },
   {
-    "s": "DDG images excluding Pinterest",
+    "s": "DuckDuckGo (Images, -Pinterest)",
     "d": "duckduckgo.com",
     "t": "inp",
     "u": "https://duckduckgo.com/?q=-site:pinterest.com+{{{s}}}&iar=images&iax=images&ia=images",
@@ -40986,7 +40986,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "lesinrocks.com",
+    "s": "Les Inrocks",
     "d": "lesinrocks.com",
     "t": "inrocks",
     "u": "https://lesinrocks.com/recherche/?q={{{s}}}",
@@ -41018,7 +41018,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Insider.in",
+    "s": "Insider",
     "d": "insider.in",
     "t": "insider",
     "u": "https://insider.in/search?q={{{s}}}",
@@ -41092,7 +41092,7 @@
     "sc": "International"
   },
   {
-    "s": "WolframAlpha integration",
+    "s": "Wolfram|Alpha (Integration)",
     "d": "www.wolframalpha.com",
     "t": "integral",
     "u": "https://www.wolframalpha.com/input/?i=integral+{{{s}}}",
@@ -41167,7 +41167,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Into.hu",
+    "s": "Into",
     "d": "into.hu",
     "t": "intohu",
     "u": "https://into.hu/kereses.php?kereses={{{s}}}&cikk=1&forum=1&letolt=1&fal=1&zene=1&kerdesek=1&page=1",
@@ -41203,7 +41203,7 @@
     "sc": "Learning"
   },
   {
-    "s": "inventaire.io",
+    "s": "Inventaire",
     "d": "inventaire.io",
     "t": "inv",
     "u": "https://inventaire.io/search?q={{{s}}}",
@@ -41235,7 +41235,7 @@
     "sc": "Academic"
   },
   {
-    "s": "iOS Developer Library",
+    "s": "Apple Developer (iOS Library)",
     "d": "developer.apple.com",
     "t": "ios",
     "u": "https://developer.apple.com/library/ios/search/?q={{{s}}}",
@@ -41251,7 +41251,7 @@
     "sc": "Companies"
   },
   {
-    "s": "IP-API.com",
+    "s": "IP-API",
     "d": "ip-api.com",
     "t": "ipapi",
     "u": "https://ip-api.com/#{{{s}}}",
@@ -41291,7 +41291,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "ipinfo.io",
+    "s": "IPinfo",
     "d": "ipinfo.io",
     "t": "ipinfo",
     "u": "https://ipinfo.io/{{{s}}}",
@@ -41326,7 +41326,7 @@
     "sc": "Sysadmin (network)"
   },
   {
-    "s": "theel0ja.info's IPLookup",
+    "s": "IPLookup",
     "d": "iplookup.theel0ja.info",
     "t": "iplookup",
     "u": "https://iplookup.theel0ja.info/?host={{{s}}}",
@@ -41369,7 +41369,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "chair6.net",
+    "s": "Chair6 (Ready)",
     "d": "ready.chair6.net",
     "t": "ipv6",
     "u": "https://ready.chair6.net/?url={{{s}}}",
@@ -41385,7 +41385,7 @@
     "sc": "Tools"
   },
   {
-    "s": "WhatIsMyIPAddress.com",
+    "s": "WhatIsMyIPAddress",
     "d": "whatismyipaddress.com",
     "t": "ip",
     "u": "https://whatismyipaddress.com/ip/{{{s}}}",
@@ -41393,7 +41393,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "iqdb",
+    "s": "IQDB",
     "d": "iqdb.org",
     "t": "iqdb",
     "u": "https://iqdb.org/?url={{{s}}}",
@@ -41409,7 +41409,7 @@
     "sc": "Social (intl)"
   },
   {
-    "s": "irc.netsplit.de",
+    "s": "IRC Netsplit",
     "d": "irc.netsplit.de",
     "t": "irc",
     "u": "https://irc.netsplit.de/channels/?chat={{{s}}}",
@@ -41465,7 +41465,7 @@
     "sc": "Government"
   },
   {
-    "s": "ISACA.org",
+    "s": "ISACA",
     "d": "www.isaca.org",
     "t": "isaca",
     "u": "https://www.isaca.org/Search/Pages/DefaultResults.aspx?k=Test&s={{{s}}}",
@@ -41607,7 +41607,7 @@
     "sc": "Online"
   },
   {
-    "s": "Islamqa.com",
+    "s": "IslamQA",
     "d": "islamqa.info",
     "t": "islamqa",
     "u": "https://islamqa.info/en/search?key={{{s}}}&yt0=search",
@@ -41651,7 +41651,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "isprimenumber",
+    "s": "Calculator.net (Is Prime)",
     "d": "www.calculator.net",
     "t": "isprime",
     "u": "https://www.calculator.net/prime-factorization-calculator.html?cvar={{{s}}}&x=Calculate",
@@ -41733,7 +41733,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "DuckDuckGo Italy",
+    "s": "DuckDuckGo (Italy)",
     "d": "duckduckgo.com",
     "t": "ddg-it",
     "u": "https://duckduckgo.com/?q={{{s}}}&kl=it-it",
@@ -41757,7 +41757,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "Google translate it-es",
+    "s": "Google Translate (it-es)",
     "d": "translate.google.com",
     "t": "ites",
     "u": "https://translate.google.com/#it/es/{{{s}}}",
@@ -41773,7 +41773,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Google Translate it-hu",
+    "s": "Google Translate (it-hu)",
     "d": "translate.google.com",
     "t": "ithu",
     "u": "https://translate.google.com/#it/hu/{{{s}}}",
@@ -41925,7 +41925,7 @@
     "sc": "Reference"
   },
   {
-    "s": "instantwatcher",
+    "s": "InstantWatcher",
     "d": "instantwatcher.com",
     "t": "iw",
     "u": "https://instantwatcher.com/search?content_type=1+2&source=1+2+3&q={{{s}}}",
@@ -41992,7 +41992,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Google Translate (ja2en)",
+    "s": "Google Translate (ja-en)",
     "d": "translate.google.com",
     "t": "ja2en",
     "ts": [
@@ -42003,7 +42003,7 @@
     "sc": "Google"
   },
   {
-    "s": "Jabong.com",
+    "s": "Jabong",
     "d": "www.jabong.com",
     "t": "jab",
     "u": "https://www.jabong.com/find/{{{s}}}",
@@ -42116,7 +42116,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Joomla API (Kagi Search)",
+    "s": "Joomla API (Kagi)",
     "d": "kagi.com",
     "ad": "api.joomla.org",
     "t": "japi",
@@ -42125,7 +42125,7 @@
     "sc": "Languages (php)"
   },
   {
-    "s": "support.justaddpower.com",
+    "s": "Just Add Power (Support)",
     "d": "support.justaddpower.com",
     "t": "jap",
     "u": "https://support.justaddpower.com/kb/search/?q={{{s}}}",
@@ -42133,7 +42133,7 @@
     "sc": "Companies"
   },
   {
-    "s": "FindJar.com",
+    "s": "FindJar",
     "d": "www.findjar.com",
     "t": "jar",
     "u": "https://www.findjar.com/index.x?query={{{s}}}",
@@ -42141,7 +42141,7 @@
     "sc": "Languages (java)"
   },
   {
-    "s": "Jargon File (Kagi Search)",
+    "s": "Jargon File (Kagi)",
     "d": "kagi.com",
     "ad": "catb.org",
     "t": "jargon",
@@ -42150,7 +42150,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "Java 11 API (Kagi Search)",
+    "s": "Java 11 API (Kagi)",
     "d": "kagi.com",
     "ad": "docs.oracle.com/en/java/javase/11/docs/api/",
     "t": "java11",
@@ -42159,7 +42159,7 @@
     "sc": "Languages (java)"
   },
   {
-    "s": "Java4 Docs",
+    "s": "Oracle (Java 1.4.2 Docs)",
     "d": "search.oracle.com",
     "t": "java4",
     "u": "https://search.oracle.com/search/search?tzoffset=420&default=true&q={{{s}}}+url:/javase/1.4.2/docs&start=1&nodeid=&fid=&showSimilarDoc=true&group=Documentation&keyword=&x=0&y=0",
@@ -42167,7 +42167,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Java5 Docs",
+    "s": "Oracle (Java 1.5 Docs)",
     "d": "search.oracle.com",
     "t": "java5",
     "u": "https://search.oracle.com/search/search?tzoffset=420&default=true&q={{{s}}}+url:/javase/1.5.0/docs&start=1&nodeid=&fid=&showSimilarDoc=true&group=Documentation&keyword=&x=0&y=0",
@@ -42175,7 +42175,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Java6 Docs",
+    "s": "Oracle (Java 6 Docs)",
     "d": "search.oracle.com",
     "t": "java6",
     "u": "https://search.oracle.com/search/search?tzoffset=420&default=true&q={{{s}}}+url:/javase/6/docs&start=1&nodeid=&fid=&showSimilarDoc=true&group=Documentation&keyword=&x=0&y=0",
@@ -42183,7 +42183,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Oracle Help Center",
+    "s": "Oracle Help Center (Java 7)",
     "d": "docs.oracle.com",
     "t": "java7",
     "u": "https://docs.oracle.com/apps/search/search.jsp?q={{{s}}}&category=java&product=e17409-01",
@@ -42191,7 +42191,7 @@
     "sc": "Languages (java)"
   },
   {
-    "s": "Java 8 API (Kagi Search)",
+    "s": "Java 8 API (Kagi)",
     "d": "kagi.com",
     "ad": "docs.oracle.com/javase/8/docs/api/",
     "t": "java8",
@@ -42200,7 +42200,7 @@
     "sc": "Languages (java)"
   },
   {
-    "s": "Java Oracle documentation",
+    "s": "Oracle Help Center (Java 9)",
     "d": "docs.oracle.com",
     "t": "java9",
     "ts": [
@@ -42211,7 +42211,7 @@
     "sc": "Languages (java)"
   },
   {
-    "s": "Oracle JavaFX",
+    "s": "Oracle (JavaFX)",
     "d": "search.oracle.com",
     "t": "javafx",
     "u": "https://search.oracle.com/search/search?num=10&exttimeout=false&q={{{s}}}+url:/javase/8/javafx/api&group=Documentation",
@@ -42343,7 +42343,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Jbovlaste - search the lojban dictionary in any language",
+    "s": "jbovlaste",
     "d": "jbovlaste.lojban.org",
     "t": "jbovlaste",
     "u": "https://jbovlaste.lojban.org/dict/{{{s}}}",
@@ -42391,7 +42391,7 @@
     "sc": "Blogs (intl)"
   },
   {
-    "s": "JustDial India",
+    "s": "JustDial (India)",
     "d": "www.justdial.com",
     "t": "jdin",
     "u": "https://www.justdial.com/National-Search/{{{s}}}",
@@ -42415,7 +42415,7 @@
     "sc": "Business"
   },
   {
-    "s": "JustDial Pune",
+    "s": "JustDial (Pune)",
     "d": "www.justdial.com",
     "t": "jdpune",
     "u": "https://www.justdial.com/Pune/{{{s}}}",
@@ -42439,7 +42439,7 @@
     "sc": "Online"
   },
   {
-    "s": "Jedipedia.net",
+    "s": "Jedipedia",
     "d": "www.jedipedia.net",
     "t": "jedi",
     "u": "https://www.jedipedia.net/w/index.php?search={{{s}}}",
@@ -42639,7 +42639,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Jisho.org",
+    "s": "Jisho",
     "d": "jisho.org",
     "t": "ji",
     "ts": [
@@ -42654,7 +42654,7 @@
     ]
   },
   {
-    "s": "Jisho (kanji search)",
+    "s": "Jisho (Kanji)",
     "d": "jisho.org",
     "t": "jik",
     "u": "https://jisho.org/search/{{{s}}}%20%23kanji",
@@ -42762,7 +42762,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Jemepropose.com",
+    "s": "Jemepropose",
     "d": "www.jemepropose.com",
     "t": "jmp",
     "u": "https://www.jemepropose.com/annonces?keywords={{{s}}}",
@@ -43005,7 +43005,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "jquery",
+    "s": "jQuery",
     "d": "api.jquery.com",
     "t": "jqd",
     "u": "https://api.jquery.com/{{{s}}}/",
@@ -43013,7 +43013,7 @@
     "sc": "Languages (javascript)"
   },
   {
-    "s": "jQuery Docs",
+    "s": "jQuery (Docs)",
     "d": "api.jquery.com",
     "t": "jq",
     "ts": [
@@ -43120,7 +43120,7 @@
     "sc": "Forum"
   },
   {
-    "s": "Mozilla Developer Network (JS)",
+    "s": "MDN Web Docs (JS)",
     "d": "developer.mozilla.org",
     "t": "js",
     "ts": [
@@ -43131,7 +43131,7 @@
     "sc": "Languages (javascript)"
   },
   {
-    "s": "Java questions on Stack Overflow",
+    "s": "Stack Overflow (Java)",
     "d": "stackoverflow.com",
     "t": "jso",
     "u": "https://stackoverflow.com/search?q=[java]+{{{s}}}",
@@ -43163,7 +43163,7 @@
     "sc": "Books"
   },
   {
-    "s": "Java Tutorial (Oracle)",
+    "s": "Oracle (Java Tutorial)",
     "d": "search.oracle.com",
     "t": "jtut",
     "u": "https://search.oracle.com/search/search?search_p_main_operator=all&group=Documentation&q={{{s}}}+url:/javase/tutorial",
@@ -43243,7 +43243,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Junat.net",
+    "s": "Junat",
     "d": "www.junat.net",
     "t": "junat",
     "u": "https://www.junat.net/en/{{{s}}}",
@@ -43294,7 +43294,7 @@
     "sc": "Law"
   },
   {
-    "s": "Justice - obchodní rejstřík",
+    "s": "Obchodní Rejstřík (Justice)",
     "d": "or.justice.cz",
     "t": "justice",
     "u": "https://or.justice.cz/ias/ui/rejstrik-$firma?jenPlatne=PLATNE&nazev={{{s}}}",
@@ -43377,7 +43377,7 @@
     "sc": "Tools"
   },
   {
-    "s": "JapaneseVehicles.com",
+    "s": "Japanese Vehicles",
     "d": "www.japanesevehicles.com",
     "t": "jvj",
     "u": "https://www.japanesevehicles.com/stocklist.php?qsearch_kbn=1&lang=en&opt=0&qsearch={{{s}}}",
@@ -43385,7 +43385,7 @@
     "sc": "Online (intl)"
   },
   {
-    "s": "Jehovas Zeugen — Offizielle Website: jw.org",
+    "s": "Jehovah's Witnesses (German)",
     "d": "www.jw.org",
     "t": "jwde",
     "u": "https://www.jw.org/de/suche/?q={{{s}}}",
@@ -43393,7 +43393,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Sitio oficial de los testigos de Jehová: jw.org",
+    "s": "Jehovah's Witnesses (Spanish)",
     "d": "www.jw.org",
     "t": "jwes",
     "u": "https://www.jw.org/es/búsquedas/?q={{{s}}}:",
@@ -43543,7 +43543,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Kaleva.fi",
+    "s": "Kaleva",
     "d": "www.kaleva.fi",
     "t": "kaleva",
     "u": "https://www.kaleva.fi/haku/?search={{{s}}}",
@@ -43653,7 +43653,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Khan Academy (Profile Page)",
+    "s": "Khan Academy (User)",
     "d": "www.khanacademy.org",
     "t": "kaprof",
     "u": "https://www.khanacademy.org/profile/{{{s}}}/",
@@ -43761,7 +43761,7 @@
     "sc": "Services"
   },
   {
-    "s": "Keybase (Kagi Search)",
+    "s": "Keybase (Kagi)",
     "d": "kagi.com",
     "ad": "keybase.io",
     "t": "kb",
@@ -43834,7 +43834,7 @@
     "sc": "Programming"
   },
   {
-    "s": "KaOS",
+    "s": "GitHub (KaOS Community Packages)",
     "d": "github.com",
     "t": "kcp",
     "u": "https://github.com/KaOS-Community-Packages?query={{{s}}}",
@@ -44126,7 +44126,7 @@
     "sc": "Services"
   },
   {
-    "s": "Kijiji Great Montreal",
+    "s": "Kijiji (Grand Montreal)",
     "d": "www.kijiji.ca",
     "t": "kijijigm",
     "u": "https://www.kijiji.ca/b-grand-montreal/{{{s}}}/k0l80002",
@@ -44150,7 +44150,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Kijiji Ottawa/Gatineau",
+    "s": "Kijiji (Ottawa-Gatineau)",
     "d": "www.kijiji.ca",
     "t": "kijijiog",
     "u": "https://www.kijiji.ca/b-ottawa-gatineau-area/{{{s}}}/k0l1700184?dc=true",
@@ -44158,7 +44158,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Kijiji Calgary",
+    "s": "Kijiji (Calgary)",
     "d": "www.kijiji.ca",
     "t": "kijijiyyc",
     "u": "https://www.kijiji.ca/b-calgary/{{{s}}}/k0l1700199?dc=true",
@@ -44214,7 +44214,7 @@
     "sc": "Tech"
   },
   {
-    "s": "KinderFilmListe.de",
+    "s": "KinderFilmListe",
     "d": "www.kinderfilmliste.de",
     "t": "kinderfilmliste",
     "u": "https://www.kinderfilmliste.de/?suche={{{s}}}",
@@ -44222,7 +44222,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Amazon Kindle",
+    "s": "Amazon (Kindle)",
     "d": "www.amazon.com",
     "t": "kindle",
     "u": "https://www.amazon.com/s?k={{{s}}}&i=digital-text",
@@ -44238,7 +44238,7 @@
     "sc": "Online"
   },
   {
-    "s": "Kindle Shop (German)",
+    "s": "Amazon (Kindle, Germany)",
     "d": "www.amazon.de",
     "t": "kindlede",
     "u": "https://www.amazon.de/s?k={{{s}}}&i=digital-text",
@@ -44254,7 +44254,7 @@
     "sc": "Online"
   },
   {
-    "s": "Amazon Kindle (Japan)",
+    "s": "Amazon (Kindle, Japan)",
     "d": "www.amazon.co.jp",
     "t": "kindlejp",
     "u": "https://www.amazon.co.jp/s?k={{{s}}}&i=digital-text",
@@ -44262,7 +44262,7 @@
     "sc": "Online"
   },
   {
-    "s": "Amazon UK Kindle",
+    "s": "Amazon (Kindle, UK)",
     "d": "www.amazon.co.uk",
     "t": "kindleuk",
     "u": "https://www.amazon.co.uk/s?k={{{s}}}&i=digital-text",
@@ -44391,7 +44391,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Kjell & Company Norge",
+    "s": "Kjell & Company (Norway)",
     "d": "www.kjell.com",
     "t": "kjellno",
     "u": "https://www.kjell.com/no/sok?query={{{s}}}",
@@ -44407,7 +44407,7 @@
     "sc": "Search"
   },
   {
-    "s": "King James Bible Study",
+    "s": "Bible Study Tools (KJV)",
     "d": "www.biblestudytools.com",
     "t": "kj",
     "u": "https://www.biblestudytools.com/search/?q={{{s}}}&s=Bibles&t=kjv",
@@ -44463,7 +44463,7 @@
     "sc": "Online"
   },
   {
-    "s": "Konsolentreff.de",
+    "s": "Konsolentreff",
     "d": "www.konsolentreff.de",
     "t": "kon",
     "u": "https://www.konsolentreff.de/search/1/?q={{{s}}}",
@@ -44562,7 +44562,7 @@
     "sc": "Companies"
   },
   {
-    "s": "forum.keyboardmaestro.com",
+    "s": "Keyboard Maestro (Forum)",
     "d": "forum.keyboardmaestro.com",
     "t": "kmf",
     "u": "https://forum.keyboardmaestro.com/search?q={{{s}}}",
@@ -44638,7 +44638,7 @@
     "sc": "Books"
   },
   {
-    "s": "Kobo NZ",
+    "s": "Kobo (New Zealand)",
     "d": "www.kobo.com",
     "t": "kobonz",
     "u": "https://www.kobo.com/nz/en/search?Query={{{s}}}",
@@ -44646,7 +44646,7 @@
     "sc": "Online"
   },
   {
-    "s": "KOBV.de",
+    "s": "KOBV",
     "d": "portal.kobv.de",
     "t": "kobv",
     "u": "https://portal.kobv.de/simpleSearch.do?query={{{s}}}",
@@ -44690,7 +44690,7 @@
     "sc": "Games (offline)"
   },
   {
-    "s": "Kogan.com",
+    "s": "Kogan",
     "d": "www.kogan.com",
     "t": "kogan",
     "u": "https://www.kogan.com/au/shop/?q={{{s}}}",
@@ -44730,7 +44730,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Kollekt.FM",
+    "s": "Kollekt",
     "d": "kollekt.fm",
     "t": "kollekt",
     "u": "https://kollekt.fm/search/?q={{{s}}}&type=all",
@@ -44746,7 +44746,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "The KoLwiki",
+    "s": "KoLwiki",
     "d": "kol.coldfront.net",
     "t": "kol",
     "ts": [
@@ -44808,7 +44808,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Reverso Konjugator",
+    "s": "bab.la (German Conjugation)",
     "d": "de.bab.la",
     "t": "konj",
     "u": "https://de.bab.la/konjugieren/deutsch/{{{s}}}",
@@ -45078,7 +45078,7 @@
     "sc": "Design"
   },
   {
-    "s": "Kritiker.se",
+    "s": "Kritiker",
     "d": "kritiker.se",
     "t": "kritiker",
     "u": "https://kritiker.se/sok/?q={{{s}}}",
@@ -45250,7 +45250,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "Kuopassa.net",
+    "s": "Kuopassa",
     "d": "kuopassa.net",
     "t": "kuopassa",
     "u": "https://kuopassa.net/haku/?q={{{s}}}",
@@ -45395,7 +45395,7 @@
     "sc": "Radio"
   },
   {
-    "s": "L3utterfish Blog (Kagi Search)",
+    "s": "L3utterfish Blog (Kagi)",
     "d": "kagi.com",
     "ad": "l3utterfish.blogspot.com",
     "t": "l3u",
@@ -45420,7 +45420,7 @@
     "sc": "Reference (science)"
   },
   {
-    "s": "Library and Archives Canada Collection Search",
+    "s": "Library and Archives Canada (Collection)",
     "d": "www.bac-lac.gc.ca",
     "t": "lac",
     "u": "https://www.bac-lac.gc.ca/eng/collectionsearch/Pages/collectionsearch.aspx?q={{{s}}}",
@@ -45436,7 +45436,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Glosbe",
+    "s": "Glosbe (la-en)",
     "d": "glosbe.com",
     "t": "lad",
     "u": "https://glosbe.com/la/en/{{{s}}}",
@@ -45484,7 +45484,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Langenscheidt (de2en)",
+    "s": "Langenscheidt (de-en)",
     "d": "de.langenscheidt.com",
     "t": "la",
     "u": "https://de.langenscheidt.com/deutsch-englisch/search?term={{{s}}}",
@@ -45492,7 +45492,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "https://forum.lametayel.co.il/",
+    "s": "Lametayel (Forum)",
     "d": "forum.lametayel.co.il",
     "t": "lametayel",
     "u": "https://forum.lametayel.co.il/index.php?t=search&forum_limiter=0&field=all&search_logic=AND&type=msg&srch={{{s}}}&btn_submit=",
@@ -45551,7 +45551,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "LaOpinione.com",
+    "s": "La Opinione",
     "d": "laopinione.com",
     "t": "laopinione",
     "u": "https://laopinione.com/?s={{{s}}}",
@@ -45626,7 +45626,7 @@
     "sc": "Languages (php)"
   },
   {
-    "s": "Larousse EN - FR translation",
+    "s": "Larousse (en-fr)",
     "d": "www.larousse.fr",
     "t": "larenfr",
     "u": "https://www.larousse.fr/dictionnaires/anglais-francais/{{{s}}}",
@@ -45634,7 +45634,7 @@
     "sc": "Learning (intl)"
   },
   {
-    "s": "Larousse (es2fr)",
+    "s": "Larousse (es-fr)",
     "d": "www.larousse.fr",
     "t": "laresfr",
     "u": "https://www.larousse.fr/dictionnaires/espagnol-francais/{{{s}}}/",
@@ -45642,7 +45642,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Larousse FR - EN translation",
+    "s": "Larousse (fr-en)",
     "d": "www.larousse.fr",
     "t": "larfren",
     "u": "https://www.larousse.fr/dictionnaires/rechercher?q={{{s}}}&l=francais-anglais&culture=",
@@ -45650,7 +45650,7 @@
     "sc": "Search"
   },
   {
-    "s": "Larousse (fr2es)",
+    "s": "Larousse (fr-es)",
     "d": "www.larousse.fr",
     "t": "larfres",
     "u": "https://www.larousse.fr/dictionnaires/francais-espagnol/{{{s}}}/",
@@ -45658,7 +45658,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Larousse (fr2it)",
+    "s": "Larousse (fr-it)",
     "d": "www.larousse.fr",
     "t": "larfrit",
     "u": "https://www.larousse.fr/dictionnaires/francais-italien/{{{s}}}/",
@@ -45677,7 +45677,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "Latin Word Study Tool",
+    "s": "Perseus Digital Library (Latin)",
     "d": "www.perseus.tufts.edu",
     "t": "las",
     "u": "https://www.perseus.tufts.edu/hopper/morph?&la=la&l={{{s}}}&la=la",
@@ -45693,7 +45693,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Last.fm",
+    "s": "last.fm",
     "d": "www.last.fm",
     "t": "lastfm",
     "ts": [
@@ -45704,7 +45704,7 @@
     "sc": "Music"
   },
   {
-    "s": "last.fm music",
+    "s": "last.fm (Music)",
     "d": "www.last.fm",
     "t": "lfm",
     "ts": [
@@ -45723,7 +45723,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Latein Wörterbuch",
+    "s": "Albert Martin (Latein)",
     "d": "www.albertmartin.de",
     "t": "lateinde",
     "u": "https://www.albertmartin.de/latein/?q={{{s}}}",
@@ -45743,7 +45743,7 @@
     "sc": "Online"
   },
   {
-    "s": "LaTeX - Wikibooks",
+    "s": "Wikibooks (LaTeX)",
     "d": "en.wikibooks.org",
     "t": "latexwb",
     "u": "https://en.wikibooks.org/wiki/Search?search={{{s}}}&prefix=LaTeX",
@@ -45778,7 +45778,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "LatLong.net",
+    "s": "LatLong",
     "d": "www.latlong.net",
     "t": "latlong",
     "u": "https://www.latlong.net/search.php?keyword={{{s}}}",
@@ -45786,7 +45786,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Whitaker's Latin",
+    "s": "Whitaker's Words (Latin)",
     "d": "www.archives.nd.edu",
     "t": "lat",
     "ts": [
@@ -45835,7 +45835,7 @@
     "sc": "Law"
   },
   {
-    "s": "Lawphil.net",
+    "s": "Lawphil",
     "d": "cse.google.com",
     "t": "lawphil",
     "u": "https://cse.google.com/cse?cx=000327027907964447955:65fjwortx5c&q={{{s}}}",
@@ -45843,7 +45843,7 @@
     "sc": "Law"
   },
   {
-    "s": "Global-Regulation.com",
+    "s": "Global Regulation",
     "d": "www.global-regulation.com",
     "t": "laws",
     "u": "https://www.global-regulation.com/search.php?year&country&province&d=1&start&q={{{s}}}&advanced=false",
@@ -45899,7 +45899,7 @@
     "sc": "Online"
   },
   {
-    "s": "Le Bon Coin IDF",
+    "s": "Leboncoin (Île-de-France)",
     "d": "www.leboncoin.fr",
     "t": "lbcidf",
     "u": "https://www.leboncoin.fr/recherche/?text={{{s}}}&regions=12",
@@ -45907,7 +45907,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Le Bon Coin",
+    "s": "Leboncoin",
     "d": "www.leboncoin.fr",
     "t": "lbc",
     "ts": [
@@ -45918,7 +45918,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Le Bon Coin Rhone-Alpes",
+    "s": "Leboncoin (Rhône-Alpes)",
     "d": "www.leboncoin.fr",
     "t": "lbcra",
     "u": "https://www.leboncoin.fr/recherche/?text={{{s}}}&regions=22",
@@ -45971,7 +45971,7 @@
     "sc": "Images"
   },
   {
-    "s": "Library of Congress LCCN search",
+    "s": "Library of Congress (LCCN)",
     "d": "lccn.loc.gov",
     "t": "lccn",
     "u": "https://lccn.loc.gov/{{{s}}}",
@@ -45995,7 +45995,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Larousse Conjugaison",
+    "s": "Larousse (Conjugaison)",
     "d": "www.larousse.fr",
     "t": "lconj",
     "u": "https://www.larousse.fr/conjugaison/francais/{{{s}}}",
@@ -46019,7 +46019,7 @@
     "sc": "Music"
   },
   {
-    "s": "Langenscheid Deutsch-Arabisch",
+    "s": "Langenscheidt (de-ar)",
     "d": "de.langenscheidt.com",
     "t": "lda",
     "u": "https://de.langenscheidt.com/deutsch-arabisch/search?term={{{s}}}",
@@ -46067,7 +46067,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Lav-det-selv.dk",
+    "s": "Lav-det-selv",
     "d": "www.lav-det-selv.dk",
     "t": "ldsdk",
     "u": "https://www.lav-det-selv.dk/find?q={{{s}}}",
@@ -46075,7 +46075,7 @@
     "sc": "Forum"
   },
   {
-    "s": "LDS.org",
+    "s": "LDS",
     "d": "www.lds.org",
     "t": "lds",
     "u": "https://www.lds.org/search?lang=eng&query={{{s}}}",
@@ -46083,7 +46083,7 @@
     "sc": "Reference (religion)"
   },
   {
-    "s": "LDS Scriptures",
+    "s": "LDS (Scriptures)",
     "d": "www.lds.org",
     "t": "ldss",
     "u": "https://www.lds.org/scriptures/search?lang=eng&query={{{s}}}",
@@ -46112,7 +46112,7 @@
     "sc": "Learning"
   },
   {
-    "s": "LearnGaelic.net",
+    "s": "LearnGaelic",
     "d": "www.learngaelic.net",
     "t": "learngaelic",
     "u": "https://www.learngaelic.net/dictionary/index.jsp?slang=both&wholeword=false&abairt={{{s}}}",
@@ -46136,7 +46136,7 @@
     "sc": "Learning"
   },
   {
-    "s": "league of legends summoner school",
+    "s": "Reddit (/r/summonerschool)",
     "d": "www.reddit.com",
     "t": "learnlol",
     "u": "https://www.reddit.com/r/summonerschool/search/?q={{{s}}}&restrict_sr=1",
@@ -46196,7 +46196,7 @@
     "sc": "Search"
   },
   {
-    "s": "Linguee EN FR",
+    "s": "Linguee (en-fr)",
     "d": "www.linguee.com",
     "t": "lef",
     "u": "https://www.linguee.com/english-french/search?source=french&query={{{s}}}",
@@ -46204,7 +46204,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Google Scholar - Legal Opinion Section",
+    "s": "Google Scholar (Legal Opinion Section)",
     "d": "scholar.google.com",
     "t": "legal",
     "u": "https://scholar.google.com/scholar?hl=en&q={{{s}}}&btnG=Search&as_sdt=2,5&as_ylo=&as_vis=0",
@@ -46212,7 +46212,7 @@
     "sc": "Google"
   },
   {
-    "s": "Legimi.pl",
+    "s": "Legimi",
     "d": "www.legimi.pl",
     "t": "legimi",
     "u": "https://www.legimi.pl/ebooki/?szukaj={{{s}}}",
@@ -46236,7 +46236,7 @@
     "sc": "Misc"
   },
   {
-    "s": "LEGO.com",
+    "s": "LEGO",
     "d": "www.lego.com",
     "t": "lego",
     "u": "https://www.lego.com/en-us/search?q={{{s}}}",
@@ -46327,13 +46327,13 @@
     "sc": "Companies"
   },
   {
-    "s": "LEO Dictionary Chinese",
+    "s": "LEO (zh-de)",
     "d": "dict.leo.org",
     "t": "leoc",
     "u": "https://dict.leo.org/chde?lp=chde&search={{{s}}}"
   },
   {
-    "s": "dict.leo.org",
+    "s": "LEO (en-de)",
     "d": "dict.leo.org",
     "t": "leo",
     "u": "https://dict.leo.org/englisch-deutsch/{{{s}}}",
@@ -46347,7 +46347,7 @@
     "u": "https://dict.leo.org/ende?lp=ende&search={{{s}}}"
   },
   {
-    "s": "LEO Dictionary French",
+    "s": "LEO (fr-de)",
     "d": "dict.leo.org",
     "t": "leofr",
     "ts": [
@@ -46358,7 +46358,7 @@
     "sc": "Tools"
   },
   {
-    "s": "LEO Dictionary Italian",
+    "s": "LEO (it-de)",
     "d": "dict.leo.org",
     "t": "leoi",
     "u": "https://dict.leo.org/itde?lp=itde&search={{{s}}}"
@@ -46380,7 +46380,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Leo (Polski-Deutsch)",
+    "s": "LEO (pl-de)",
     "d": "dict.leo.org",
     "t": "leopl",
     "u": "https://dict.leo.org/plde/?search={{{s}}}",
@@ -46388,7 +46388,7 @@
     "sc": "Tools"
   },
   {
-    "s": "LEO Dictionary Portuguese",
+    "s": "LEO (pt-de)",
     "d": "dict.leo.org",
     "t": "leopt",
     "u": "https://dict.leo.org/portugiesisch-deutsch/{{{s}}}",
@@ -46396,7 +46396,7 @@
     "sc": "Tools"
   },
   {
-    "s": "LEO Dictionary Russian",
+    "s": "LEO (ru-de)",
     "d": "dict.leo.org",
     "t": "leoru",
     "ts": [
@@ -46407,7 +46407,7 @@
     "sc": "Tools"
   },
   {
-    "s": "LEO Dictionary Spanish",
+    "s": "LEO (es-de)",
     "d": "dict.leo.org",
     "t": "leos",
     "u": "https://dict.leo.org/esde?lp=esde&search={{{s}}}"
@@ -46421,7 +46421,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Lernu!",
+    "s": "lernu!",
     "d": "lernu.net",
     "t": "lernuen",
     "u": "https://lernu.net/en/vortaro/{{{s}}}",
@@ -46429,7 +46429,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Lernu! (es)",
+    "s": "lernu! (Spanish)",
     "d": "lernu.net",
     "t": "lernues",
     "u": "https://lernu.net/es/vortaro/{{{s}}}",
@@ -46437,7 +46437,7 @@
     "sc": "Tools"
   },
   {
-    "s": "LeroyMerlin.it",
+    "s": "Leroy Merlin (Italy)",
     "d": "www.leroymerlin.it",
     "t": "leroymerlinit",
     "u": "https://www.leroymerlin.it/ricerca?q={{{s}}}&page=1",
@@ -46445,7 +46445,7 @@
     "sc": "Online"
   },
   {
-    "s": "Les Cris (Kagi Search)",
+    "s": "Les Cris (Kagi)",
     "d": "kagi.com",
     "ad": "les-cris.com",
     "t": "lescris",
@@ -46454,7 +46454,7 @@
     "sc": "Business"
   },
   {
-    "s": "linguee Es-Fr",
+    "s": "Linguee (es-fr)",
     "d": "www.linguee.fr",
     "t": "lesfr",
     "u": "https://www.linguee.fr/francais-espagnol/search?source=espagnol&query={{{s}}}",
@@ -46519,7 +46519,7 @@
     "sc": "Music (Lyrics)"
   },
   {
-    "s": "letras.mus.br",
+    "s": "Letras",
     "d": "letras.mus.br",
     "t": "letrasbr",
     "ts": [
@@ -46554,7 +46554,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Lew Rockwell (Kagi Search)",
+    "s": "Lew Rockwell (Kagi)",
     "d": "kagi.com",
     "ad": "lewrockwell.com",
     "t": "lewrockwell",
@@ -46595,7 +46595,7 @@
     "sc": "Law"
   },
   {
-    "s": "lexparency.org",
+    "s": "Lexparency",
     "d": "lexparency.org",
     "t": "lexp",
     "u": "https://lexparency.org/eu/EN/search?deep=True&search_words={{{s}}}",
@@ -46603,7 +46603,7 @@
     "sc": "Tools"
   },
   {
-    "s": "LiverpoolFC sub (old style)",
+    "s": "Reddit (/r/LiverpoolFC, Old)",
     "d": "old.reddit.com",
     "t": "lfc",
     "u": "https://old.reddit.com/r/LiverpoolFC/search?q={{{s}}}&restrict_sr=on",
@@ -46627,7 +46627,7 @@
     "sc": "Reference (fun)"
   },
   {
-    "s": "libregamewiki",
+    "s": "LibreGameWiki",
     "d": "libregamewiki.org",
     "t": "lgw",
     "u": "https://libregamewiki.org/index.php?search={{{s}}}",
@@ -46655,7 +46655,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Le Hollandais Volant : au fil du web",
+    "s": "Le Hollandais Volant (Au fil du web)",
     "d": "lehollandaisvolant.net",
     "t": "lhvl",
     "u": "https://lehollandaisvolant.net/?mode=links&q={{{s}}}",
@@ -46671,7 +46671,7 @@
     "sc": "Misc"
   },
   {
-    "s": "libcom.org",
+    "s": "Libcom",
     "d": "libcom.org",
     "t": "libcom",
     "u": "https://libcom.org/search/node/{{{s}}}",
@@ -46706,7 +46706,7 @@
     "sc": "Academic"
   },
   {
-    "s": "LibGDX (Kagi Search)",
+    "s": "LibGDX (Kagi)",
     "d": "kagi.com",
     "ad": "libgdx.badlogicgames.com",
     "t": "libgdx",
@@ -46723,7 +46723,7 @@
     "sc": "Local"
   },
   {
-    "s": "libraries.io",
+    "s": "Libraries.io",
     "d": "libraries.io",
     "t": "libraries",
     "ts": [
@@ -46755,7 +46755,7 @@
     "sc": "Movies"
   },
   {
-    "s": "libre.fm",
+    "s": "Libre.fm",
     "d": "libre.fm",
     "t": "librefm",
     "u": "https://libre.fm/search.php?search_term={{{s}}}",
@@ -46843,7 +46843,7 @@
     "sc": "Programming"
   },
   {
-    "s": "자유인사전(Licentium Wiki)",
+    "s": "Licentium Wiki",
     "d": "licentium.net",
     "t": "licentium",
     "u": "https://licentium.net/w/index.php?search={{{s}}}",
@@ -46851,7 +46851,7 @@
     "sc": "Docs"
   },
   {
-    "s": "linkedin.com/company",
+    "s": "LinkedIn (Companies)",
     "d": "www.linkedin.com",
     "t": "lic",
     "u": "https://www.linkedin.com/search/results/companies/?keywords={{{s}}}",
@@ -46859,7 +46859,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "Linguee (Deutsch/Englisch)",
+    "s": "Linguee (de-en)",
     "d": "www.linguee.de",
     "t": "lide",
     "ts": [
@@ -46870,7 +46870,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Linguee Deutsch <-> Français (German  <-> French)",
+    "s": "Linguee (de-fr)",
     "d": "www.linguee.de",
     "t": "lidf",
     "ts": [
@@ -46881,7 +46881,7 @@
     "sc": "General"
   },
   {
-    "s": "Linguee De-Ita",
+    "s": "Linguee (de-it)",
     "d": "www.linguee.de",
     "t": "lidi",
     "u": "https://www.linguee.de/deutsch-italienisch/search?query={{{s}}}",
@@ -46908,7 +46908,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Linguee (en2de)",
+    "s": "Linguee (en-de)",
     "d": "www.linguee.com",
     "t": "liende",
     "ts": [
@@ -46920,7 +46920,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Linguee (English <-> Italian)",
+    "s": "Linguee (en-it)",
     "d": "www.linguee.com",
     "t": "lienit",
     "u": "https://www.linguee.com/english-italian/search?source=auto&query={{{s}}}",
@@ -46928,7 +46928,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Linguee Français <-> Deutsch (German <-> French) with French interface",
+    "s": "Linguee (fr-de)",
     "d": "www.linguee.fr",
     "t": "lifd",
     "ts": [
@@ -46995,7 +46995,7 @@
     "sc": "Social"
   },
   {
-    "s": "Linguee (Hungarian - English)",
+    "s": "Linguee (en-hu)",
     "d": "www.linguee.com",
     "t": "lihu",
     "u": "https://www.linguee.com/english-hungarian/search?source=auto&query={{{s}}}",
@@ -47011,7 +47011,7 @@
     "sc": "Online"
   },
   {
-    "s": "Thesaurus.com",
+    "s": "Thesaurus",
     "d": "thesaurus.com",
     "t": "like",
     "ts": [
@@ -47090,7 +47090,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Linguee (de2pt)",
+    "s": "Linguee (de-pt)",
     "d": "www.linguee.de",
     "t": "lindp",
     "ts": [
@@ -47120,7 +47120,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Linguee English - Dutch",
+    "s": "Linguee (en-nl)",
     "d": "www.linguee.com",
     "t": "linen",
     "u": "https://www.linguee.com/english-dutch/search?source=auto&query={{{s}}}",
@@ -47128,7 +47128,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Linguee (en2pt)",
+    "s": "Linguee (en-pt)",
     "d": "www.linguee.com",
     "t": "linep",
     "ts": [
@@ -47139,7 +47139,7 @@
     "sc": "Search"
   },
   {
-    "s": "Linguee (en2es)",
+    "s": "Linguee (en-es)",
     "d": "www.linguee.com",
     "t": "lines",
     "u": "https://www.linguee.com/english-spanish/?query={{{s}}}",
@@ -47166,7 +47166,7 @@
     "sc": "Search"
   },
   {
-    "s": "Linguee (Fr-En)",
+    "s": "Linguee (fr-en)",
     "d": "www.linguee.fr",
     "t": "lingfe",
     "ts": [
@@ -47177,7 +47177,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Linguee (Fr-Nl)",
+    "s": "Linguee (fr-nl)",
     "d": "www.linguee.fr",
     "t": "lingfn",
     "u": "https://www.linguee.fr/francais-neerlandais/search?source=auto&query={{{s}}}",
@@ -47185,7 +47185,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Linguee (fr2pt)",
+    "s": "Linguee (fr-pt)",
     "d": "www.linguee.fr",
     "t": "lingfp",
     "ts": [
@@ -47196,7 +47196,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Ling.pl Angielsko-Polski",
+    "s": "Ling (en-pl)",
     "d": "ling.pl",
     "t": "ling",
     "u": "https://ling.pl/slownik/angielsko-polski/{{{s}}}",
@@ -47223,7 +47223,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "lingualeo.com",
+    "s": "LinguaLeo",
     "d": "lingualeo.com",
     "t": "lingualeo",
     "u": "https://lingualeo.com/ru/glossary/learn/dictionary#{{{s}}}",
@@ -47287,7 +47287,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Linux.org",
+    "s": "Linux",
     "d": "www.linux.org",
     "t": "linorg",
     "u": "https://www.linux.org/search/?q={{{s}}}",
@@ -47295,7 +47295,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Linguee Swedish",
+    "s": "Linguee (en-sv)",
     "d": "www.linguee.com",
     "t": "linse",
     "u": "https://www.linguee.com/english-swedish/search?query={{{s}}}",
@@ -47463,7 +47463,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "DuckDuckGo Lite",
+    "s": "DuckDuckGo (Lite)",
     "d": "duckduckgo.com",
     "t": "lite",
     "u": "https://duckduckgo.com/lite?q={{{s}}}",
@@ -47495,7 +47495,7 @@
     "sc": "Health"
   },
   {
-    "s": "luvit.io",
+    "s": "Luvit (Lit)",
     "d": "luvit.io",
     "t": "lit",
     "u": "https://luvit.io/lit.html#{{{s}}}",
@@ -47535,7 +47535,7 @@
     "sc": "Audio"
   },
   {
-    "s": "LiveChart.me",
+    "s": "LiveChart",
     "d": "www.livechart.me",
     "t": "livec",
     "u": "https://www.livechart.me/search?q={{{s}}}",
@@ -47578,7 +47578,7 @@
     "sc": "Health"
   },
   {
-    "s": "Lizzart - Original Handmade in France",
+    "s": "Lizzart",
     "d": "www.lizzart.fr",
     "t": "lizzart",
     "u": "https://www.lizzart.fr/boutique/tout/recherche.html?keyword={{{s}}}&limitstart=0&option=com_virtuemart&view=category",
@@ -47586,7 +47586,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "LiveJournal (Kagi Search)",
+    "s": "LiveJournal (Kagi)",
     "d": "kagi.com",
     "ad": "livejournal.com",
     "t": "lj",
@@ -47606,7 +47606,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "LoKan.jp",
+    "s": "LoKan",
     "d": "lokan.jp",
     "t": "lkn",
     "u": "https://lokan.jp/?s={{{s}}}",
@@ -47622,7 +47622,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Liverpool Libraries catalogue",
+    "s": "Liverpool Libraries",
     "d": "capitadiscovery.co.uk",
     "t": "lluk",
     "u": "https://capitadiscovery.co.uk/liverpool/items?query={{{s}}}",
@@ -47630,7 +47630,7 @@
     "sc": "Topical"
   },
   {
-    "s": "LLVM (Kagi Search)",
+    "s": "LLVM (Kagi)",
     "d": "kagi.com",
     "ad": "llvm.org",
     "t": "llvm",
@@ -47647,7 +47647,7 @@
     "sc": "Online"
   },
   {
-    "s": "LMDDGTFY.NET",
+    "s": "LMDDGTFY",
     "d": "lmddgtfy.net",
     "t": "lmddgtfy",
     "u": "https://lmddgtfy.net/?q={{{s}}}",
@@ -47679,7 +47679,7 @@
     "sc": "Music"
   },
   {
-    "s": "lmms wiki",
+    "s": "LMMS (Wiki)",
     "d": "lmms.io",
     "t": "lmms",
     "u": "https://lmms.io/wiki/index.php?title=Special:Search&profile=default&search={{{s}}}&fulltext=Search",
@@ -47711,7 +47711,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "lostmediawiki",
+    "s": "Lost Media Wiki",
     "d": "lostmediawiki.com",
     "t": "lmw",
     "u": "https://lostmediawiki.com/index.php?search={{{s}}}",
@@ -47743,7 +47743,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Linnéuniversitetet Bibliotek LNU",
+    "s": "Linnaeus University Library",
     "d": "lnu-se-primo.hosted.exlibrisgroup.com",
     "t": "lnu",
     "u": "https://lnu-se-primo.hosted.exlibrisgroup.com/primo-explore/search?query=any,contains,{{{s}}}&search_scope=default_scope&sortby=rank&vid=primo-custom-lnu&pcAvailability=false&lang=sv_SE",
@@ -47791,7 +47791,7 @@
     "sc": "Search"
   },
   {
-    "s": "Time an Date (local time)",
+    "s": "Time and Date (Local Time)",
     "d": "www.timeanddate.com",
     "t": "localtime",
     "u": "https://www.timeanddate.com/time/zone/?query={{{s}}}",
@@ -47815,7 +47815,7 @@
     "sc": "Government"
   },
   {
-    "s": "lodash documentation",
+    "s": "Lodash (Documentation)",
     "d": "lodash.com",
     "t": "lodash",
     "u": "https://lodash.com/docs#{{{s}}}",
@@ -47850,7 +47850,7 @@
     "sc": "TV"
   },
   {
-    "s": "logopond",
+    "s": "LogoPond",
     "d": "logopond.com",
     "t": "logo",
     "u": "https://logopond.com/search/?search={{{s}}}",
@@ -47858,7 +47858,7 @@
     "sc": "Design"
   },
   {
-    "s": "Logo Search",
+    "s": "LogoSearch",
     "d": "logosear.ch",
     "t": "logosearch",
     "u": "https://logosear.ch/?q={{{s}}}",
@@ -47874,7 +47874,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Lojban.org (the official website and wiki)",
+    "s": "Lojban Wiki",
     "d": "mw.lojban.org",
     "t": "lojban",
     "u": "https://mw.lojban.org/index.php?search={{{s}}}&title=Special:Search&go=Go",
@@ -47882,7 +47882,7 @@
     "sc": "Learning (intl)"
   },
   {
-    "s": "lolalytics",
+    "s": "LoLalytics",
     "d": "lolalytics.com",
     "t": "lolchamp",
     "u": "https://lolalytics.com/ranked/worldwide/current/diamond/plus/champion/{{{s}}}",
@@ -47890,7 +47890,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "LocksOnline.com",
+    "s": "LocksOnline",
     "d": "www.locksonline.com",
     "t": "lolcom",
     "u": "https://www.locksonline.com/search/search.html?zoom_query={{{s}}}",
@@ -47906,7 +47906,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "LocksOnline.co.uk",
+    "s": "LocksOnline (UK)",
     "d": "www.locksonline.co.uk",
     "t": "lol",
     "u": "https://www.locksonline.co.uk/index.php?route=product/search&search={{{s}}}",
@@ -47986,7 +47986,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "LoopBack.js Documentation (Kagi Search)",
+    "s": "LoopBack.js Documentation (Kagi)",
     "d": "kagi.com",
     "ad": "loopback.io/doc/en/lb3",
     "t": "loopbackjs",
@@ -47995,7 +47995,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Loot.co.za",
+    "s": "Loot",
     "d": "www.loot.co.za",
     "t": "loot",
     "u": "https://www.loot.co.za/search?cat=b&terms={{{s}}}",
@@ -48227,7 +48227,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "Langenscheid dictionary German-Swedish",
+    "s": "Langenscheidt (de-sv)",
     "d": "de.langenscheidt.com",
     "t": "ls.de-sv",
     "u": "https://de.langenscheidt.com/deutsch-schwedisch/search?term={{{s}}}&q_cat=/deutsch-schwedisch/",
@@ -48302,7 +48302,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Langenscheid dictionary Swedish-German",
+    "s": "Langenscheidt (sv-de)",
     "d": "de.langenscheidt.com",
     "t": "ls.sv",
     "u": "https://de.langenscheidt.com/schwedisch-deutsch/search?term={{{s}}}&q_cat=/schwedisch-deutsch/",
@@ -48310,7 +48310,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Liquipedia Starcraft 2",
+    "s": "Liquipedia (StarCraft II)",
     "d": "liquipedia.net",
     "t": "lstarcraft",
     "u": "https://liquipedia.net/starcraft2/index.php?search={{{s}}}",
@@ -48342,7 +48342,7 @@
     "sc": "Search"
   },
   {
-    "s": "Larousse",
+    "s": "Larousse (it-fr)",
     "d": "www.larousse.fr",
     "t": "ltfr",
     "u": "https://www.larousse.fr/dictionnaires/italien-francais/{{{s}}}",
@@ -48358,7 +48358,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Linus Tech Tips Forum (Kagi Search)",
+    "s": "Linus Tech Tips Forum (Kagi)",
     "d": "kagi.com",
     "ad": "linustechtips.com",
     "t": "lttforum",
@@ -48391,7 +48391,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Lua 5.1 Documentation",
+    "s": "Lua (5.1)",
     "d": "www.lua.org",
     "t": "luadoc51",
     "u": "https://www.lua.org/manual/5.1/manual.html#pdf-{{{s}}}",
@@ -48399,7 +48399,7 @@
     "sc": "Languages (lua)"
   },
   {
-    "s": "Lua 5.2 Documentation",
+    "s": "Lua (5.2)",
     "d": "www.lua.org",
     "t": "luadoc52",
     "u": "https://www.lua.org/manual/5.2/manual.html#pdf-{{{s}}}",
@@ -48407,7 +48407,7 @@
     "sc": "Languages (lua)"
   },
   {
-    "s": "Lua 5.3 Documentation",
+    "s": "Lua (5.3)",
     "d": "www.lua.org",
     "t": "luadoc53",
     "u": "https://www.lua.org/manual/5.3/manual.html#pdf-{{{s}}}",
@@ -48434,7 +48434,7 @@
     "sc": "Languages (lua)"
   },
   {
-    "s": "lubimyczytac",
+    "s": "Lubimyczytać",
     "d": "lubimyczytac.pl",
     "t": "lubimyczytac",
     "u": "https://lubimyczytac.pl/szukaj/ksiazki?phrase={{{s}}}",
@@ -48442,7 +48442,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Lubuntu.me",
+    "s": "Lubuntu",
     "d": "lubuntu.me",
     "t": "lubuntu",
     "u": "https://lubuntu.me/?s={{{s}}}",
@@ -48458,7 +48458,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Lucire (Kagi Search)",
+    "s": "Lucire (Kagi)",
     "d": "kagi.com",
     "ad": "lucire.com",
     "t": "lucire",
@@ -48553,7 +48553,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Lupa by Piaui (Kagi Search)",
+    "s": "Lupa by Piauí (Kagi)",
     "d": "kagi.com",
     "ad": "piaui.folha.uol.com.br",
     "t": "lupa",
@@ -48562,7 +48562,7 @@
     "sc": "Tools"
   },
   {
-    "s": "BibleServer Lutherbibel 2017",
+    "s": "BibleServer (LUT)",
     "d": "www.bibleserver.com",
     "t": "lut",
     "u": "https://www.bibleserver.com/text/LUT/{{{s}}}",
@@ -48578,7 +48578,7 @@
     "sc": "Search"
   },
   {
-    "s": "Lutris - Open Gaming Platform",
+    "s": "Lutris",
     "d": "lutris.net",
     "t": "lutris",
     "u": "https://lutris.net/games/?q={{{s}}}",
@@ -48658,7 +48658,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "LWJGL Javadoc (Kagi Search)",
+    "s": "LWJGL Javadoc (Kagi)",
     "d": "kagi.com",
     "ad": "lwjgl.org/javadoc/",
     "t": "lwjgl",
@@ -48675,7 +48675,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "LWN.net",
+    "s": "LWN",
     "d": "lwn.net",
     "t": "lwn",
     "u": "https://lwn.net/Search/DoSearch?words={{{s}}}",
@@ -48699,7 +48699,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "MARC Linux Kernel",
+    "s": "MARC.info (Linux Kernel)",
     "d": "marc.info",
     "t": "lxml",
     "u": "https://marc.info/?l=linux-kernel&w=2&r=1&s={{{s}}}&q=b",
@@ -48707,7 +48707,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Linux Cross Reference",
+    "s": "Elixir Bootlin (Linux)",
     "d": "elixir.bootlin.com",
     "t": "lxr",
     "u": "https://elixir.bootlin.com/linux/latest/ident/{{{s}}}",
@@ -48723,7 +48723,7 @@
     "sc": "Search"
   },
   {
-    "s": "Lyle McDonald Forums (Kagi Search)",
+    "s": "Lyle McDonald Forums (Kagi)",
     "d": "kagi.com",
     "ad": "forums.lylemcdonald.com",
     "t": "lyle",
@@ -48732,7 +48732,7 @@
     "sc": "Health"
   },
   {
-    "s": "Lynda.com",
+    "s": "Lynda",
     "d": "www.lynda.com",
     "t": "lynda",
     "u": "https://www.lynda.com/search?q={{{s}}}",
@@ -48740,7 +48740,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Lyrical Nonsense (Kagi Search)",
+    "s": "Lyrical Nonsense (Kagi)",
     "d": "kagi.com",
     "ad": "lyrical-nonsense.com",
     "t": "lyrical",
@@ -48844,7 +48844,7 @@
     "sc": "Online (intl)"
   },
   {
-    "s": "Metal Archives (album)",
+    "s": "Metal Archives (Albums)",
     "d": "www.metal-archives.com",
     "t": "maalbum",
     "u": "https://www.metal-archives.com/search?searchString={{{s}}}&type=album_title",
@@ -48860,7 +48860,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "Metal Archives",
+    "s": "Metal Archives (Bands)",
     "d": "www.metal-archives.com",
     "t": "maband",
     "ts": [
@@ -48874,7 +48874,7 @@
     "sc": "Music"
   },
   {
-    "s": "Encyclopaedia metallum",
+    "s": "Metal Archives",
     "d": "www.metal-archives.com",
     "t": "mab",
     "u": "https://www.metal-archives.com/search?type=band_name&searchString={{{s}}}",
@@ -48890,7 +48890,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Macmillan Dictionary (British)",
+    "s": "Macmillan Dictionary (UK)",
     "d": "www.macmillandictionary.com",
     "t": "macbrit",
     "ts": [
@@ -49045,7 +49045,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Made.com",
+    "s": "Made",
     "d": "www.made.com",
     "t": "made",
     "u": "https://www.made.com/catalogsearch/result/?q={{{s}}}",
@@ -49053,7 +49053,7 @@
     "sc": "Online"
   },
   {
-    "s": "Madison.com",
+    "s": "Madison",
     "d": "host.madison.com",
     "t": "madison",
     "u": "https://host.madison.com/search/?l=25&sd=desc&s=start_time&f=html&t=article,video,youtube,collection&app=editorial&q={{{s}}}&nsa=eedition",
@@ -49085,7 +49085,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Maerklin.de",
+    "s": "Märklin",
     "d": "www.maerklin.de",
     "t": "maerklinde",
     "u": "https://www.maerklin.de/index.php?id=247&q={{{s}}}",
@@ -49137,7 +49137,7 @@
     "sc": "Games (offline)"
   },
   {
-    "s": "Magisk modules repo",
+    "s": "GitHub (Magisk Modules)",
     "d": "github.com",
     "t": "magiskmod",
     "u": "https://github.com/Magisk-Modules-Repo?&q={{{s}}}",
@@ -49180,7 +49180,7 @@
     "sc": "Languages (php)"
   },
   {
-    "s": "mailcatch.com",
+    "s": "MailCatch",
     "d": "mailcatch.com",
     "t": "mailcatch",
     "u": "https://mailcatch.com/en/temporary-inbox?box={{{s}}}",
@@ -49274,7 +49274,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Maku.fi",
+    "s": "Maku",
     "d": "www.maku.fi",
     "t": "maku",
     "u": "https://www.maku.fi/haku/recipe?q={{{s}}}",
@@ -49282,7 +49282,7 @@
     "sc": "Misc"
   },
   {
-    "s": "MyAnimeList Search All",
+    "s": "MyAnimeList (All)",
     "d": "myanimelist.net",
     "t": "malall",
     "u": "https://myanimelist.net/search/all?q={{{s}}}",
@@ -49348,7 +49348,7 @@
     "sc": "Search"
   },
   {
-    "s": "Linux Die.net Manual Page 1",
+    "s": "Die.net (Linux Man Section 1)",
     "d": "linux.die.net",
     "t": "man1",
     "u": "https://linux.die.net/man/1/{{{s}}}",
@@ -49356,7 +49356,7 @@
     "sc": "Sysadmin (man)"
   },
   {
-    "s": "Man7 Linux Pages (Kagi Search)",
+    "s": "Man7 Linux Pages (Kagi)",
     "d": "kagi.com",
     "ad": "man7.org/linux/man-pages",
     "t": "man7",
@@ -49400,7 +49400,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "MyAnimeList Manga",
+    "s": "MyAnimeList (Manga)",
     "d": "myanimelist.net",
     "t": "manga",
     "ts": [
@@ -49411,7 +49411,7 @@
     "sc": "Books"
   },
   {
-    "s": "mangarock",
+    "s": "MangaRock",
     "d": "mangarock.com",
     "t": "mangarock",
     "u": "https://mangarock.com/search?q={{{s}}}",
@@ -49462,7 +49462,7 @@
     "sc": "Sysadmin (man)"
   },
   {
-    "s": "man-k.org",
+    "s": "NetBSD (Kernel Man Pages)",
     "d": "man-k.org",
     "t": "man-k",
     "u": "https://man-k.org/search?q={{{s}}}&dist=NetBSD-current",
@@ -49486,7 +49486,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Apple Developer (Kagi Search)",
+    "s": "Apple Developer (Kagi)",
     "d": "kagi.com",
     "ad": "developer.apple.com",
     "t": "manosx",
@@ -49566,7 +49566,7 @@
     "sc": "Maps"
   },
   {
-    "s": "Google Maps FR",
+    "s": "Google Maps (France)",
     "d": "maps.google.com",
     "t": "mapsfr",
     "u": "https://maps.google.com/maps?hl=fr&q={{{s}}}",
@@ -49609,7 +49609,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Marginalia Search",
+    "s": "Marginalia",
     "d": "search.marginalia.nu",
     "t": "marginalia",
     "u": "https://search.marginalia.nu/search?query={{{s}}}",
@@ -49701,7 +49701,7 @@
     "sc": "Online"
   },
   {
-    "s": "Markos Web Tools (Kagi Search)",
+    "s": "Markos Web Tools (Kagi)",
     "d": "kagi.com",
     "ad": "markosweb.com",
     "t": "markos",
@@ -49710,7 +49710,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "Markt.de",
+    "s": "Markt",
     "d": "www.markt.de",
     "t": "markt",
     "u": "https://www.markt.de/muenchen/keywords,{{{s}}}/suche.htm",
@@ -49761,7 +49761,7 @@
     "sc": "Online"
   },
   {
-    "s": "Comics in marvel.com",
+    "s": "Marvel (Comics)",
     "d": "marvel.com",
     "t": "marvelc",
     "u": "https://marvel.com/search/?q={{{s}}}&category=comics",
@@ -49769,7 +49769,7 @@
     "sc": "Comics"
   },
   {
-    "s": "Marvel.com",
+    "s": "Marvel",
     "d": "www.marvel.com",
     "t": "marvel",
     "u": "https://www.marvel.com/search/?query={{{s}}}",
@@ -49877,7 +49877,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "Mathematics - Stack Exchange",
+    "s": "Mathematics (Stack Exchange)",
     "d": "math.stackexchange.com",
     "t": "mathse",
     "ts": [
@@ -49889,7 +49889,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "MathWorks (Kagi Search)",
+    "s": "MathWorks (Kagi)",
     "d": "kagi.com",
     "ad": "mathworks.com",
     "t": "mathworks",
@@ -49934,7 +49934,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Forum Matematyka.pl",
+    "s": "Matematyka (Forum)",
     "d": "www.matematyka.pl",
     "t": "matpl",
     "u": "https://www.matematyka.pl/search.php?keywords={{{s}}}",
@@ -50009,7 +50009,7 @@
     "sc": "Blogs (intl)"
   },
   {
-    "s": "MusicBrainz Annotations",
+    "s": "MusicBrainz (Annotations)",
     "d": "musicbrainz.org",
     "t": "mbannotation",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=annotation",
@@ -50017,7 +50017,7 @@
     "sc": "Music"
   },
   {
-    "s": "MusicBrainz Areas",
+    "s": "MusicBrainz (Areas)",
     "d": "musicbrainz.org",
     "t": "mbarea",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=area",
@@ -50025,7 +50025,7 @@
     "sc": "Music"
   },
   {
-    "s": "MusicBrainz Artists",
+    "s": "MusicBrainz (Artists)",
     "d": "musicbrainz.org",
     "t": "mbartist",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=artist",
@@ -50033,7 +50033,7 @@
     "sc": "Music"
   },
   {
-    "s": "MusicBrainz CD Stubs",
+    "s": "MusicBrainz (CD Stubs)",
     "d": "musicbrainz.org",
     "t": "mbcdstub",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=cdstub",
@@ -50049,7 +50049,7 @@
     "sc": "Food"
   },
   {
-    "s": "MusicBrainz documentation",
+    "s": "MusicBrainz (Documentation)",
     "d": "musicbrainz.org",
     "t": "mbdoc",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=doc",
@@ -50065,7 +50065,7 @@
     "sc": "Online"
   },
   {
-    "s": "MusicBrainz Editors",
+    "s": "MusicBrainz (Editors)",
     "d": "musicbrainz.org",
     "t": "mbeditor",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=editor",
@@ -50073,7 +50073,7 @@
     "sc": "Music"
   },
   {
-    "s": "MusicBrainz events",
+    "s": "MusicBrainz (Events)",
     "d": "musicbrainz.org",
     "t": "mbe",
     "ts": [
@@ -50103,7 +50103,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "MusicBrainz instruments",
+    "s": "MusicBrainz (Instruments)",
     "d": "musicbrainz.org",
     "t": "mbinstrument",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=instrument",
@@ -50119,7 +50119,7 @@
     "sc": "Music"
   },
   {
-    "s": "MusicBrainz labels",
+    "s": "MusicBrainz (Labels)",
     "d": "musicbrainz.org",
     "t": "mbl",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=label&method=indexed",
@@ -50138,7 +50138,7 @@
     "sc": "Weather"
   },
   {
-    "s": "MusicBrainz (artist)",
+    "s": "MusicBrainz (Artist)",
     "d": "musicbrainz.org",
     "t": "mb",
     "ts": [
@@ -50165,7 +50165,7 @@
     "sc": "Music"
   },
   {
-    "s": "MusicBrainz places",
+    "s": "MusicBrainz (Places)",
     "d": "musicbrainz.org",
     "t": "mbp",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=place&method=indexed",
@@ -50173,7 +50173,7 @@
     "sc": "Music"
   },
   {
-    "s": "MusicBrainz Recordings",
+    "s": "MusicBrainz (Recordings)",
     "d": "musicbrainz.org",
     "t": "mbrc",
     "ts": [
@@ -50192,7 +50192,7 @@
     "sc": "Music"
   },
   {
-    "s": "MusicBrainz Release Groups",
+    "s": "MusicBrainz (Release Groups)",
     "d": "musicbrainz.org",
     "t": "mbreleasegroup",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=release_group",
@@ -50200,7 +50200,7 @@
     "sc": "Music"
   },
   {
-    "s": "MusicBrainz Releases",
+    "s": "MusicBrainz (Releases)",
     "d": "musicbrainz.org",
     "t": "mbrelease",
     "ts": [
@@ -50211,7 +50211,7 @@
     "sc": "Music"
   },
   {
-    "s": "MusicBrainz Release Group",
+    "s": "MusicBrainz (Release Group)",
     "d": "musicbrainz.org",
     "t": "mbrg",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=release_group&method=indexed",
@@ -50219,7 +50219,7 @@
     "sc": "Music"
   },
   {
-    "s": "MirBSD Manpages",
+    "s": "MirBSD (Manpages)",
     "d": "www.mirbsd.org",
     "t": "mbsdman",
     "u": "https://www.mirbsd.org/man.cgi?q={{{s}}}",
@@ -50227,7 +50227,7 @@
     "sc": "Programming"
   },
   {
-    "s": "MusicBrainz series",
+    "s": "MusicBrainz (Series)",
     "d": "musicbrainz.org",
     "t": "mbseries",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=series",
@@ -50246,7 +50246,7 @@
     "sc": "Maps"
   },
   {
-    "s": "MusicBrainz tags",
+    "s": "MusicBrainz (Tags)",
     "d": "musicbrainz.org",
     "t": "mbtag",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=tag",
@@ -50262,7 +50262,7 @@
     "sc": "Search"
   },
   {
-    "s": "MusicBrainz work",
+    "s": "MusicBrainz (Work)",
     "d": "musicbrainz.org",
     "t": "mbw",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=work&method=indexed",
@@ -50270,7 +50270,7 @@
     "sc": "Music"
   },
   {
-    "s": "MusicBrainz Works",
+    "s": "MusicBrainz (Works)",
     "d": "musicbrainz.org",
     "t": "mbwork",
     "u": "https://musicbrainz.org/search?query={{{s}}}&type=work",
@@ -50398,7 +50398,7 @@
     ]
   },
   {
-    "s": "Magic Card Market",
+    "s": "Cardmarket (Magic)",
     "d": "www.cardmarket.com",
     "t": "mcm",
     "ts": [
@@ -50411,7 +50411,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Curseforge Minecraft Mods",
+    "s": "CurseForge (Minecraft Mods)",
     "d": "www.curseforge.com",
     "t": "mcmods",
     "u": "https://www.curseforge.com/minecraft/mc-mods/search?search={{{s}}}",
@@ -50419,7 +50419,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Curseforge Minecraft Modpacks",
+    "s": "CurseForge (Minecraft Modpacks)",
     "d": "www.curseforge.com",
     "t": "mcmodpacks",
     "u": "https://www.curseforge.com/minecraft/modpacks/search?search={{{s}}}",
@@ -50601,7 +50601,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Minecraft Skin Search",
+    "s": "MCSkinSearch",
     "d": "www.mcskinsearch.com",
     "t": "mcskin",
     "u": "https://www.mcskinsearch.com/skin/{{{s}}}",
@@ -50609,7 +50609,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Movie-Censorship.com",
+    "s": "Movie-Censorship",
     "d": "www.movie-censorship.com",
     "t": "mcs",
     "u": "https://www.movie-censorship.com/list.php?s={{{s}}}",
@@ -50718,7 +50718,7 @@
     "sc": "Health"
   },
   {
-    "s": "The M Dash",
+    "s": "MM.LaFleur (The M Dash)",
     "d": "mmlafleur.com",
     "t": "mdash",
     "u": "https://mmlafleur.com/mdash/search/{{{s}}}",
@@ -50801,7 +50801,7 @@
     "sc": "Languages (javascript)"
   },
   {
-    "s": "Mozilla Developer Network (HTML)",
+    "s": "MDN Web Docs (HTML)",
     "d": "developer.mozilla.org",
     "t": "mdnhtml",
     "u": "https://developer.mozilla.org/en-US/search?q={{{s}}}&topic=html",
@@ -50817,7 +50817,7 @@
     "sc": "Programming"
   },
   {
-    "s": "MDN (Kagi Search)",
+    "s": "MDN (Kagi)",
     "d": "kagi.com",
     "ad": "developer.mozilla.org",
     "t": "mdn.s",
@@ -51083,7 +51083,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "/r/me_irl",
+    "s": "Reddit (/r/me_irl)",
     "d": "www.reddit.com",
     "t": "me_irl",
     "u": "https://www.reddit.com/r/me_irl/search?q={{{s}}}&restrict_sr=on",
@@ -51289,7 +51289,7 @@
     "sc": "Online"
   },
   {
-    "s": "Mercadolibre México",
+    "s": "Mercado Libre (Mexico)",
     "d": "listado.mercadolibre.com.mx",
     "t": "mercadolibremx",
     "ts": [
@@ -51310,7 +51310,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "mercari JP",
+    "s": "Mercari (Japan)",
     "d": "www.mercari.com",
     "t": "mercarijp",
     "u": "https://www.mercari.com/jp/search/?keyword={{{s}}}",
@@ -51318,7 +51318,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "mercari US",
+    "s": "Mercari (US)",
     "d": "www.mercari.com",
     "t": "mercari",
     "u": "https://www.mercari.com/search/?keyword={{{s}}}",
@@ -51393,7 +51393,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Subreddit r/metacanada",
+    "s": "Reddit (/r/metacanada)",
     "d": "www.reddit.com",
     "t": "metacanada",
     "u": "https://www.reddit.com/r/metacanada/search?q={{{s}}}&restrict_sr=on",
@@ -51417,7 +51417,7 @@
     "sc": "Tools"
   },
   {
-    "s": "de.Metapedia.org",
+    "s": "Metapedia (DE)",
     "d": "de.metapedia.org",
     "t": "metade",
     "u": "https://de.metapedia.org/m/index.php?search={{{s}}}&title=Spezial:Suche",
@@ -51594,7 +51594,7 @@
     "sc": "Social"
   },
   {
-    "s": "Meyers Großes Konversationslexikon",
+    "s": "Wörterbuchnetz (Meyers)",
     "d": "woerterbuchnetz.de",
     "t": "meyers",
     "u": "https://woerterbuchnetz.de/Meyers/?lemme={{{s}}}",
@@ -51623,7 +51623,7 @@
     "sc": "Search"
   },
   {
-    "s": "Mobafire",
+    "s": "MobaFire",
     "d": "www.mobafire.com",
     "t": "mfg",
     "u": "https://www.mobafire.com/league-of-legends/{{{s}}}-guide",
@@ -51707,7 +51707,7 @@
     "sc": "Law"
   },
   {
-    "s": "Monster Hunter Subreddit",
+    "s": "Reddit (/r/MonsterHunter)",
     "d": "www.reddit.com",
     "t": "mhr",
     "u": "https://www.reddit.com/r/MonsterHunter/search?q={{{s}}}&restrict_sr=on",
@@ -51734,7 +51734,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Michaelis - Português - Inglês",
+    "s": "Michaelis (pt-en)",
     "d": "michaelis.uol.com.br",
     "t": "michaelis",
     "u": "https://michaelis.uol.com.br/busca?r=1&f=0&t=1&palavra={{{s}}}",
@@ -51742,7 +51742,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Michaelis English - Portuguese",
+    "s": "Michaelis (en-pt)",
     "d": "michaelis.uol.com.br",
     "t": "michaelispt",
     "u": "https://michaelis.uol.com.br/busca?r=1&f=1&t=0&palavra={{{s}}}",
@@ -51785,7 +51785,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "freemidi.org",
+    "s": "Free MIDI",
     "d": "freemidi.org",
     "t": "midi",
     "u": "https://freemidi.org/search?q={{{s}}}",
@@ -51912,7 +51912,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Minds.com",
+    "s": "Minds",
     "d": "www.minds.com",
     "t": "minds",
     "u": "https://www.minds.com/search;q={{{s}}}",
@@ -51920,7 +51920,7 @@
     "sc": "Social"
   },
   {
-    "s": "ru.minecraft.wiki",
+    "s": "Minecraft Wiki (Russian)",
     "d": "ru.minecraft.wiki",
     "t": "minecraft-ru",
     "u": "https://ru.minecraft.wiki/?search={{{s}}}",
@@ -52102,7 +52102,7 @@
     "sc": "Music"
   },
   {
-    "s": "Mining Job Search",
+    "s": "Mining Job",
     "d": "www.miningjobsearch.com",
     "t": "mjs",
     "u": "https://www.miningjobsearch.com/Mining-Jobs/Search/{{{s}}}",
@@ -52110,7 +52110,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "Michael Tsai - Blog",
+    "s": "Michael Tsai (Blog)",
     "d": "duckduckgo.com",
     "t": "mjtsai",
     "u": "https://duckduckgo.com/?q={{{s}}}&sites=mjtsai.com&ia=web",
@@ -52177,7 +52177,7 @@
     "sc": "Sports"
   },
   {
-    "s": "MLB Player Search",
+    "s": "ESPN (MLB Players)",
     "d": "espn.go.com",
     "t": "mlbp",
     "u": "https://espn.go.com/mlb/players?=1&search={{{s}}}",
@@ -52252,7 +52252,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Google Maps Lite",
+    "s": "Google (Maps Lite)",
     "d": "google.com",
     "t": "ml",
     "u": "https://google.com/maps/search/{{{s}}}?force=canvas",
@@ -52303,7 +52303,7 @@
     "sc": "Online"
   },
   {
-    "s": "Medline plus in spanish",
+    "s": "MedlinePlus (Spanish)",
     "d": "vsearch.nlm.nih.gov",
     "t": "mlpes",
     "u": "https://vsearch.nlm.nih.gov/vivisimo/cgi-bin/query-meta?v:project=medlineplus-spanish&v:sources=medlineplus-spanish-bundle&query={{{s}}}",
@@ -52319,7 +52319,7 @@
     "sc": "Social"
   },
   {
-    "s": "Multiplayer.it",
+    "s": "Multiplayer",
     "d": "multiplayer.it",
     "t": "mlpit",
     "u": "https://multiplayer.it/ricerca/?q={{{s}}}",
@@ -52483,7 +52483,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Cardmarket Manamaze",
+    "s": "Cardmarket (Manamaze)",
     "d": "www.cardmarket.com",
     "t": "mmz",
     "u": "https://www.cardmarket.com/en/Magic/MainPage/browseUserProducts?idCategory=1&idUser=25674&resultsPage=0&cardName={{{s}}}",
@@ -52531,7 +52531,7 @@
     "sc": "Reference (science)"
   },
   {
-    "s": "Morrowind NexusMods",
+    "s": "Nexus Mods (Morrowind)",
     "d": "www.nexusmods.com",
     "t": "mnm",
     "u": "https://www.nexusmods.com/morrowind/search/?gsearch={{{s}}}&gsearchtype=mods",
@@ -52563,7 +52563,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Mobafire Builds",
+    "s": "MobaFire (Builds)",
     "d": "www.mobafire.com",
     "t": "mobafirebuilds",
     "u": "https://www.mobafire.com/league-of-legends/browse/?q={{{s}}}:",
@@ -52595,7 +52595,7 @@
     "sc": "Audio"
   },
   {
-    "s": "Mobile-Friendly Test - Google",
+    "s": "Google (Mobile-Friendly Test)",
     "d": "search.google.com",
     "t": "mobilefriendly",
     "u": "https://search.google.com/test/mobile-friendly?url={{{s}}}",
@@ -52678,7 +52678,7 @@
     "sc": "Programming"
   },
   {
-    "s": "modeS4u [IT]",
+    "s": "Modes4u (Italy)",
     "d": "www.modes4u.com",
     "t": "modes4u_it",
     "u": "https://www.modes4u.com/carino/{{{s}}}",
@@ -52686,7 +52686,7 @@
     "sc": "Online (intl)"
   },
   {
-    "s": "modeS4u",
+    "s": "Modes4u",
     "d": "www.modes4u.com",
     "t": "modes4u",
     "u": "https://www.modes4u.com/japanese/{{{s}}}",
@@ -52694,7 +52694,7 @@
     "sc": "Online (intl)"
   },
   {
-    "s": "Reddit Modhelp",
+    "s": "Reddit (/r/modhelp)",
     "d": "www.reddit.com",
     "t": "modhelp",
     "u": "https://www.reddit.com/r/modhelp/search?q={{{s}}}",
@@ -52806,7 +52806,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "WebQC.org",
+    "s": "WebQC",
     "d": "www.webqc.org",
     "t": "molw",
     "u": "https://www.webqc.org/mmcalc.php?compound={{{s}}}",
@@ -52921,7 +52921,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Monster.com",
+    "s": "Monster",
     "d": "jobsearch.monster.com",
     "t": "monster",
     "u": "https://jobsearch.monster.com/Search.aspx?re=130&cy=us&brd=1&JSNONREG=1&q={{{s}}}&rad=20&rad_units=miles",
@@ -52929,7 +52929,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "DuckDuckGo (past month)",
+    "s": "DuckDuckGo (Past Month)",
     "d": "duckduckgo.com",
     "t": "ddg-month",
     "u": "https://duckduckgo.com/?q={{{s}}}&df=m",
@@ -52999,7 +52999,7 @@
     "sc": "Online (intl)"
   },
   {
-    "s": "MobileRead Forum (Kagi Search)",
+    "s": "MobileRead Forum (Kagi)",
     "d": "kagi.com",
     "ad": "www.mobileread.com",
     "t": "more",
@@ -53016,7 +53016,7 @@
     "sc": "Reference (religion)"
   },
   {
-    "s": "Morningstar Search",
+    "s": "Morningstar",
     "d": "www.morningstar.com",
     "t": "morningstar",
     "u": "https://www.morningstar.com/search?query={{{s}}}",
@@ -53136,7 +53136,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "MozBrowser.nl",
+    "s": "MozBrowser",
     "d": "www.mozbrowser.nl",
     "t": "mozbrowser",
     "u": "https://www.mozbrowser.nl/forum/search.php?keywords={{{s}}}",
@@ -53252,7 +53252,7 @@
     "skip_tests": true
   },
   {
-    "s": "MPG.ReNa - Max Planck Reseource Navigator",
+    "s": "MPG.ReNa (Max Planck Resource Navigator)",
     "d": "rena.mpdl.mpg.de",
     "t": "mpgrena",
     "u": "https://rena.mpdl.mpg.de/rena/Search/Results?lookfor={{{s}}}",
@@ -53375,7 +53375,7 @@
     "sc": "Forum"
   },
   {
-    "s": "Microsoft Research Search",
+    "s": "Microsoft Research",
     "d": "www.microsoft.com",
     "t": "msacademic",
     "ts": [
@@ -53426,7 +53426,7 @@
     "sc": "Online"
   },
   {
-    "s": "MuseScore (Kagi Search)",
+    "s": "MuseScore (Kagi)",
     "d": "kagi.com",
     "ad": "musescore.org",
     "t": "mscore",
@@ -53435,7 +53435,7 @@
     "sc": "Docs"
   },
   {
-    "s": "Microsoft Docs C++",
+    "s": "Microsoft Docs (C++)",
     "d": "docs.microsoft.com",
     "t": "mscpp",
     "u": "https://docs.microsoft.com/en-us/search/index?search={{{s}}}&scope=C++",
@@ -53459,7 +53459,7 @@
     "sc": "Companies"
   },
   {
-    "s": ".NET Docs",
+    "s": "Microsoft Docs (.NET)",
     "d": "docs.microsoft.com",
     "t": "msdotnet",
     "u": "https://docs.microsoft.com/en-us/search/index?search={{{s}}}&scope=.NET",
@@ -53499,7 +53499,7 @@
     "sc": "Companies"
   },
   {
-    "s": "MS Malware Encyclopedia",
+    "s": "Microsoft (Malware Encyclopedia)",
     "d": "www.microsoft.com",
     "t": "msmalware",
     "u": "https://www.microsoft.com/security/portal/Threat/Encyclopedia/Search.aspx?query={{{s}}}",
@@ -53515,7 +53515,7 @@
     "sc": "Broadcast"
   },
   {
-    "s": "Microsoft .Net API",
+    "s": "Microsoft .NET (API)",
     "d": "docs.microsoft.com",
     "t": "ms.net",
     "u": "https://docs.microsoft.com/en-us/dotnet/api/?view=netframework-4.7&term={{{s}}}",
@@ -53558,7 +53558,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Microsoft TechNet SQL Server",
+    "s": "Microsoft TechNet (SQL Server)",
     "d": "social.technet.microsoft.com",
     "t": "mssql",
     "u": "https://social.technet.microsoft.com/Search/en-US/sqlserver?query={{{s}}}&Refinement=30&ac=4",
@@ -53745,7 +53745,7 @@
     "sc": "Search (Private)"
   },
   {
-    "s": "Material.io",
+    "s": "Material Design",
     "d": "material.io",
     "t": "mtrl",
     "u": "https://material.io/search.html?q={{{s}}}",
@@ -53825,7 +53825,7 @@
     "sc": "Social"
   },
   {
-    "s": "Mugshots.com",
+    "s": "Mugshots",
     "d": "mugshots.com",
     "t": "mugshots",
     "u": "https://mugshots.com/search.html?q={{{s}}}",
@@ -53924,7 +53924,7 @@
     "sc": "Programming"
   },
   {
-    "s": "MuseScore.com",
+    "s": "MuseScore",
     "d": "musescore.com",
     "t": "musescore",
     "u": "https://musescore.com/sheetmusic?text={{{s}}}",
@@ -53988,7 +53988,7 @@
     "sc": "Music (Lyrics)"
   },
   {
-    "s": "Musiker Board",
+    "s": "Google (Musiker Board)",
     "d": "www.google.de",
     "t": "musiker-board",
     "u": "https://www.google.de/search?q={{{s}}}+site:www.musiker-board.de",
@@ -54036,7 +54036,7 @@
     "sc": "Music"
   },
   {
-    "s": "Muusikoiden.net",
+    "s": "Muusikoiden",
     "d": "muusikoiden.net",
     "t": "muusikoiden",
     "u": "https://muusikoiden.net/tori/haku.php?keyword={{{s}}}&title_only=0&location=all&province=&city=&type=all&price_min=&price_max=&category=all&with_image=0",
@@ -54119,7 +54119,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Münchner Verkehrs- und Tarifbund (MVV)",
+    "s": "MVV",
     "d": "efa.mvv-muenchen.de",
     "t": "mvv",
     "u": "https://efa.mvv-muenchen.de/index.html?name_destination={{{s}}}",
@@ -54143,7 +54143,7 @@
     "sc": "Tools"
   },
   {
-    "s": "MusicWeb International (Kagi Search)",
+    "s": "MusicWeb International (Kagi)",
     "d": "kagi.com",
     "ad": "musicweb-international.com",
     "t": "mwi",
@@ -54160,7 +54160,7 @@
     "sc": "General"
   },
   {
-    "s": "Thesaurus by Merriam-Webster",
+    "s": "Merriam-Webster (Thesaurus)",
     "d": "www.merriam-webster.com",
     "t": "mwt",
     "u": "https://www.merriam-webster.com/thesaurus/{{{s}}}",
@@ -54190,7 +54190,7 @@
     "sc": "Audio"
   },
   {
-    "s": "MxToolbox",
+    "s": "MXToolbox (MX Lookup)",
     "d": "mxtoolbox.com",
     "t": "mx",
     "u": "https://mxtoolbox.com/SuperTool.aspx?action=mx:{{{s}}}&run=networktools",
@@ -54214,7 +54214,7 @@
     "sc": "Forum"
   },
   {
-    "s": "MxToolBox",
+    "s": "MXToolbox",
     "d": "mxtoolbox.com",
     "t": "mxtool",
     "u": "https://mxtoolbox.com/SuperTool.aspx?action={{{s}}}",
@@ -54354,7 +54354,7 @@
     "sc": "Movies"
   },
   {
-    "s": "MyMovingReviews.com",
+    "s": "MyMovingReviews",
     "d": "www.mymovingreviews.com",
     "t": "mymovingreviews",
     "u": "https://www.mymovingreviews.com/search.php?q={{{s}}}&x=0&y=0",
@@ -54405,7 +54405,7 @@
     "sc": "Food"
   },
   {
-    "s": "myshows.ru",
+    "s": "MyShows",
     "d": "myshows.me",
     "t": "myshows",
     "u": "https://myshows.me/search/?q={{{s}}}",
@@ -54413,7 +54413,7 @@
     "sc": "TV"
   },
   {
-    "s": "Mysku.ru",
+    "s": "Mysku",
     "d": "mysku.ru",
     "t": "mysku",
     "u": "https://mysku.ru/search/topics/?q={{{s}}}",
@@ -54437,7 +54437,7 @@
     "sc": "Social"
   },
   {
-    "s": "MySQL.com",
+    "s": "MySQL",
     "d": "kagi.com",
     "ad": "dev.mysql.com",
     "t": "mysql",
@@ -54533,7 +54533,7 @@
     "sc": "Online (intl)"
   },
   {
-    "s": "notabug.org (free code hosting)",
+    "s": "NotABug",
     "d": "notabug.org",
     "t": "nab",
     "u": "https://notabug.org/explore/repos?q={{{s}}}",
@@ -54541,7 +54541,7 @@
     "sc": "Downloads (code)"
   },
   {
-    "s": "BibleGateway NABRE",
+    "s": "BibleGateway (NABRE)",
     "d": "www.biblegateway.com",
     "t": "nabre",
     "u": "https://www.biblegateway.com/passage/?search={{{s}}}&version=NABRE",
@@ -54608,7 +54608,7 @@
     "sc": "Domains"
   },
   {
-    "s": "namuwiki",
+    "s": "Namu Wiki",
     "d": "namu.wiki",
     "t": "namu",
     "u": "https://namu.wiki/Go?q={{{s}}}",
@@ -54648,7 +54648,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "opgg",
+    "s": "OP.GG (NA)",
     "d": "na.op.gg",
     "t": "naopgg",
     "ts": [
@@ -54677,7 +54677,7 @@
     "sc": "Government"
   },
   {
-    "s": "New American Standard Bible",
+    "s": "BibleGateway (New American Standard Bible)",
     "d": "www.biblegateway.com",
     "t": "nasb",
     "u": "https://www.biblegateway.com/quicksearch/?quicksearch={{{s}}}&qs_version=NASB",
@@ -54696,7 +54696,7 @@
     "sc": "Business"
   },
   {
-    "s": "Naslovi.net",
+    "s": "Naslovi",
     "d": "www.naslovi.net",
     "t": "naslovi",
     "u": "https://www.naslovi.net/search.php?q={{{s}}}",
@@ -54801,7 +54801,7 @@
     "sc": "Images"
   },
   {
-    "s": "Naturvin – The Sound of Soil",
+    "s": "Naturvin",
     "d": "naturvin.wordpress.com",
     "t": "naturvin",
     "u": "https://naturvin.wordpress.com/?s={{{s}}}",
@@ -54833,7 +54833,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Naver Dictionnaire Fr",
+    "s": "Naver Dictionary (fr-ko)",
     "d": "dict.naver.com",
     "t": "naverdicfr",
     "u": "https://dict.naver.com/frkodict/#/search?query={{{s}}}",
@@ -54878,7 +54878,7 @@
     "sc": "Sports"
   },
   {
-    "s": "NBA.com",
+    "s": "NBA",
     "d": "www.nba.com",
     "t": "nba",
     "u": "https://www.nba.com/search#/{{{s}}}",
@@ -54886,7 +54886,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Kagi Bangs repo",
+    "s": "GitHub (Kagi Bangs)",
     "d": "github.com",
     "t": "nbang",
     "u": "https://github.com/search?q=repo:kagisearch/bangs+{{{s}}}&type=code",
@@ -54977,7 +54977,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Nciku English",
+    "s": "Nciku (English)",
     "d": "nciku.com",
     "t": "nce",
     "u": "https://nciku.com/search/en/{{{s}}}",
@@ -55041,7 +55041,7 @@
     "sc": "Video"
   },
   {
-    "s": "Nciku Chinese",
+    "s": "Nciku (Chinese)",
     "d": "nciku.com",
     "t": "ncz",
     "ts": [
@@ -55060,7 +55060,7 @@
     "sc": "Reference"
   },
   {
-    "s": "DuckDuckGo News DE",
+    "s": "DuckDuckGo (News, Germany)",
     "d": "duckduckgo.com",
     "t": "nde",
     "ts": [
@@ -55079,7 +55079,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Naver English Dictionary",
+    "s": "NAVER Dictionary (English)",
     "d": "endic.naver.com",
     "t": "ndic",
     "u": "https://endic.naver.com/search.nhn?query={{{s}}}",
@@ -55355,7 +55355,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": ".NET API Browser - .NET Core 2.0",
+    "s": ".NET API Browser (.NET Core 2.0)",
     "d": "docs.microsoft.com",
     "t": "netcore2api",
     "u": "https://docs.microsoft.com/en-us/dotnet/api/?view=netcore-2.0&term={{{s}}}",
@@ -55550,7 +55550,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "NewsDay.com",
+    "s": "Newsday",
     "d": "www.newsday.com",
     "t": "newsday",
     "u": "https://www.newsday.com/7.25434?q={{{s}}}",
@@ -55566,7 +55566,7 @@
     "sc": "Learning"
   },
   {
-    "s": "DuckDuckGo News France",
+    "s": "DuckDuckGo (News, France)",
     "d": "duckduckgo.com",
     "t": "newsfr",
     "ts": [
@@ -55593,7 +55593,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "NewsMax.com",
+    "s": "Newsmax",
     "d": "www.google.com",
     "t": "newsmax",
     "u": "https://www.google.com/search?domains=NewsMax.com&sitesearch=Newsmax.com&q={{{s}}}",
@@ -55601,7 +55601,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "DuckDuckGo News Mexico",
+    "s": "DuckDuckGo (News, Mexico)",
     "d": "duckduckgo.com",
     "t": "newsmx",
     "u": "https://duckduckgo.com/?q={{{s}}}&iar=news&kl=mx-es&ia=news",
@@ -55713,7 +55713,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Angular.io v2",
+    "s": "Angular (v2)",
     "d": "v2.angular.io",
     "t": "ng2",
     "u": "https://v2.angular.io/api?search={{{s}}}",
@@ -55721,7 +55721,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Angular.io v8",
+    "s": "Angular (v8)",
     "d": "v8.angular.io",
     "t": "ng8",
     "u": "https://v8.angular.io/api?search={{{s}}}",
@@ -55729,7 +55729,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Newgrounds Games",
+    "s": "Newgrounds (Games)",
     "d": "www.newgrounds.com",
     "t": "ngg",
     "u": "https://www.newgrounds.com/portal/search/games/{{{s}}}",
@@ -55772,7 +55772,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "NGÜ auf Bibleserver",
+    "s": "BibleServer (NGÜ)",
     "d": "www.bibleserver.com",
     "t": "ngü",
     "u": "https://www.bibleserver.com/search/NGÜ/{{{s}}}",
@@ -55804,7 +55804,7 @@
     "sc": "Health"
   },
   {
-    "s": "nicegear",
+    "s": "NiceGear",
     "d": "nicegear.co.nz",
     "t": "nicegear",
     "u": "https://nicegear.co.nz/search/?q={{{s}}}",
@@ -55922,7 +55922,7 @@
     "sc": "Search"
   },
   {
-    "s": "niice.co",
+    "s": "Niice",
     "d": "niice.co",
     "t": "niice",
     "u": "https://niice.co/?search={{{s}}}",
@@ -55970,7 +55970,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Narodowy Instytut Audiowizualny (nina.gov.pl)",
+    "s": "Narodowy Instytut Audiowizualny",
     "d": "www.nina.gov.pl",
     "t": "nina",
     "u": "https://www.nina.gov.pl/searchresult?query={{{s}}}",
@@ -56081,7 +56081,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "BibleStudyTools.com",
+    "s": "Bible Study Tools (NIV)",
     "d": "www.biblestudytools.com",
     "t": "niv",
     "u": "https://www.biblestudytools.com/search/?q={{{s}}}&s=Bibles&t=niv",
@@ -56173,7 +56173,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Bible Gateway: New King James Version (NKJV)",
+    "s": "BibleGateway (New King James Version)",
     "d": "www.biblegateway.com",
     "t": "nkj",
     "u": "https://www.biblegateway.com/quicksearch/?quicksearch={{{s}}}&qs_version=NKJV",
@@ -56205,7 +56205,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Bibleserver (NLB)",
+    "s": "BibleServer (NLB)",
     "d": "www.bibleserver.com",
     "t": "nlb",
     "u": "https://www.bibleserver.com/text/NLB/{{{s}}}",
@@ -56213,7 +56213,7 @@
     "sc": "Reference (religion)"
   },
   {
-    "s": "Google Translate (nl2de)",
+    "s": "Google Translate (nl-de)",
     "d": "translate.google.com",
     "t": "nlde",
     "u": "https://translate.google.com/#view=home&op=translate&sl=nl&tl=de&text={{{s}}}",
@@ -56325,7 +56325,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Norwegian Nynorsk dictionary",
+    "s": "Nynorskordboka",
     "d": "ordbokene.no",
     "t": "nnd",
     "u": "https://ordbokene.no/nob/nn/{{{s}}}",
@@ -56333,7 +56333,7 @@
     "sc": "Tools"
   },
   {
-    "s": "cowlevel",
+    "s": "Cowlevel",
     "d": "cowlevel.net",
     "t": "nng",
     "u": "https://cowlevel.net/search?q={{{s}}}",
@@ -56385,7 +56385,7 @@
     "sc": "Languages (javascript)"
   },
   {
-    "s": "node.js docs",
+    "s": "Node.js (Docs)",
     "d": "nodejs.org",
     "t": "node",
     "u": "https://nodejs.org/api/{{{s}}}.html",
@@ -56401,7 +56401,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Google Translate no-en",
+    "s": "Google Translate (no-en)",
     "d": "translate.google.com",
     "t": "noen",
     "u": "https://translate.google.com/#no/en/{{{s}}}",
@@ -56409,7 +56409,7 @@
     "sc": "Google"
   },
   {
-    "s": "NoFap",
+    "s": "Reddit (/r/NoFap)",
     "d": "www.reddit.com",
     "t": "nofap",
     "u": "https://www.reddit.com/r/NoFap/search/?q={{{s}}}&restrict_sr=1",
@@ -56417,7 +56417,7 @@
     "sc": "Social (intl)"
   },
   {
-    "s": "Google Translate no-hu",
+    "s": "Google Translate (no-hu)",
     "d": "translate.google.hu",
     "t": "nohu",
     "u": "https://translate.google.hu/#view=home&op=translate&sl=no&tl=hu&text={{{s}}}",
@@ -56449,7 +56449,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Nolo.com",
+    "s": "Nolo",
     "d": "www.nolo.com",
     "t": "nolo",
     "u": "https://www.nolo.com/search2?type=all&query={{{s}}}&location=",
@@ -56687,7 +56687,7 @@
     "sc": "Programming"
   },
   {
-    "s": "npms.io",
+    "s": "npms",
     "d": "npms.io",
     "t": "npms",
     "u": "https://npms.io/search?q={{{s}}}",
@@ -56746,7 +56746,7 @@
     "sc": "Academic"
   },
   {
-    "s": "NPR.org",
+    "s": "NPR",
     "d": "www.npr.org",
     "t": "npr",
     "u": "https://www.npr.org/search/index.php?query={{{s}}}",
@@ -56802,7 +56802,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Nixpkgs Repository",
+    "s": "GitHub (NixOS/nixpkgs)",
     "d": "github.com",
     "ad": "github.com/NixOS/nixpkgs",
     "t": "nr",
@@ -56832,7 +56832,7 @@
     "sc": "Tools"
   },
   {
-    "s": "DuckDuckGo Safe Off",
+    "s": "DuckDuckGo (Safe Off)",
     "d": "duckduckgo.com",
     "t": "nsfw",
     "u": "https://duckduckgo.com/?q={{{s}}}&kp=-2&ia=web",
@@ -56912,7 +56912,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "TriTrans (Norsk)",
+    "s": "TriTrans (no-en)",
     "d": "www.tritrans.net",
     "t": "ntrans",
     "u": "https://www.tritrans.net/cgibin/translate.cgi?spraak=Norsk&Fra={{{s}}}",
@@ -56968,7 +56968,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "nuget gallery",
+    "s": "NuGet",
     "d": "nuget.org",
     "t": "nuget",
     "u": "https://nuget.org/packages?q={{{s}}}&sortOrder=package-download-count",
@@ -57016,7 +57016,7 @@
     "sc": "Reference"
   },
   {
-    "s": "numpy",
+    "s": "NumPy",
     "d": "docs.scipy.org",
     "t": "numpy",
     "u": "https://docs.scipy.org/doc/numpy/search.html?q={{{s}}}&check_keywords=yes&area=default",
@@ -57072,7 +57072,7 @@
     "sc": "Online"
   },
   {
-    "s": "Naver german-korean dictionary",
+    "s": "Naver Dictionary (de-ko)",
     "d": "dict.naver.com",
     "t": "nvde",
     "u": "https://dict.naver.com/dekodict/#/search?query={{{s}}}",
@@ -57102,7 +57102,7 @@
     "sc": "General"
   },
   {
-    "s": "NVIDIA (Kagi Search)",
+    "s": "NVIDIA (Kagi)",
     "d": "kagi.com",
     "ad": "nvidia.com",
     "t": "nvidia",
@@ -57111,7 +57111,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Naver Images",
+    "s": "NAVER (Images)",
     "d": "search.naver.com",
     "t": "nvi",
     "u": "https://search.naver.com/search.naver?sm=tab_hty.top&where=image&query={{{s}}}",
@@ -57119,7 +57119,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "NAVER Translate from Korean to Japanese",
+    "s": "Naver Papago (ko-ja)",
     "d": "papago.naver.com",
     "t": "nvkrjp",
     "u": "https://papago.naver.com/?sk=ko&tk=ja&st={{{s}}}",
@@ -57330,7 +57330,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "The Oatmeal (Kagi Search)",
+    "s": "The Oatmeal (Kagi)",
     "d": "kagi.com",
     "ad": "theoatmeal.com",
     "t": "oatmeal",
@@ -57395,7 +57395,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "observador",
+    "s": "Observador",
     "d": "observador.pt",
     "t": "observador",
     "u": "https://observador.pt/pesquisa/?q={{{s}}}",
@@ -57411,7 +57411,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Obspy documentation of development version",
+    "s": "ObsPy (Dev)",
     "d": "docs.obspy.org",
     "t": "obspydev",
     "u": "https://docs.obspy.org/master/search.html?q={{{s}}}",
@@ -57419,7 +57419,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "Obspy documentation",
+    "s": "ObsPy (Docs)",
     "d": "docs.obspy.org",
     "t": "obspy",
     "u": "https://docs.obspy.org/search.html?q={{{s}}}",
@@ -57508,7 +57508,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "OCLC Worldcat",
+    "s": "WorldCat",
     "d": "www.worldcat.org",
     "t": "oclc",
     "u": "https://www.worldcat.org/search?q={{{s}}}",
@@ -57807,7 +57807,7 @@
     "sc": "Search"
   },
   {
-    "s": "OpenFrameworks Forum (Kagi Search)",
+    "s": "OpenFrameworks Forum (Kagi)",
     "d": "kagi.com",
     "ad": "forum.openframeworks.cc",
     "t": "of",
@@ -57816,7 +57816,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "OpenGameArt.org",
+    "s": "OpenGameArt",
     "d": "opengameart.org",
     "t": "oga",
     "ts": [
@@ -57835,7 +57835,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Oil and Gas Job Search",
+    "s": "Oil and Gas Jobs",
     "d": "www.oilandgasjobsearch.com",
     "t": "ogjs",
     "ts": [
@@ -57878,7 +57878,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Omniglot (Kagi Search)",
+    "s": "Omniglot (Kagi)",
     "d": "kagi.com",
     "ad": "omniglot.com",
     "t": "og",
@@ -57938,7 +57938,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Search OID registry",
+    "s": "OID Registry",
     "d": "oid-base.com",
     "t": "oid",
     "u": "https://oid-base.com/cgi-bin/display?oid={{{s}}}&submit=Display&action=display",
@@ -57954,7 +57954,7 @@
     "sc": "Reference (science)"
   },
   {
-    "s": "OJAD - Online Japanese Accent Dictionary",
+    "s": "OJAD (Online Japanese Accent Dictionary)",
     "d": "www.gavo.t.u-tokyo.ac.jp",
     "t": "ojad",
     "u": "https://www.gavo.t.u-tokyo.ac.jp/ojad/search/index/word:{{{s}}}",
@@ -57962,7 +57962,7 @@
     "sc": "Tools"
   },
   {
-    "s": "The Ojibwe People's Dictionary",
+    "s": "Ojibwe People's Dictionary (Ojibwe)",
     "d": "ojibwe.lib.umn.edu",
     "t": "ojen",
     "u": "https://ojibwe.lib.umn.edu/search?utf8=%E2%9C%93&q={{{s}}}&commit=Search&type=ojibwe",
@@ -58018,7 +58018,7 @@
     "sc": "Search"
   },
   {
-    "s": "OldApps.com",
+    "s": "OldApps",
     "d": "www.oldapps.com",
     "t": "oldapps",
     "u": "https://www.oldapps.com/betasearch.php?q={{{s}}}",
@@ -58080,7 +58080,7 @@
     "sc": "Books"
   },
   {
-    "s": "Open Library (Full Text Search)",
+    "s": "Open Library (Full Text)",
     "d": "openlibrary.org",
     "t": "olibtext",
     "u": "https://openlibrary.org/search/inside?q={{{s}}}",
@@ -58148,7 +58148,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "OLX.pl",
+    "s": "OLX (Poland)",
     "d": "olx.pl",
     "t": "olxpl",
     "ts": [
@@ -58280,7 +58280,7 @@
     "sc": "Blogs (intl)"
   },
   {
-    "s": "OMIM Search",
+    "s": "OMIM",
     "d": "omim.org",
     "t": "omim",
     "u": "https://omim.org/search?index=entry&sort=score+desc,+prefix_sort+desc&start=1&limit=10&search={{{s}}}",
@@ -58376,7 +58376,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "OneLook Reverse",
+    "s": "OneLook (Reverse)",
     "d": "onelook.com",
     "t": "onelookr",
     "u": "https://onelook.com/?w=*&loc=revfp2&clue={{{s}}}",
@@ -58435,7 +58435,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Oblivion NexusMods",
+    "s": "Nexus Mods (Oblivion)",
     "d": "www.nexusmods.com",
     "t": "onm",
     "u": "https://www.nexusmods.com/oblivion/search/?gsearch={{{s}}}&gsearchtype=mods",
@@ -58443,7 +58443,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Old Norse dictionary",
+    "s": "Perseus Digital Library (Old Norse)",
     "d": "www.perseus.tufts.edu",
     "t": "onorsk",
     "u": "https://www.perseus.tufts.edu/hopper/morph?l={{{s}}}&la=non",
@@ -58518,7 +58518,7 @@
     "sc": "Online"
   },
   {
-    "s": "r/OutOfTheLoop",
+    "s": "Reddit (/r/OutOfTheLoop)",
     "d": "www.reddit.com",
     "t": "ootl",
     "u": "https://www.reddit.com/r/OutOfTheLoop/search?q={{{s}}}&restrict_sr=on",
@@ -58550,7 +58550,7 @@
     "sc": "Academic"
   },
   {
-    "s": "OCaml OPAM (Kagi Search)",
+    "s": "OCaml OPAM (Kagi)",
     "d": "kagi.com",
     "ad": "opam.ocaml.org/packages",
     "t": "opam",
@@ -58559,7 +58559,7 @@
     "sc": "Languages (other)"
   },
   {
-    "s": "OP.GG Brazil - League of Legends Summoners statistics and MMR",
+    "s": "OP.GG (Brazil)",
     "d": "br.op.gg",
     "t": "opbr",
     "u": "https://br.op.gg/summoner/userName={{{s}}}",
@@ -58583,7 +58583,7 @@
     "sc": "Docs"
   },
   {
-    "s": "man.openbsd.org",
+    "s": "OpenBSD (Man Pages)",
     "d": "man.openbsd.org",
     "t": "openbsdman",
     "u": "https://man.openbsd.org/?query={{{s}}}&apropos=0&sec=0&arch=default&manpath=OpenBSD-current",
@@ -58591,7 +58591,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "OpenBSD misc list",
+    "s": "MARC.info (OpenBSD Misc)",
     "d": "marc.info",
     "t": "openbsdmisc",
     "u": "https://marc.info/?l=openbsd-misc&w=2&r=1&s={{{s}}}&q=b",
@@ -58607,7 +58607,7 @@
     "sc": "Sysadmin (man)"
   },
   {
-    "s": "marc.info",
+    "s": "MARC.info (OpenBSD Ports)",
     "d": "marc.info",
     "t": "openbsdports",
     "u": "https://marc.info/?l=openbsd-ports&w=2&r=1&s={{{s}}}&q=b",
@@ -58640,7 +58640,7 @@
     "sc": "Search"
   },
   {
-    "s": "Open Culture (Kagi Search)",
+    "s": "Open Culture (Kagi)",
     "d": "kagi.com",
     "ad": "openculture.com",
     "t": "openculture",
@@ -58753,7 +58753,7 @@
     "sc": "Food"
   },
   {
-    "s": "OpenSecrets.org",
+    "s": "OpenSecrets",
     "d": "www.opensecrets.org",
     "t": "opensecrets",
     "u": "https://www.opensecrets.org/usearch/?q={{{s}}}",
@@ -58761,7 +58761,7 @@
     "sc": "Government"
   },
   {
-    "s": "Opensource.com",
+    "s": "Opensource",
     "d": "opensource.com",
     "t": "opensource",
     "u": "https://opensource.com/sitewide-search?search_api_views_fulltext={{{s}}}",
@@ -58790,7 +58790,7 @@
     "sc": "Maps"
   },
   {
-    "s": "OpenSUSE Software Search",
+    "s": "openSUSE (Software)",
     "d": "software.opensuse.org",
     "t": "opensusesoftware",
     "ts": [
@@ -58832,7 +58832,7 @@
     "u": "https://www.yelp.com/search?find_desc={{{s}}}&ns=1#start=0&open_now=2510"
   },
   {
-    "s": "Opera Extensions",
+    "s": "Opera (Extensions)",
     "d": "addons.opera.com",
     "t": "operaext",
     "u": "https://addons.opera.com/addons/extensions/?query={{{s}}}&order=new&top=0",
@@ -58867,7 +58867,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "OP.GG LAS - League of Legends Summoners statistics and MMR",
+    "s": "OP.GG (LAS)",
     "d": "las.op.gg",
     "t": "oplas",
     "u": "https://las.op.gg/summoner/userName={{{s}}}",
@@ -58907,7 +58907,7 @@
     "sc": "Tools"
   },
   {
-    "s": "OP.GG Russia - League of Legends Summoners statistics and MMR",
+    "s": "OP.GG (Russia)",
     "d": "ru.op.gg",
     "t": "opru",
     "u": "https://ru.op.gg/summoner/userName={{{s}}}",
@@ -58939,7 +58939,7 @@
     "sc": "Companies"
   },
   {
-    "s": "OP.GG Turkey - League of Legends Summoners statistics and MMR",
+    "s": "OP.GG (Turkey)",
     "d": "tr.op.gg",
     "t": "optr",
     "u": "https://tr.op.gg/summoner/userName={{{s}}}",
@@ -59011,7 +59011,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Ord.se FR",
+    "s": "Ord (French)",
     "d": "www.ord.se",
     "t": "ordfr",
     "u": "https://www.ord.se/oversattning/franska/?s={{{s}}}&l=FRASVE",
@@ -59051,7 +59051,7 @@
     "sc": "Learning (intl)"
   },
   {
-    "s": "Ord.se SV",
+    "s": "Ord (Swedish)",
     "d": "www.ord.se",
     "t": "ordsv",
     "u": "https://www.ord.se/oversattning/Svenska/?s={{{s}}}&l=SVESVE",
@@ -59059,7 +59059,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "old reddit",
+    "s": "Reddit (Old)",
     "d": "old.reddit.com",
     "t": "ored",
     "u": "https://old.reddit.com/search?q={{{s}}}&sort=relevance&t=all",
@@ -59067,7 +59067,7 @@
     "sc": "Forum"
   },
   {
-    "s": "Oregon Coast Info (Kagi Search)",
+    "s": "Oregon Coast Info (Kagi)",
     "d": "kagi.com",
     "ad": "theoregoncoast.info",
     "t": "oregon",
@@ -59122,7 +59122,7 @@
     "sc": "TV"
   },
   {
-    "s": "Org Mode Manual (Kagi Search)",
+    "s": "Org Mode Manual (Kagi)",
     "d": "kagi.com",
     "ad": "orgmode.org/manual/",
     "t": "org",
@@ -59174,7 +59174,7 @@
     "sc": "Online"
   },
   {
-    "s": "Obchodní rejstřík – Ministerstvo spravedlnosti České republiky",
+    "s": "Obchodní Rejstřík",
     "d": "or.justice.cz",
     "t": "or",
     "u": "https://or.justice.cz/ias/ui/rejstrik-$firma?jenPlatne=PLATNE&nazev={{{s}}}&polozek=50&typHledani=STARTS_WITH",
@@ -59182,7 +59182,7 @@
     "sc": "Government"
   },
   {
-    "s": "Subreddit (Old Style)",
+    "s": "Reddit (Old, Subreddits)",
     "d": "old.reddit.com",
     "t": "ors",
     "ts": [
@@ -59234,7 +59234,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Oscobo Search",
+    "s": "Oscobo",
     "d": "oscobo.co.uk",
     "t": "osc",
     "u": "https://oscobo.co.uk/search.php?q={{{s}}}",
@@ -59298,7 +59298,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Openstreetmap forum Netherlands",
+    "s": "OpenStreetMap (Netherlands Forum)",
     "d": "community.openstreetmap.org",
     "t": "osmforumnl",
     "u": "https://community.openstreetmap.org/search?q={{{s}}}%20%23communities:nl",
@@ -59306,7 +59306,7 @@
     "sc": "Maps"
   },
   {
-    "s": "OpenStreetMap Community Forum",
+    "s": "OpenStreetMap (Forum)",
     "d": "community.openstreetmap.org",
     "t": "osmforum",
     "ts": [
@@ -59326,7 +59326,7 @@
     "sc": "Maps"
   },
   {
-    "s": "OpenStreetMap Node",
+    "s": "OpenStreetMap (Node)",
     "d": "www.openstreetmap.org",
     "t": "osmnode",
     "u": "https://www.openstreetmap.org/node/{{{s}}}",
@@ -59334,7 +59334,7 @@
     "sc": "Maps"
   },
   {
-    "s": "OpenStreetMap Relation",
+    "s": "OpenStreetMap (Relation)",
     "d": "www.openstreetmap.org",
     "t": "osmrelation",
     "u": "https://www.openstreetmap.org/relation/{{{s}}}",
@@ -59342,7 +59342,7 @@
     "sc": "Maps"
   },
   {
-    "s": "OpenStreetMap Way",
+    "s": "OpenStreetMap (Way)",
     "d": "www.openstreetmap.org",
     "t": "osmway",
     "u": "https://www.openstreetmap.org/way/{{{s}}}",
@@ -59374,7 +59374,7 @@
     "sc": "Forum"
   },
   {
-    "s": "The Old School Runescape Grand Exchange",
+    "s": "RuneScape (OSRS Grand Exchange)",
     "d": "services.runescape.com",
     "t": "osrsge",
     "u": "https://services.runescape.com/m=itemdb_oldschool/results?query={{{s}}}",
@@ -59382,7 +59382,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Old School Runescape Hiscores",
+    "s": "RuneScape (OSRS Hiscores)",
     "d": "services.runescape.com",
     "t": "osrshs",
     "u": "https://services.runescape.com/m=hiscore_oldschool/hiscorepersonal.ws?user1={{{s}}}",
@@ -59453,7 +59453,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Osu! Forums",
+    "s": "osu! (Forums)",
     "d": "osu.ppy.sh",
     "t": "osuf",
     "u": "https://osu.ppy.sh/forum/search.php?keywords={{{s}}}&terms=all&author=&sc=1&sd=d&sr=posts&ch=300&t=0&submit=Search",
@@ -59485,7 +59485,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "osu.ppy.sh",
+    "s": "osu! (User)",
     "d": "osu.ppy.sh",
     "t": "osuu",
     "u": "https://osu.ppy.sh/u/{{{s}}}",
@@ -59493,7 +59493,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "openSUSE Wiki",
+    "s": "openSUSE (Wiki)",
     "d": "en.opensuse.org",
     "t": "osw",
     "ts": [
@@ -59512,7 +59512,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "OS X Developer Library",
+    "s": "Apple Developer (OS X)",
     "d": "developer.apple.com",
     "t": "osx",
     "u": "https://developer.apple.com/search/?q={{{s}}}&platform=OS X",
@@ -59557,7 +59557,7 @@
     "sc": "Companies"
   },
   {
-    "s": "OneLook Thesaurus",
+    "s": "OneLook (Thesaurus)",
     "d": "onelook.com",
     "t": "otrd",
     "u": "https://onelook.com/thesaurus/?s={{{s}}}",
@@ -59718,7 +59718,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Webster's Dictionary 1828 - Online Edition",
+    "s": "Webster's Dictionary 1828 (Online Edition)",
     "d": "webstersdictionary1828.com",
     "t": "owd",
     "u": "https://webstersdictionary1828.com/Dictionary/{{{s}}}",
@@ -59750,7 +59750,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Overwatch Liquipedia",
+    "s": "Liquipedia (Overwatch)",
     "d": "liquipedia.net",
     "t": "owliquipedia",
     "u": "https://liquipedia.net/overwatch/index.php?search={{{s}}}",
@@ -59814,7 +59814,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Overwatch subreddit",
+    "s": "Reddit (/r/Overwatch)",
     "d": "www.reddit.com",
     "t": "owsr",
     "u": "https://www.reddit.com/r/Overwatch/search?q={{{s}}}&restrict_sr=on",
@@ -59830,7 +59830,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Oxford English to Spanish",
+    "s": "Oxford (en-es)",
     "d": "es.oxforddictionaries.com",
     "t": "oxenes",
     "u": "https://es.oxforddictionaries.com/translate/english-spanish/{{{s}}}",
@@ -59838,7 +59838,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Oxford Spanish to English",
+    "s": "Oxford (es-en)",
     "d": "es.oxforddictionaries.com",
     "t": "oxesen",
     "u": "https://es.oxforddictionaries.com/translate/spanish-english/{{{s}}}",
@@ -59846,7 +59846,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Oxford learners dictionary",
+    "s": "Oxford Learner's Dictionary",
     "d": "www.oxfordlearnersdictionaries.com",
     "t": "oxfordlearners",
     "u": "https://www.oxfordlearnersdictionaries.com/definition/english/{{{s}}}",
@@ -59894,7 +59894,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Oxford Dictionary Thesaurus",
+    "s": "Oxford Dictionaries (Thesaurus)",
     "d": "en.oxforddictionaries.com",
     "t": "oxs",
     "ts": [
@@ -60096,7 +60096,7 @@
     "sc": "Local"
   },
   {
-    "s": "Pages Jaunes",
+    "s": "PagesJaunes",
     "d": "www.pagesjaunes.fr",
     "t": "pagesjaunes",
     "u": "https://www.pagesjaunes.fr/annuaire/chercherlespros?quoiqui={{{s}}}&monochamp={{{s}}}",
@@ -60105,7 +60105,7 @@
     "skip_tests": true
   },
   {
-    "s": "Google PageSpeed insights",
+    "s": "Google (PageSpeed)",
     "d": "developers.google.com",
     "t": "pagespeed",
     "u": "https://developers.google.com/speed/pagespeed/insights/?url={{{s}}}",
@@ -60137,7 +60137,7 @@
     "sc": "Local"
   },
   {
-    "s": "Pale Moon forum",
+    "s": "Pale Moon (Forum)",
     "d": "forum.palemoon.org",
     "t": "palemoon",
     "ts": [
@@ -60295,7 +60295,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "PortableApps.com",
+    "s": "PortableApps",
     "d": "portableapps.com",
     "t": "portableapps",
     "ts": [
@@ -60314,7 +60314,7 @@
     "sc": "Online"
   },
   {
-    "s": "Parcello Sendungsverfolgung - Parcel Tracking",
+    "s": "Parcello",
     "d": "www.parcello.org",
     "t": "parcello",
     "ts": [
@@ -60408,7 +60408,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "passmark.com",
+    "s": "PassMark",
     "d": "www.passmark.com",
     "t": "passmark",
     "u": "https://www.passmark.com/search/zoomsearch.php?zoom_query={{{s}}}&search=Search",
@@ -60432,7 +60432,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Pauker.at Dictionary (German-Finnish)",
+    "s": "Pauker (de-fi)",
     "d": "www.pauker.at",
     "t": "pat.fi",
     "u": "https://www.pauker.at/pauker/DE_DE/FI/wb/?modus=&suche={{{s}}}&page=1#",
@@ -60503,7 +60503,7 @@
     "sc": "Health"
   },
   {
-    "s": "pauker.at Dictionary (Mobile)",
+    "s": "Pauker (Mobile)",
     "d": "www.pauker.at",
     "t": "patm",
     "u": "https://www.pauker.at/app.php/DE_DE/?s={{{s}}}#suche",
@@ -60511,7 +60511,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "pauker.at Dictionary (German-English)",
+    "s": "Pauker (de-en)",
     "d": "www.pauker.at",
     "t": "pat",
     "u": "https://www.pauker.at/pauker/DE_DE/EN/wb?modus=&suche={{{s}}}&page=1#",
@@ -60519,7 +60519,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Pauker.at",
+    "s": "Pauker (de-pt)",
     "d": "www.pauker.at",
     "t": "pat.pt",
     "u": "https://www.pauker.at/pauker/DE_DE/PT/wb/?modus=&suche={{{s}}}&page=1#",
@@ -60535,7 +60535,7 @@
     "sc": "Tools (fundraising)"
   },
   {
-    "s": "pauker.at Dictionary (German-Swedish)",
+    "s": "Pauker (de-sv)",
     "d": "www.pauker.at",
     "t": "pat.sv",
     "u": "https://www.pauker.at/pauker/DE_DE/SE/wb?modus=&suche={{{s}}}&page=1#",
@@ -60634,7 +60634,7 @@
     "sc": "Online"
   },
   {
-    "s": "pages blanches",
+    "s": "PagesBlanches",
     "d": "www.pagesjaunes.fr",
     "t": "pbl",
     "u": "https://www.pagesjaunes.fr/pagesblanches/recherche?quoiqui={{{s}}}&proximite=0",
@@ -60650,7 +60650,7 @@
     "sc": "Misc"
   },
   {
-    "s": "RPM.pbone.net",
+    "s": "RPM.Pbone",
     "d": "rpm.pbone.net",
     "t": "pbone",
     "u": "https://rpm.pbone.net/index.php3?stat=3&search={{{s}}}&Search.x=0&Search.y=0&simple=1&srodzaj=1",
@@ -60686,7 +60686,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Pinboard.in (Tag)",
+    "s": "Pinboard (Tag)",
     "d": "pinboard.in",
     "t": "pbtag",
     "u": "https://pinboard.in/t:{{{s}}}",
@@ -60880,7 +60880,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "Reddit PC Master Race",
+    "s": "Reddit (/r/pcmasterrace)",
     "d": "www.reddit.com",
     "t": "pcmr",
     "u": "https://www.reddit.com/r/pcmasterrace/search?q={{{s}}}&restrict_sr=on&sort=relevance&t=all",
@@ -60990,7 +60990,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "PewDiePieSubmissions",
+    "s": "Reddit (/r/PewdiepieSubmissions)",
     "d": "www.reddit.com",
     "t": "pdpreddit",
     "u": "https://www.reddit.com/r/PewdiepieSubmissions/search?q={{{s}}}&restrict_sr=1",
@@ -61014,7 +61014,7 @@
     "sc": "Academic"
   },
   {
-    "s": "The People's Dictionary",
+    "s": "Folkets lexikon (English)",
     "d": "folkets-lexikon.csc.kth.se",
     "t": "pd",
     "u": "https://folkets-lexikon.csc.kth.se/folkets/folkets.en.html#lookup&{{{s}}}&0",
@@ -61062,7 +61062,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Dicionário Porto Editora",
+    "s": "Infopédia (Dictionaries)",
     "d": "www.infopedia.pt",
     "t": "pe",
     "u": "https://www.infopedia.pt/dicionarios/pesquisa/{{{s}}}",
@@ -61105,7 +61105,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "www.pole-emploi.fr",
+    "s": "Pôle Emploi (Candidat)",
     "d": "candidat.pole-emploi.fr",
     "t": "pef",
     "u": "https://candidat.pole-emploi.fr/offres/recherche?motsCles={{{s}}}",
@@ -61360,7 +61360,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "PewDiePie",
+    "s": "YouTube (PewDiePie)",
     "d": "www.youtube.com",
     "t": "pewdiepie",
     "u": "https://www.youtube.com/user/PewDiePie/search?query={{{s}}}",
@@ -61479,7 +61479,7 @@
     "sc": "Academic"
   },
   {
-    "s": "PostgreSQL documentation",
+    "s": "PostgreSQL (Documentation)",
     "d": "www.postgresql.org",
     "t": "pgdocs",
     "u": "https://www.postgresql.org/search/?u=/docs/&q={{{s}}}",
@@ -61506,7 +61506,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Prisguiden.no",
+    "s": "Prisguiden",
     "d": "prisguiden.no",
     "t": "pgno",
     "u": "https://prisguiden.no/sok?q={{{s}}}",
@@ -61514,7 +61514,7 @@
     "sc": "Services"
   },
   {
-    "s": "PlusGirot - Search PlusGiro number",
+    "s": "PlusGirot (PlusGiro Number)",
     "d": "kontoutdrag.plusgirot.se",
     "t": "pgn",
     "u": "https://kontoutdrag.plusgirot.se/ku/sokko002?SO_KTO={{{s}}}",
@@ -61546,7 +61546,7 @@
     "sc": "Government"
   },
   {
-    "s": "Perseus word study tool",
+    "s": "Perseus Digital Library (Greek)",
     "d": "www.perseus.tufts.edu",
     "t": "pgr",
     "u": "https://www.perseus.tufts.edu/hopper/morph?l={{{s}}}&la=greek",
@@ -61562,7 +61562,7 @@
     "sc": "Languages (php)"
   },
   {
-    "s": "Phaser 3 Docs (Kagi Search)",
+    "s": "Phaser 3 Docs (Kagi)",
     "d": "kagi.com",
     "ad": "photonstorm.github.io/phaser3-docs/",
     "t": "phas3r",
@@ -61692,7 +61692,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "PhotoBucket.com",
+    "s": "Photobucket",
     "d": "photobucket.com",
     "t": "photobucket",
     "u": "https://photobucket.com/images/{{{s}}}/",
@@ -61732,7 +61732,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "PHP.net",
+    "s": "PHP",
     "d": "www.php.net",
     "ad": "php.net",
     "t": "phpnet",
@@ -61755,7 +61755,7 @@
     "sc": "Online"
   },
   {
-    "s": "Phrasen.com",
+    "s": "Phrasen",
     "d": "www.phrasen.com",
     "t": "phrasen",
     "u": "https://www.phrasen.com/index.php?do=suche&q={{{s}}}",
@@ -61763,7 +61763,7 @@
     "sc": "Search"
   },
   {
-    "s": "Phrase Finder (Kagi Search)",
+    "s": "Phrase Finder (Kagi)",
     "d": "kagi.com",
     "ad": "phrases.org.uk",
     "t": "phrase",
@@ -61876,7 +61876,7 @@
     "sc": "Online"
   },
   {
-    "s": "Pikabu.ru",
+    "s": "Pikabu",
     "d": "pikabu.ru",
     "t": "pikabu",
     "ts": [
@@ -61922,7 +61922,7 @@
     "sc": "Search"
   },
   {
-    "s": "pine64.org",
+    "s": "PINE64 (Forum)",
     "d": "forum.pine64.org",
     "t": "pine64",
     "u": "https://forum.pine64.org/search.php?text={{{s}}}&sortby=&order=desc",
@@ -61930,7 +61930,7 @@
     "sc": "Design"
   },
   {
-    "s": "DomainTools.com",
+    "s": "DomainTools (Ping)",
     "d": "dns-tools.domaintools.com",
     "t": "ping",
     "u": "https://dns-tools.domaintools.com/?method=ping&query={{{s}}}",
@@ -61989,7 +61989,7 @@
     "sc": "Online"
   },
   {
-    "s": "Pinvoke.net",
+    "s": "PInvoke",
     "d": "pinvoke.net",
     "t": "pinvoke",
     "u": "https://pinvoke.net/search.aspx?search={{{s}}}",
@@ -62045,7 +62045,7 @@
     "sc": "Academic"
   },
   {
-    "s": "PitchBook Profiles (Kagi Search)",
+    "s": "PitchBook Profiles (Kagi)",
     "d": "kagi.com",
     "ad": "pitchbook.com/profiles/company",
     "t": "pitchbook",
@@ -62153,7 +62153,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "Linux Packages Search",
+    "s": "Linux Packages",
     "d": "pkgs.org",
     "t": "pkgs",
     "u": "https://pkgs.org/search/?q={{{s}}}",
@@ -62161,7 +62161,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Pkgsrc.se",
+    "s": "Pkgsrc",
     "d": "pkgsrc.se",
     "t": "pkgsrc",
     "u": "https://pkgsrc.se/search.php?so={{{s}}}",
@@ -62236,7 +62236,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Planet Math (GitHub repo)",
+    "s": "GitHub (Planet Math)",
     "d": "github.com",
     "t": "planetmath",
     "u": "https://github.com/search?l=TeX&q=org:planetmath+{{{s}}}&type=Topics",
@@ -62244,7 +62244,7 @@
     "sc": "Academic (math/cs)"
   },
   {
-    "s": "PlanetMinecraft",
+    "s": "Planet Minecraft",
     "d": "www.planetminecraft.com",
     "t": "planetmc",
     "ts": [
@@ -62271,7 +62271,7 @@
     "sc": "Reference (science)"
   },
   {
-    "s": "Plase.Net",
+    "s": "Plase",
     "d": "plase.net",
     "t": "plase",
     "u": "https://plase.net/?s={{{s}}}&post_type=product",
@@ -62298,7 +62298,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Plattentests.de",
+    "s": "Plattentests",
     "d": "www.plattentests.de",
     "t": "plattentests",
     "u": "https://www.plattentests.de/suche.php?parameter=all&suche={{{s}}}",
@@ -62330,7 +62330,7 @@
     "sc": "Online"
   },
   {
-    "s": "PlayOnLinux (Kagi Search)",
+    "s": "PlayOnLinux (Kagi)",
     "d": "kagi.com",
     "ad": "playonlinux.com",
     "t": "playonlinux",
@@ -62366,7 +62366,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "google translate pl-de",
+    "s": "Google Translate (pl-de)",
     "d": "translate.google.com",
     "t": "plde",
     "u": "https://translate.google.com/#view=home&op=translate&sl=pl&tl=de&text={{{s}}}",
@@ -62390,7 +62390,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Google Translate: pl-en",
+    "s": "Google Translate (pl-en)",
     "d": "translate.google.com",
     "t": "plen",
     "u": "https://translate.google.com/#pl/en/{{{s}}}",
@@ -62398,7 +62398,7 @@
     "sc": "Google"
   },
   {
-    "s": "Reverse (plfr)",
+    "s": "Reverso (pl-fr)",
     "d": "dictionnaire.reverso.net",
     "t": "plfr",
     "u": "https://dictionnaire.reverso.net/polonais-francais/{{{s}}}",
@@ -62438,7 +62438,7 @@
     "sc": "Health"
   },
   {
-    "s": "Ploum Blog (Kagi Search)",
+    "s": "Ploum Blog (Kagi)",
     "d": "kagi.com",
     "ad": "ploum.net",
     "t": "ploum",
@@ -62519,7 +62519,7 @@
     "sc": "Maps"
   },
   {
-    "s": "Plus.codes",
+    "s": "Plus Codes (Map)",
     "d": "plus.codes",
     "t": "plus",
     "u": "https://plus.codes/map/{{{s}}}",
@@ -62527,7 +62527,7 @@
     "sc": "Maps"
   },
   {
-    "s": "PLyrics.com",
+    "s": "PLyrics",
     "d": "www.plyrics.com",
     "t": "plyrics",
     "u": "https://www.plyrics.com/search.php?q={{{s}}}",
@@ -62543,7 +62543,7 @@
     "sc": "Search"
   },
   {
-    "s": "Planet Minecraft - banners",
+    "s": "Planet Minecraft (Banners)",
     "d": "www.planetminecraft.com",
     "t": "pmcb",
     "u": "https://www.planetminecraft.com/banners/?keywords={{{s}}}",
@@ -62551,7 +62551,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Planet Minecraft - collections",
+    "s": "Planet Minecraft (Collections)",
     "d": "www.planetminecraft.com",
     "t": "pmcc",
     "u": "https://www.planetminecraft.com/collections/?keywords={{{s}}}",
@@ -62559,7 +62559,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Planet Minecraft - data packs",
+    "s": "Planet Minecraft (Data Packs)",
     "d": "www.planetminecraft.com",
     "t": "pmcd",
     "u": "https://www.planetminecraft.com/resources/mods/data-pack/?keywords={{{s}}}",
@@ -62567,7 +62567,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Planet Minecraft - skins",
+    "s": "Planet Minecraft (Skins)",
     "d": "www.planetminecraft.com",
     "t": "pmck",
     "u": "https://www.planetminecraft.com/resources/skins/?keywords={{{s}}}",
@@ -62575,7 +62575,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Planet Minecraft - mods",
+    "s": "Planet Minecraft (Mods)",
     "d": "www.planetminecraft.com",
     "t": "pmcm",
     "u": "https://www.planetminecraft.com/resources/mods/?keywords={{{s}}}",
@@ -62583,7 +62583,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Planet Minecraft - projects",
+    "s": "Planet Minecraft (Projects)",
     "d": "www.planetminecraft.com",
     "t": "pmcp",
     "u": "https://www.planetminecraft.com/resources/projects/?keywords={{{s}}}",
@@ -62591,7 +62591,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Planet Minecraft - resource packs",
+    "s": "Planet Minecraft (Resource Packs)",
     "d": "www.planetminecraft.com",
     "t": "pmcr",
     "u": "https://www.planetminecraft.com/resources/texture_packs/?keywords={{{s}}}",
@@ -62599,7 +62599,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Planet Minecraft - servers",
+    "s": "Planet Minecraft (Servers)",
     "d": "www.planetminecraft.com",
     "t": "pmcs",
     "u": "https://www.planetminecraft.com/resources/servers/?keywords={{{s}}}",
@@ -62607,7 +62607,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Pubmed",
+    "s": "PubMed",
     "d": "www.ncbi.nlm.nih.gov",
     "t": "pmd",
     "ts": [
@@ -62621,7 +62621,7 @@
     "sc": "Academic"
   },
   {
-    "s": "PMEG (Kagi Search)",
+    "s": "PMEG (Kagi)",
     "d": "kagi.com",
     "ad": "bertilow.com/pmeg/",
     "t": "pmeg",
@@ -62630,7 +62630,7 @@
     "sc": "Search"
   },
   {
-    "s": "Pale Moon forum en español",
+    "s": "Pale Moon (Spanish Forum)",
     "d": "forum.palemoon.org",
     "t": "pmfe",
     "u": "https://forum.palemoon.org/search.php?keywords={{{s}}}&fid[0]=9",
@@ -62857,7 +62857,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Path of Exile Subreddit",
+    "s": "Reddit (/r/pathofexile)",
     "d": "www.reddit.com",
     "t": "poer",
     "u": "https://www.reddit.com/r/pathofexile/search?q={{{s}}}&restrict_sr=on",
@@ -62983,7 +62983,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Politiken.dk",
+    "s": "Politiken",
     "d": "politiken.dk",
     "t": "politiken",
     "u": "https://politiken.dk/search/?q={{{s}}}",
@@ -63074,7 +63074,7 @@
     "sc": "General"
   },
   {
-    "s": "Pons de<>es",
+    "s": "PONS (de-es)",
     "d": "de.pons.com",
     "t": "ponsdees",
     "u": "https://de.pons.com/übersetzung?q={{{s}}}&l=dees&in=&lf=de",
@@ -63082,7 +63082,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Pons de<>fr",
+    "s": "PONS (de-fr)",
     "d": "de.pons.com",
     "t": "ponsdefr",
     "u": "https://de.pons.com/übersetzung?q={{{s}}}&l=defr&in=&lf=de",
@@ -63090,7 +63090,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Pons de<>it",
+    "s": "PONS (de-it)",
     "d": "de.pons.com",
     "t": "ponsdeit",
     "u": "https://de.pons.com/übersetzung?q={{{s}}}&l=deit&in=&lf=de",
@@ -63106,7 +63106,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Pons German-Polish",
+    "s": "PONS (de-pl)",
     "d": "en.pons.com",
     "t": "ponsdepl",
     "u": "https://en.pons.com/translate?q={{{s}}}&l=depl&in=&lf=de",
@@ -63114,7 +63114,7 @@
     "sc": "Learning (intl)"
   },
   {
-    "s": "Pons (deen)",
+    "s": "PONS (de-en)",
     "d": "de.pons.com",
     "t": "ponsde",
     "ts": [
@@ -63126,7 +63126,7 @@
     "sc": "Learning"
   },
   {
-    "s": "PONS Deutsch-Russisch",
+    "s": "PONS (de-ru)",
     "d": "en.pons.com",
     "t": "ponsderu",
     "u": "https://en.pons.com/translate?q={{{s}}}&l=deru&in=&lf=de&cid=",
@@ -63134,7 +63134,7 @@
     "sc": "Tools"
   },
   {
-    "s": "pons.com",
+    "s": "PONS (de-sv)",
     "d": "de.pons.com",
     "t": "ponsdesv",
     "u": "https://de.pons.com/übersetzung?q={{{s}}}&l=desv&in=&lf=de",
@@ -63142,7 +63142,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Pons (ende)",
+    "s": "PONS (en-de)",
     "d": "en.pons.com",
     "t": "ponsed",
     "ts": [
@@ -63153,7 +63153,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Pons en->sl",
+    "s": "PONS (en-sl)",
     "d": "en.pons.com",
     "t": "ponsensl",
     "u": "https://en.pons.com/translate?q={{{s}}}&l=ensl&in=en&lf=en",
@@ -63161,7 +63161,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Pons it<>pl",
+    "s": "Pons (it-pl)",
     "d": "pl.pons.com",
     "t": "ponsitpl",
     "u": "https://pl.pons.com/tłumaczenie?q={{{s}}}&l=itpl",
@@ -63169,7 +63169,7 @@
     "sc": "Search"
   },
   {
-    "s": "Pons pl-de",
+    "s": "Pons (de-pl)",
     "d": "pl.pons.com",
     "t": "ponsplde",
     "u": "https://pl.pons.com/tłumaczenie?q={{{s}}}&l=depl&in=&lf=de",
@@ -63177,7 +63177,7 @@
     "sc": "Search"
   },
   {
-    "s": "Pons PL-EN",
+    "s": "PONS (en-pl)",
     "d": "en.pons.com",
     "t": "ponsplen",
     "u": "https://en.pons.com/translate?q={{{s}}}&l=enpl&in=&lf=en",
@@ -63185,7 +63185,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Pons Polish->Spanish",
+    "s": "Pons (es-pl)",
     "d": "pl.pons.com",
     "t": "ponsples",
     "u": "https://pl.pons.com/tłumaczenie?q={{{s}}}&l=espl&in=&lf=es",
@@ -63193,7 +63193,7 @@
     "sc": "General"
   },
   {
-    "s": "pons.eu",
+    "s": "PONS",
     "d": "en.pons.com",
     "t": "pons",
     "u": "https://en.pons.com/translate?q={{{s}}}",
@@ -63201,7 +63201,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Pons.eu",
+    "s": "PONS (en-pt)",
     "d": "en.pons.com",
     "t": "ponspt",
     "u": "https://en.pons.com/translate?q={{{s}}}&l=enpt&in=&lf=en",
@@ -63289,7 +63289,7 @@
     "sc": "Online"
   },
   {
-    "s": "Poradnia Języka Polskiego",
+    "s": "Słownik Języka Polskiego (Poradnia)",
     "d": "sjp.pwn.pl",
     "t": "por",
     "u": "https://sjp.pwn.pl/poradnia/szukaj/{{{s}}}.html",
@@ -63313,7 +63313,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "PORT.hu",
+    "s": "PORT",
     "d": "port.hu",
     "t": "porthu",
     "u": "https://port.hu/kereso?q={{{s}}}",
@@ -63332,7 +63332,7 @@
     "sc": "Sysadmin (network)"
   },
   {
-    "s": "Speedguide.net Port Lookup",
+    "s": "SpeedGuide (Port)",
     "d": "www.speedguide.net",
     "t": "ports",
     "u": "https://www.speedguide.net/port.php?port={{{s}}}",
@@ -63407,7 +63407,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "PostgreSQL.org",
+    "s": "PostgreSQL",
     "d": "www.postgresql.org",
     "t": "postgresql",
     "u": "https://www.postgresql.org/search?q={{{s}}}&a=1&submit=Search",
@@ -63535,7 +63535,7 @@
     "sc": "Food"
   },
   {
-    "s": "Personal Package Archives for Ubuntu",
+    "s": "Launchpad (PPA)",
     "d": "launchpad.net",
     "t": "ppa",
     "u": "https://launchpad.net/ubuntu/+ppas?name_filter={{{s}}}",
@@ -63591,7 +63591,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Kagi Search (ppt)",
+    "s": "Kagi (PPT)",
     "d": "kagi.com",
     "ad": "",
     "t": "ppt",
@@ -63600,7 +63600,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "Polish Post tracking",
+    "s": "Poczta Polska (Tracking)",
     "d": "emonitoring.poczta-polska.pl",
     "t": "pptrack",
     "u": "https://emonitoring.poczta-polska.pl/?lang=en&numer={{{s}}}",
@@ -63685,7 +63685,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Internet Archive - Prelinger Archives",
+    "s": "Internet Archive (Prelinger Archives)",
     "d": "archive.org",
     "t": "prel",
     "u": "https://archive.org/details/prelinger?and[]={{{s}}}",
@@ -63797,7 +63797,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Tweakers Pricewatch",
+    "s": "Tweakers (Pricewatch)",
     "d": "tweakers.net",
     "t": "pricewatch",
     "ts": [
@@ -63825,7 +63825,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Amazon Prime Video",
+    "s": "Amazon (Prime Video)",
     "d": "www.amazon.com",
     "t": "primevideo",
     "u": "https://www.amazon.com/s?url=search-alias=prime-instant-video&field-keywords={{{s}}}",
@@ -63833,7 +63833,7 @@
     "sc": "Movies"
   },
   {
-    "s": "amazon prime video jp",
+    "s": "Amazon (Prime Video, Japan)",
     "d": "www.amazon.co.jp",
     "t": "primevideojp",
     "u": "https://www.amazon.co.jp/s/?url=search-alias=instant-video&field-keywords={{{s}}}",
@@ -63897,7 +63897,7 @@
     "sc": "Design"
   },
   {
-    "s": "r/privacy Subreddit",
+    "s": "Reddit (/r/privacy)",
     "d": "www.reddit.com",
     "t": "privacy",
     "ts": [
@@ -63916,7 +63916,7 @@
     "sc": "TV"
   },
   {
-    "s": "Processing.org",
+    "s": "Processing (Kagi)",
     "d": "kagi.com",
     "ad": "processing.org",
     "t": "processing",
@@ -63990,7 +63990,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Reddit /r/ProgrammerHumor",
+    "s": "Reddit (/r/ProgrammerHumor)",
     "d": "www.reddit.com",
     "t": "programmerhumor",
     "u": "https://www.reddit.com/r/ProgrammerHumor/search?q={{{s}}}&restrict_sr=on",
@@ -64089,7 +64089,7 @@
     "sc": "Business"
   },
   {
-    "s": "Protocols.io",
+    "s": "Protocols",
     "d": "protocols.io",
     "t": "protocolsio",
     "u": "https://protocols.io/search?key={{{s}}}",
@@ -64140,7 +64140,7 @@
     "sc": "Services"
   },
   {
-    "s": "Proz.com Forums",
+    "s": "ProZ (Forums)",
     "d": "www.proz.com",
     "t": "proz",
     "u": "https://www.proz.com/search/?term={{{s}}}",
@@ -64204,7 +64204,7 @@
     "sc": "Design"
   },
   {
-    "s": "PlayStation Store Games Canada",
+    "s": "PlayStation Store (Canada Games)",
     "d": "store.playstation.com",
     "t": "psgca",
     "u": "https://store.playstation.com/en-ca/grid/search-game/1?query={{{s}}}",
@@ -64252,7 +64252,7 @@
     "sc": "Languages (other)"
   },
   {
-    "s": "PlayStation Store Deutschland",
+    "s": "PlayStation Store (Germany)",
     "d": "store.playstation.com",
     "t": "psnde",
     "u": "https://store.playstation.com/de-de/search/{{{s}}}",
@@ -64260,7 +64260,7 @@
     "sc": "Online"
   },
   {
-    "s": "Playstation Store JP",
+    "s": "PlayStation Store (Japan)",
     "d": "store.playstation.com",
     "t": "psnjp",
     "u": "https://store.playstation.com/ja-jp/search/{{{s}}}",
@@ -64268,7 +64268,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Playstation Store NZ",
+    "s": "PlayStation Store (New Zealand)",
     "d": "store.playstation.com",
     "t": "psnnz",
     "u": "https://store.playstation.com/en-nz/grid/search-game/1?query={{{s}}}",
@@ -64292,7 +64292,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Playstation Store UK",
+    "s": "PlayStation Store (UK)",
     "d": "store.playstation.com",
     "t": "psnuk",
     "u": "https://store.playstation.com/#!/en-gb/search/q={{{s}}}",
@@ -64388,7 +64388,7 @@
     "sc": "Games (Pokemon)"
   },
   {
-    "s": "Google Translate - pt-en",
+    "s": "Google Translate (pt-en)",
     "d": "translate.google.com",
     "t": "pten",
     "u": "https://translate.google.com/#pt/en/{{{s}}}",
@@ -64396,7 +64396,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Translate Portuguese-Spanish",
+    "s": "Google Translate (pt-es)",
     "d": "translate.google.com",
     "t": "ptes",
     "u": "https://translate.google.com/#pt/es/{{{s}}}",
@@ -64572,7 +64572,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "PulseUniform - Nursing Uniforms, Medical Scrubs, Lab Coats and Accessories",
+    "s": "PulseUniform",
     "d": "www.pulseuniform.com",
     "t": "pu",
     "u": "https://www.pulseuniform.com/search.asp?q={{{s}}}",
@@ -64596,7 +64596,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "PurpleMath",
+    "s": "Purplemath",
     "d": "search.freefind.com",
     "t": "purplemath",
     "u": "https://search.freefind.com/find.html?id=5014414&pageid=r&mode=ALL&n=0&query={{{s}}}",
@@ -64690,7 +64690,7 @@
     "sc": "Images"
   },
   {
-    "s": "Pixabay Vector Graphics",
+    "s": "Pixabay (Vectors)",
     "d": "pixabay.com",
     "t": "pxv",
     "u": "https://pixabay.com/en/photos/?q={{{s}}}&image_type=vector&cat=&min_width=&min_height=",
@@ -64698,7 +64698,7 @@
     "sc": "Images"
   },
   {
-    "s": "Python 2.7.10 Documentation",
+    "s": "Python Docs (2.7)",
     "d": "docs.python.org",
     "t": "py27",
     "ts": [
@@ -64709,7 +64709,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "Python Documentation",
+    "s": "Python Docs (3.4)",
     "d": "docs.python.org",
     "t": "py34",
     "u": "https://docs.python.org/3.4/search.html?q={{{s}}}",
@@ -64717,7 +64717,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "Python 3.5 Documentation",
+    "s": "Python Docs (3.5)",
     "d": "docs.python.org",
     "t": "py35",
     "u": "https://docs.python.org/3.5/search.html?q={{{s}}}",
@@ -64725,7 +64725,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Python 3.6 Documentation",
+    "s": "Python Docs (3.6)",
     "d": "docs.python.org",
     "t": "py36doc",
     "u": "https://docs.python.org/3.6/library/{{{s}}}.html",
@@ -64733,7 +64733,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "Python3 Documentation (French)",
+    "s": "Python Docs (3, French)",
     "d": "docs.python.org",
     "t": "py3fr",
     "u": "https://docs.python.org/fr/3/search.html?q={{{s}}}",
@@ -64741,7 +64741,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "Python 3 Docs",
+    "s": "Python Docs (3)",
     "d": "docs.python.org",
     "t": "py3k",
     "ts": [
@@ -64755,7 +64755,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "PrimiciasYA.com",
+    "s": "PrimiciasYA",
     "d": "www.primiciasya.com",
     "t": "pya",
     "u": "https://www.primiciasya.com/search.html?q={{{s}}}",
@@ -64815,7 +64815,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "docs.pylonproject.org",
+    "s": "Pyramid (Docs)",
     "d": "docs.pylonsproject.org",
     "t": "pyramid",
     "u": "https://docs.pylonsproject.org/projects/pyramid/en/latest/search.html?q={{{s}}}",
@@ -64850,7 +64850,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "Python2.6 Docs",
+    "s": "Python Docs (2.6)",
     "d": "docs.python.org",
     "t": "python26",
     "u": "https://docs.python.org/2.6/search.html?q={{{s}}}&check_keywords=yes&area=default",
@@ -64866,7 +64866,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "Python",
+    "s": "Python Docs (2)",
     "d": "docs.python.org",
     "t": "python2",
     "u": "https://docs.python.org/2/search.html?q={{{s}}}",
@@ -64874,7 +64874,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "Python3.0 Docs",
+    "s": "Python Docs (3.0)",
     "d": "docs.python.org",
     "t": "python30",
     "u": "https://docs.python.org/3.0/search.html?q={{{s}}}&check_keywords=yes&area=default",
@@ -64882,7 +64882,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "Python3.1 Docs",
+    "s": "Python Docs (3.1)",
     "d": "docs.python.org",
     "t": "python31",
     "u": "https://docs.python.org/3.1/search.html?q={{{s}}}&check_keywords=yes&area=default",
@@ -64890,7 +64890,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "Python3.2 Docs",
+    "s": "Python Docs (3.2)",
     "d": "docs.python.org",
     "t": "python32",
     "u": "https://docs.python.org/3.2/search.html?q={{{s}}}&check_keywords=yes&area=default",
@@ -64898,7 +64898,7 @@
     "sc": "Languages (python)"
   },
   {
-    "s": "Python dev doc",
+    "s": "Python Docs (Dev)",
     "d": "docs.python.org",
     "t": "pythondev",
     "u": "https://docs.python.org/dev/search.html?q={{{s}}}",
@@ -64970,7 +64970,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Bash.org",
+    "s": "Bash",
     "d": "www.bash.org",
     "t": "qdb",
     "u": "https://www.bash.org/?search={{{s}}}",
@@ -64978,7 +64978,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Quora Español",
+    "s": "Quora (Spanish)",
     "d": "es.quora.com",
     "t": "qes",
     "u": "https://es.quora.com/search?q={{{s}}}",
@@ -64994,7 +64994,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Québec Info Musique (album)",
+    "s": "Québec Info Musique (Album)",
     "d": "www.qim.com",
     "t": "qimalbum",
     "ts": [
@@ -65025,7 +65025,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Qwant Maps",
+    "s": "Qwant (Maps)",
     "d": "www.qwant.com",
     "t": "qmaps",
     "u": "https://www.qwant.com/maps/?q={{{s}}}",
@@ -65033,7 +65033,7 @@
     "sc": "Maps"
   },
   {
-    "s": "quickmeme",
+    "s": "Quickmeme",
     "d": "m.quickmeme.com",
     "t": "qme",
     "u": "https://m.quickmeme.com/search/?q={{{s}}}",
@@ -65041,7 +65041,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Qwant music search",
+    "s": "Qwant (Music)",
     "d": "www.qwant.com",
     "t": "qm",
     "ts": [
@@ -65103,7 +65103,7 @@
     "sc": "Design"
   },
   {
-    "s": "QR Code Search",
+    "s": "QRserver",
     "d": "api.qrserver.com",
     "t": "qr",
     "u": "https://api.qrserver.com/v1/create-qr-code/?qzone=1&data={{{s}}}",
@@ -65378,7 +65378,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Qwant Images",
+    "s": "Qwant (Images)",
     "d": "www.qwant.com",
     "t": "qwi",
     "u": "https://www.qwant.com/?q={{{s}}}&t=images",
@@ -65394,7 +65394,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Qwant News",
+    "s": "Qwant (News)",
     "d": "www.qwant.com",
     "t": "qwn",
     "u": "https://www.qwant.com/?q={{{s}}}&t=news",
@@ -65402,7 +65402,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "Qwant Social",
+    "s": "Qwant (Social)",
     "d": "www.qwant.com",
     "t": "qws",
     "u": "https://www.qwant.com/?q={{{s}}}&t=social",
@@ -65410,7 +65410,7 @@
     "sc": "Social (intl)"
   },
   {
-    "s": "Qwant Videos",
+    "s": "Qwant (Videos)",
     "d": "www.qwant.com",
     "t": "qwv",
     "u": "https://www.qwant.com/?q={{{s}}}&t=videos",
@@ -65418,7 +65418,7 @@
     "sc": "Video"
   },
   {
-    "s": "Qwant web",
+    "s": "Qwant (Web)",
     "d": "www.qwant.com",
     "t": "qww",
     "u": "https://www.qwant.com/?q={{{s}}}&t=web",
@@ -65477,7 +65477,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "RACING.COM",
+    "s": "Racing",
     "d": "www.racing.com",
     "t": "racing",
     "u": "https://www.racing.com/search?q={{{s}}}",
@@ -65512,7 +65512,7 @@
     "sc": "Services"
   },
   {
-    "s": "r/ADHD",
+    "s": "Reddit (/r/ADHD)",
     "d": "www.reddit.com",
     "t": "radhd",
     "u": "https://www.reddit.com/r/ADHD/search/?q={{{s}}}&restrict_sr=1",
@@ -65539,7 +65539,7 @@
     "sc": "Broadcast"
   },
   {
-    "s": "Radiopaedia.org",
+    "s": "Radiopaedia",
     "d": "radiopaedia.org",
     "t": "radio",
     "ts": [
@@ -65602,7 +65602,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Raider.io",
+    "s": "Raider",
     "d": "raider.io",
     "t": "raiderio",
     "u": "https://raider.io/search?type=character&name[0][contains]={{{s}}}",
@@ -65618,7 +65618,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Rails-Dock",
+    "s": "APIDock (Rails)",
     "d": "apidock.com",
     "t": "railsdock",
     "u": "https://apidock.com/rails/search?query={{{s}}}",
@@ -65651,7 +65651,7 @@
     "sc": "Video"
   },
   {
-    "s": "Rakuten.de",
+    "s": "Rakuten (Germany)",
     "d": "www.rakuten.de",
     "t": "rakde",
     "u": "https://www.rakuten.de/suchen/{{{s}}}?category=0",
@@ -65683,7 +65683,7 @@
     "sc": "Social"
   },
   {
-    "s": "rgb to",
+    "s": "rgb.to",
     "d": "rgb.to",
     "t": "ral",
     "u": "https://rgb.to/ral/{{{s}}}",
@@ -65769,7 +65769,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Rate Your Music (genre)",
+    "s": "Rate Your Music (Genre)",
     "d": "rateyourmusic.com",
     "t": "rateyourgenre",
     "ts": [
@@ -65933,7 +65933,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Roblox Users",
+    "s": "Roblox (Users)",
     "d": "www.roblox.com",
     "t": "rblxg",
     "ts": [
@@ -65944,7 +65944,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Roblox Marketplace",
+    "s": "Roblox (Marketplace)",
     "d": "www.roblox.com",
     "t": "rblx",
     "u": "https://www.roblox.com/catalog?Keyword={{{s}}}",
@@ -65952,7 +65952,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Reverse Beacon Network - DX station",
+    "s": "Reverse Beacon Network (DX Station)",
     "d": "www.reversebeacon.net",
     "t": "rbndx",
     "u": "https://www.reversebeacon.net/dxsd1/dxsd1.php?f=0&c={{{s}}}&t=dx",
@@ -66067,7 +66067,7 @@
     "sc": "General"
   },
   {
-    "s": "Rust Compiler Error Index",
+    "s": "Rust (Compiler Error Index)",
     "d": "doc.rust-lang.org",
     "t": "rce",
     "u": "https://doc.rust-lang.org/error-index.html#E{{{s}}}",
@@ -66107,7 +66107,7 @@
     "sc": "Food"
   },
   {
-    "s": "Craigslist - Raleigh, NC",
+    "s": "Craigslist (Raleigh, NC)",
     "d": "raleigh.craigslist.org",
     "t": "rcl",
     "u": "https://raleigh.craigslist.org/search/?query={{{s}}}",
@@ -66214,7 +66214,7 @@
     "sc": "Online"
   },
   {
-    "s": "Romajidesu Kanji",
+    "s": "Romajidesu (Kanji)",
     "d": "www.romajidesu.com",
     "t": "rdkj",
     "ts": [
@@ -66225,7 +66225,7 @@
     "sc": "Learning (intl)"
   },
   {
-    "s": "MXToolbox (dns ptr)",
+    "s": "MXToolbox (DNS PTR)",
     "d": "mxtoolbox.com",
     "t": "rdns",
     "u": "https://mxtoolbox.com/SuperTool.aspx?action=ptr:{{{s}}}&run=toolpage",
@@ -66262,7 +66262,7 @@
     "sc": "Languages (r)"
   },
   {
-    "s": "Romajidesu Vocabulary",
+    "s": "Romajidesu (Vocabulary)",
     "d": "www.romajidesu.com",
     "t": "rdvcb",
     "ts": [
@@ -66297,7 +66297,7 @@
     "sc": "Languages (javascript)"
   },
   {
-    "s": "Digital Comics - DC Entertainment",
+    "s": "ReadDC",
     "d": "www.readdc.com",
     "t": "readdc",
     "u": "https://www.readdc.com/search?search={{{s}}}&submit=SEARCH",
@@ -66348,7 +66348,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Reason.com",
+    "s": "Reason",
     "d": "reason.com",
     "t": "reason",
     "u": "https://reason.com/search?q={{{s}}}",
@@ -66396,7 +66396,7 @@
     "sc": "Online"
   },
   {
-    "s": "CourtListener - RECAP Archive",
+    "s": "CourtListener (RECAP)",
     "d": "www.courtlistener.com",
     "t": "recap",
     "ts": [
@@ -66407,7 +66407,7 @@
     "sc": "Law"
   },
   {
-    "s": "CourtListener - Case Law",
+    "s": "CourtListener",
     "d": "www.courtlistener.com",
     "t": "courtlistener",
     "ts": [
@@ -66418,7 +66418,7 @@
     "sc": "Law"
   },
   {
-    "s": "CourtListener - Oral Argument Audio",
+    "s": "CourtListener (Oral Arguments)",
     "d": "www.courtlistener.com",
     "t": "cl-audio",
     "u": "https://www.courtlistener.com/?type=oa&q={{{s}}}&order_by=score desc",
@@ -66426,7 +66426,7 @@
     "sc": "Law"
   },
   {
-    "s": "DuckDuckGo Last Week",
+    "s": "DuckDuckGo (Past Week)",
     "d": "duckduckgo.com",
     "t": "ddg-recent",
     "ts": [
@@ -66552,7 +66552,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "Reddit subreddit",
+    "s": "Reddit (Subreddits)",
     "d": "www.reddit.com",
     "t": "reddits",
     "ts": [
@@ -66569,7 +66569,7 @@
     "sc": "Social"
   },
   {
-    "s": "Reverso German - English",
+    "s": "Reverso (de-en)",
     "d": "dictionary.reverso.net",
     "t": "redeen",
     "ts": [
@@ -66671,7 +66671,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Reverso English - Spanish",
+    "s": "Reverso (en-es)",
     "d": "dictionary.reverso.net",
     "t": "reenes",
     "u": "https://dictionary.reverso.net/english-spanish/{{{s}}}",
@@ -66679,7 +66679,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Reverso English - French",
+    "s": "Reverso (en-fr)",
     "d": "dictionary.reverso.net",
     "t": "reenfr",
     "ts": [
@@ -66692,7 +66692,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Reverso English - Definition",
+    "s": "Reverso (en Definition)",
     "d": "dictionary.reverso.net",
     "t": "reen",
     "ts": [
@@ -66703,7 +66703,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Reverso Spanish - English",
+    "s": "Reverso (es-en)",
     "d": "dictionary.reverso.net",
     "t": "reesen",
     "u": "https://dictionary.reverso.net/spanish-english/{{{s}}}",
@@ -66711,7 +66711,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Reverso Spanish - French",
+    "s": "Reverso (es-fr)",
     "d": "dictionary.reverso.net",
     "t": "reesfr",
     "u": "https://dictionary.reverso.net/spanish-french/{{{s}}}",
@@ -66719,7 +66719,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Reverso Spanish - German",
+    "s": "Reverso (es-de)",
     "d": "woerterbuch.reverso.net",
     "t": "reesge",
     "u": "https://woerterbuch.reverso.net/spanisch-deutsch/{{{s}}}",
@@ -66727,7 +66727,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Reverso",
+    "s": "Reverso (es-pt)",
     "d": "dictionary.reverso.net",
     "t": "reespt",
     "u": "https://dictionary.reverso.net/spanish-portuguese/{{{s}}}",
@@ -66735,7 +66735,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Reverso Spanish - Definition",
+    "s": "Reverso (es Definition)",
     "d": "dictionary.reverso.net",
     "t": "rees",
     "u": "https://dictionary.reverso.net/spanish-definition/{{{s}}}",
@@ -66751,7 +66751,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Reverso French - English",
+    "s": "Reverso (fr-en)",
     "d": "dictionary.reverso.net",
     "t": "refreb",
     "ts": [
@@ -66778,7 +66778,7 @@
     "sc": "Online"
   },
   {
-    "s": "Reverso French - Spanish",
+    "s": "Reverso (fr-es)",
     "d": "dictionary.reverso.net",
     "t": "refres",
     "u": "https://dictionary.reverso.net/french-spanish/{{{s}}}",
@@ -66786,7 +66786,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Reverso French - Definition",
+    "s": "Reverso (fr Definition)",
     "d": "dictionary.reverso.net",
     "t": "refr",
     "u": "https://dictionary.reverso.net/french-definition/{{{s}}}",
@@ -66805,7 +66805,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Reverso German - Spanish",
+    "s": "Reverso (de-es)",
     "d": "woerterbuch.reverso.net",
     "t": "regees",
     "u": "https://woerterbuch.reverso.net/deutsch-spanisch/{{{s}}}",
@@ -66813,7 +66813,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Reverso German - Definition",
+    "s": "Reverso (de Definition)",
     "d": "dictionary.reverso.net",
     "t": "rege",
     "u": "https://dictionary.reverso.net/german-definition/{{{s}}}",
@@ -66928,7 +66928,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "repl.it",
+    "s": "Replit",
     "d": "repl.it",
     "t": "repl",
     "u": "https://repl.it/languages/{{{s}}}",
@@ -66995,7 +66995,7 @@
     "sc": "Academic"
   },
   {
-    "s": "duckduckgo spain",
+    "s": "DuckDuckGo (Spain)",
     "d": "duckduckgo.com",
     "t": "r-es",
     "u": "https://duckduckgo.com/?q={{{s}}}&kl=es-es",
@@ -67108,7 +67108,7 @@
     "sc": "International"
   },
   {
-    "s": "Reddit User",
+    "s": "Reddit (User)",
     "d": "www.reddit.com",
     "t": "reu",
     "u": "https://www.reddit.com/user/{{{s}}}",
@@ -67164,7 +67164,7 @@
     "sc": "Online"
   },
   {
-    "s": "Reverso DIctionary",
+    "s": "Reverso (it-en)",
     "d": "dictionary.reverso.net",
     "t": "reversoiten",
     "u": "https://dictionary.reverso.net/italian-english/{{{s}}}",
@@ -67180,7 +67180,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Reverso (German-French)",
+    "s": "Reverso (de-fr)",
     "d": "dictionary.reverso.net",
     "t": "revgf",
     "u": "https://dictionary.reverso.net/german-french/{{{s}}}",
@@ -67247,7 +67247,7 @@
     "sc": "Online"
   },
   {
-    "s": "REX – The Royal Library and Copenhagen University Library Service",
+    "s": "REX (Royal Library Copenhagen)",
     "d": "rex.kb.dk",
     "t": "rex",
     "u": "https://rex.kb.dk/primo_library/libweb/action/search.do?fn=search&vl(freeText0)={{{s}}}",
@@ -67263,7 +67263,7 @@
     "sc": "Programming"
   },
   {
-    "s": "IETF RFC Keyword Search",
+    "s": "RFC Editor (Keyword)",
     "d": "www.rfc-editor.org",
     "t": "rfck",
     "u": "https://www.rfc-editor.org/search/rfc_search_detail.php?title={{{s}}}",
@@ -67303,7 +67303,7 @@
     "sc": "Reference (religion)"
   },
   {
-    "s": "Reverso French Definition",
+    "s": "Reverso (French Definition)",
     "d": "dictionnaire.reverso.net",
     "t": "rfr",
     "u": "https://dictionnaire.reverso.net/francais-definition/{{{s}}}",
@@ -67311,7 +67311,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "RedFox Sanakirja (enfi)",
+    "s": "RedFox Sanakirja (en-fi)",
     "d": "redfoxsanakirja.fi",
     "t": "rfsanae",
     "u": "https://redfoxsanakirja.fi/sanakirja/-/s/eng/fin/{{{s}}}",
@@ -67319,7 +67319,7 @@
     "sc": "General"
   },
   {
-    "s": "RedFox Sanakirja",
+    "s": "RedFox Sanakirja (fi-en)",
     "d": "redfoxsanakirja.fi",
     "t": "rfsana",
     "u": "https://redfoxsanakirja.fi/sanakirja/-/s/fin/eng/{{{s}}}",
@@ -67488,7 +67488,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Riksdagen.se",
+    "s": "Riksdagen",
     "d": "www.riksdagen.se",
     "t": "riksdagen",
     "u": "https://www.riksdagen.se/sv/global/sok/?q={{{s}}}&st=1",
@@ -67504,7 +67504,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Rimessolides.com",
+    "s": "Rimessolides",
     "d": "www.rimessolides.com",
     "t": "rime",
     "u": "https://www.rimessolides.com/rime.aspx?m={{{s}}}",
@@ -67512,7 +67512,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Rimlexikon.com",
+    "s": "Rimlexikon",
     "d": "rimlexikon.com",
     "t": "rim",
     "u": "https://rimlexikon.com/index.php?rim={{{s}}}",
@@ -67614,7 +67614,7 @@
     "sc": "Business"
   },
   {
-    "s": "Роскомсвобода (rublacklist)",
+    "s": "Роскомсвобода",
     "d": "reestr.rublacklist.net",
     "t": "rkn",
     "u": "https://reestr.rublacklist.net/search/?q={{{s}}}",
@@ -67630,7 +67630,7 @@
     "sc": "Tech"
   },
   {
-    "s": "r/leb",
+    "s": "Reddit (/r/lebanon)",
     "d": "www.reddit.com",
     "t": "r/leb",
     "u": "https://www.reddit.com/r/lebanon/search?q={{{s}}}",
@@ -67646,7 +67646,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Rocket League Reddit",
+    "s": "Reddit (/r/RocketLeague)",
     "d": "www.reddit.com",
     "t": "rlr",
     "ts": [
@@ -67673,7 +67673,7 @@
     "sc": "Tracking"
   },
   {
-    "s": "r/Melbourne",
+    "s": "Reddit (/r/melbourne)",
     "d": "www.reddit.com",
     "t": "rmelb",
     "u": "https://www.reddit.com/r/melbourne/search?q={{{s}}}&restrict_sr=on&sort=relevance&t=all",
@@ -67689,7 +67689,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Reddit's Mechanical Keyboards Subreddit",
+    "s": "Reddit (/r/MechanicalKeyboards)",
     "d": "www.reddit.com",
     "t": "rmk",
     "u": "https://www.reddit.com/r/MechanicalKeyboards/search?q={{{s}}}&sort=relevance&t=all",
@@ -67745,7 +67745,7 @@
     "sc": "Music"
   },
   {
-    "s": "Roblox Experiences",
+    "s": "Roblox (Experiences)",
     "d": "www.roblox.com",
     "t": "robloxg",
     "ts": [
@@ -67757,7 +67757,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Roblox Communities",
+    "s": "Roblox (Communities)",
     "d": "www.roblox.com",
     "t": "robloxgr",
     "u": "https://www.roblox.com/search/communities?keyword={{{s}}}",
@@ -67896,7 +67896,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "rokomari.com",
+    "s": "Rokomari",
     "d": "rokomari.com",
     "t": "rokomari",
     "u": "https://rokomari.com/search?term={{{s}}}",
@@ -67944,7 +67944,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "RosettaCode.org",
+    "s": "Rosetta Code",
     "d": "rosettacode.org",
     "t": "rosettacode",
     "ts": [
@@ -68029,7 +68029,7 @@
     "sc": "Online"
   },
   {
-    "s": "Rouxbe (Kagi Search)",
+    "s": "Rouxbe (Kagi)",
     "d": "kagi.com",
     "ad": "rouxbe.com",
     "t": "rouxbe",
@@ -68070,7 +68070,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Reddit PublicFreakout",
+    "s": "Reddit (/r/PublicFreakout)",
     "d": "www.reddit.com",
     "t": "rpf",
     "u": "https://www.reddit.com/r/PublicFreakout/search/?q={{{s}}}&restrict_sr=1",
@@ -68121,7 +68121,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "RPMfind.net",
+    "s": "RPMfind",
     "d": "rpmfind.net",
     "t": "rpmfind",
     "ts": [
@@ -68172,7 +68172,7 @@
     "sc": "Misc"
   },
   {
-    "s": "rs.4chan.org",
+    "s": "4chan (Serbia)",
     "d": "rs.4chan.org",
     "t": "rs4",
     "u": "https://rs.4chan.org/?s={{{s}}}&from=ALL",
@@ -68200,7 +68200,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "admin.ch -  Recueil systématique",
+    "s": "admin.ch (Recueil systématique)",
     "d": "www.admin.ch",
     "t": "rsch",
     "u": "https://www.admin.ch/opc/search/?text={{{s}}}&lang=fr&product[]=cc&date_range_min=&date_range_max=&d_compilation=both&d_is_in_force=yes&thesaurus=1",
@@ -68208,7 +68208,7 @@
     "sc": "Law"
   },
   {
-    "s": "Reddit Ask Science",
+    "s": "Reddit (/r/askscience)",
     "d": "www.reddit.com",
     "t": "rsci",
     "u": "https://www.reddit.com/r/askscience/search?q={{{s}}}&restrict_sr=1",
@@ -68224,7 +68224,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Royal Society Collections Catalogues, archives",
+    "s": "Royal Society (Archives)",
     "d": "catalogues.royalsociety.org",
     "t": "rsca",
     "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.Catalog&r=((((text)='{{{s}}}')))",
@@ -68232,7 +68232,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Royal Society Collections Catalogues, printed works",
+    "s": "Royal Society (Printed Works)",
     "d": "catalogues.royalsociety.org",
     "t": "rscp",
     "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.CatalogL&r=((((text)='{{{s}}}')))",
@@ -68240,7 +68240,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Royal Society Collections Catalogues, past Fellows by surname",
+    "s": "Royal Society (Fellows)",
     "d": "catalogues.royalsociety.org",
     "t": "rscf",
     "u": "https://catalogues.royalsociety.org/CalmView/Overview.aspx?src=CalmView.Persons&r=(((Surname='{{{s}}}')))",
@@ -68280,7 +68280,7 @@
     "sc": "Tech"
   },
   {
-    "s": "The RuneScape Grand Exchange",
+    "s": "RuneScape (Grand Exchange)",
     "d": "services.runescape.com",
     "t": "rsge",
     "u": "https://services.runescape.com/m=itemdb_rs/results?query={{{s}}}",
@@ -68320,7 +68320,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Reddit (subreddit new)",
+    "s": "Reddit (New)",
     "d": "www.reddit.com",
     "t": "rsn",
     "u": "https://www.reddit.com/r/{{{s}}}/new/",
@@ -68336,7 +68336,7 @@
     "sc": "Tech"
   },
   {
-    "s": "R questions on Stack Overflow",
+    "s": "Stack Overflow (R)",
     "d": "stackoverflow.com",
     "t": "rso",
     "ts": [
@@ -68371,7 +68371,7 @@
     "sc": "Search"
   },
   {
-    "s": "std library docs for rust",
+    "s": "Rust (Standard Library)",
     "d": "doc.rust-lang.org",
     "t": "rs-std",
     "u": "https://doc.rust-lang.org/std/index.html?search={{{s}}}",
@@ -68398,7 +68398,7 @@
     "sc": "Services"
   },
   {
-    "s": "BibleGateway: Revised Standard Version Catholic Edition",
+    "s": "BibleGateway (Revised Standard Version Catholic Edition)",
     "d": "www.biblegateway.com",
     "t": "rsvce",
     "u": "https://www.biblegateway.com/passage/?search={{{s}}}&version=RSVCE",
@@ -68430,7 +68430,7 @@
     "sc": "Broadcast"
   },
   {
-    "s": "Binding of Isaac subreddit",
+    "s": "Reddit (/r/bindingofisaac)",
     "d": "www.reddit.com",
     "t": "rtboi",
     "u": "https://www.reddit.com/r/bindingofisaac/search?q={{{s}}}&restrict_sr=on",
@@ -68446,7 +68446,7 @@
     "sc": "TV"
   },
   {
-    "s": "RT en Español",
+    "s": "RT (Español)",
     "d": "actualidad.rt.com",
     "t": "rtes",
     "u": "https://actualidad.rt.com/search?q={{{s}}}",
@@ -68510,7 +68510,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Rtings.com",
+    "s": "RTINGS",
     "d": "www.rtings.com",
     "t": "rtings",
     "u": "https://www.rtings.com/search?q={{{s}}}",
@@ -68574,7 +68574,7 @@
     "sc": "Languages (ruby)"
   },
   {
-    "s": "Ruby-Doc.org",
+    "s": "Ruby-Doc",
     "d": "www.ruby-doc.org",
     "t": "rubydoc",
     "u": "https://www.ruby-doc.org/search.html?q={{{s}}}",
@@ -68606,7 +68606,7 @@
     "sc": "Languages (ruby)"
   },
   {
-    "s": "Google Translate (ruen)",
+    "s": "Google Translate (ru-en)",
     "d": "translate.google.com",
     "t": "ruen",
     "ts": [
@@ -68617,7 +68617,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Google Translate RU-FR",
+    "s": "Google Translate (ru-fr)",
     "d": "translate.google.com",
     "t": "rufr",
     "u": "https://translate.google.com/#ru/fr/{{{s}}}",
@@ -68641,7 +68641,7 @@
     "sc": "Academic"
   },
   {
-    "s": "ruk.ca",
+    "s": "RUK",
     "d": "ruk.ca",
     "t": "ruk",
     "u": "https://ruk.ca/search/site/{{{s}}}",
@@ -68657,7 +68657,7 @@
     "sc": "Video"
   },
   {
-    "s": "Runescape Wiki",
+    "s": "runeScape Wiki",
     "d": "runescape.wiki",
     "t": "runescape",
     "u": "https://runescape.wiki/w/Special:Search?search={{{s}}}",
@@ -68673,7 +68673,7 @@
     "sc": "Blogs (intl)"
   },
   {
-    "s": "DuckDuckGo US",
+    "s": "DuckDuckGo (US)",
     "d": "duckduckgo.com",
     "t": "r-us",
     "u": "https://duckduckgo.com/?q={{{s}}}&kl=us-en",
@@ -68697,7 +68697,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "RustDocs",
+    "s": "Rust (Docs)",
     "d": "doc.rust-lang.org",
     "t": "rustdoc",
     "ts": [
@@ -68718,7 +68718,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Rust Nightly Standard Library Documentation",
+    "s": "Rust (Nightly Standard Library)",
     "d": "doc.rust-lang.org",
     "t": "rustn",
     "u": "https://doc.rust-lang.org/nightly/std/?search={{{s}}}",
@@ -68726,7 +68726,7 @@
     "sc": "Languages (other)"
   },
   {
-    "s": "Rust RFC GitHub.com",
+    "s": "GitHub (Rust RFCs)",
     "d": "github.com",
     "t": "rustrfc",
     "u": "https://github.com/rust-lang/rfcs/issues?utf8=%E2%9C%93&q={{{s}}}",
@@ -68734,7 +68734,7 @@
     "sc": "Programming"
   },
   {
-    "s": "ruten",
+    "s": "Ruten",
     "d": "find.ruten.com.tw",
     "t": "ruten",
     "u": "https://find.ruten.com.tw/search/s000.php?enc=u&searchfrom=searchf&k={{{s}}}&t=0",
@@ -68830,7 +68830,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Reddit (past year (and more))",
+    "s": "Reddit (Past Year)",
     "d": "www.reddit.com",
     "t": "ryear",
     "u": "https://www.reddit.com/search?q={{{s}}}&t=year",
@@ -68854,7 +68854,7 @@
     "sc": "Music"
   },
   {
-    "s": "rateyourmusic.com",
+    "s": "Rate Your Music (Releases)",
     "d": "rateyourmusic.com",
     "t": "rymrelease",
     "u": "https://rateyourmusic.com/search?searchterm={{{s}}}&type=l",
@@ -68862,7 +68862,7 @@
     "sc": "Music"
   },
   {
-    "s": "Rate Your Music (All releases)",
+    "s": "Rate Your Music (All Releases)",
     "d": "rateyourmusic.com",
     "t": "rymr",
     "u": "https://rateyourmusic.com/search?searchtype=l&searchterm={{{s}}}",
@@ -68870,7 +68870,7 @@
     "sc": "Music"
   },
   {
-    "s": "/r/zelda",
+    "s": "Reddit (/r/zelda)",
     "d": "www.reddit.com",
     "t": "rzelda",
     "u": "https://www.reddit.com/r/zelda/search/?q={{{s}}}",
@@ -68918,7 +68918,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Saabforum.nl",
+    "s": "Saabforum",
     "d": "www.saabforum.nl",
     "t": "saabforum",
     "u": "https://www.saabforum.nl/search.php?keywords={{{s}}}",
@@ -68958,7 +68958,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Skeptics Annotated Bible (Kagi Search)",
+    "s": "Skeptics Annotated Bible (Kagi)",
     "d": "kagi.com",
     "ad": "skepticsannotatedbible.com",
     "t": "sab",
@@ -68986,7 +68986,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "Safari Extensions Gallery",
+    "s": "App Store (Mac, US)",
     "d": "apps.apple.com",
     "t": "safariext",
     "u": "https://apps.apple.com/us/mac/search?term={{{s}}}",
@@ -69010,7 +69010,7 @@
     "sc": "Images"
   },
   {
-    "s": "DDG Safesearch On",
+    "s": "Kagi (SafeSearch On)",
     "d": "kagi.com",
     "ad": "",
     "t": "safe",
@@ -69022,7 +69022,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "Safe search off",
+    "s": "Kagi (SafeSearch Off)",
     "d": "kagi.com",
     "ad": "",
     "t": "safeoff",
@@ -69031,7 +69031,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "SageMath Docs (Kagi Search)",
+    "s": "SageMath Docs (Kagi)",
     "d": "kagi.com",
     "ad": "doc.sagemath.org",
     "t": "sage",
@@ -69120,7 +69120,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Salon.com",
+    "s": "Salon",
     "d": "www.salon.com",
     "t": "salon",
     "u": "https://www.salon.com/search/{{{s}}}",
@@ -69144,7 +69144,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "SaltStack Execution Modules",
+    "s": "Salt (Execution Modules)",
     "d": "docs.saltstack.com",
     "t": "saltmod",
     "u": "https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.{{{s}}}.html",
@@ -69160,7 +69160,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "SaltStack Docs (Kagi Search)",
+    "s": "SaltStack Docs (Kagi)",
     "d": "kagi.com",
     "ad": "docs.saltstack.com",
     "t": "saltstack",
@@ -69169,7 +69169,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "SaltStack State Modules",
+    "s": "Salt (State Modules)",
     "d": "docs.saltstack.com",
     "t": "saltstates",
     "u": "https://docs.saltstack.com/en/latest/ref/states/all/salt.states.{{{s}}}.html",
@@ -69238,7 +69238,7 @@
     "sc": "Search"
   },
   {
-    "s": "Sanakirja.org",
+    "s": "Sanakirja",
     "d": "www.sanakirja.org",
     "t": "sanakirja",
     "ts": [
@@ -69265,7 +69265,7 @@
     "sc": "Movies"
   },
   {
-    "s": "San Diego - The Official Travel Resource for the San Diego Region",
+    "s": "San Diego",
     "d": "www.sandiego.org",
     "t": "sandiego",
     "u": "https://www.sandiego.org/search/site.aspx?q={{{s}}}",
@@ -69327,7 +69327,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "SAP Downloads",
+    "s": "SAP Launchpad (Downloads)",
     "d": "launchpad.support.sap.com",
     "t": "sapdl",
     "u": "https://launchpad.support.sap.com/#/softwarecenter/search/{{{s}}}",
@@ -69351,7 +69351,7 @@
     "sc": "Online"
   },
   {
-    "s": "SAP notes",
+    "s": "SAP Launchpad (Note)",
     "d": "launchpad.support.sap.com",
     "t": "sapnote",
     "u": "https://launchpad.support.sap.com/#/notes/{{{s}}}/E",
@@ -69359,7 +69359,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "SAP Notes",
+    "s": "SAP Launchpad (Notes)",
     "d": "launchpad.support.sap.com",
     "t": "sapnotes",
     "u": "https://launchpad.support.sap.com/#/solutions/notes/?q={{{s}}}",
@@ -69399,7 +69399,7 @@
     "sc": "Programming"
   },
   {
-    "s": "TCodeSearch Tables",
+    "s": "TCodeSearch (Tables)",
     "d": "www.tcodesearch.com",
     "t": "saptables",
     "ts": [
@@ -69410,7 +69410,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Skeptics Annotated Quran (Kagi Search)",
+    "s": "Skeptics Annotated Quran (Kagi)",
     "d": "kagi.com",
     "ad": "skepticsannotatedbible.com/quran/",
     "t": "saq",
@@ -69463,7 +69463,7 @@
     "sc": "Images"
   },
   {
-    "s": "Saugus.net: Resources for Saugus, Massachusetts",
+    "s": "Saugus (MA)",
     "d": "www.saugus.net",
     "t": "saugus",
     "u": "https://www.saugus.net/cgi-bin/htsearch?config=htdig&restrict=&exclude=&words={{{s}}}&method=and&format=long",
@@ -69502,7 +69502,7 @@
     "sc": "Video"
   },
   {
-    "s": "SAXO.com",
+    "s": "Saxo",
     "d": "www.saxo.com",
     "t": "saxo",
     "u": "https://www.saxo.com/dk/products/search?query={{{s}}}",
@@ -69510,7 +69510,7 @@
     "sc": "Books"
   },
   {
-    "s": "Merriam-Webster Pronunciation",
+    "s": "Merriam-Webster (Pronunciation)",
     "d": "www.merriam-webster.com",
     "t": "say",
     "u": "https://www.merriam-webster.com/dictionary/{{{s}}}?pronunciation",
@@ -69558,7 +69558,7 @@
     "sc": "TV"
   },
   {
-    "s": "Science-Based Medicine (Kagi Search)",
+    "s": "Science-Based Medicine (Kagi)",
     "d": "kagi.com",
     "ad": "sciencebasedmedicine.org",
     "t": "sbm",
@@ -69575,7 +69575,7 @@
     "sc": "Academic"
   },
   {
-    "s": "SlackBuilds.org",
+    "s": "SlackBuilds",
     "d": "slackbuilds.org",
     "t": "sbopkg",
     "ts": [
@@ -69588,7 +69588,7 @@
     "sc": "Sysadmin (packages)"
   },
   {
-    "s": "slounik.org: беларускія слоўнікі і энцыкляпэдыі",
+    "s": "Slounik",
     "d": "www.slounik.org",
     "t": "sbrm",
     "u": "https://www.slounik.org/search?dict=&search={{{s}}}",
@@ -69612,7 +69612,7 @@
     "sc": "Search"
   },
   {
-    "s": "Socialblade twitter",
+    "s": "Social Blade (Twitter)",
     "d": "socialblade.com",
     "t": "sbt",
     "u": "https://socialblade.com/twitter/user/{{{s}}}",
@@ -69636,7 +69636,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "Socialblade YouTube",
+    "s": "Social Blade (YouTube)",
     "d": "socialblade.com",
     "t": "sbyt",
     "u": "https://socialblade.com/youtube/user/{{{s}}}",
@@ -69644,7 +69644,7 @@
     "sc": "Social (intl)"
   },
   {
-    "s": "Scala Standard Library",
+    "s": "Scala (Standard Library)",
     "d": "www.scala-lang.org",
     "t": "scalaapi",
     "u": "https://www.scala-lang.org/api/current/index.html?search={{{s}}}",
@@ -69663,7 +69663,7 @@
     "sc": "Languages (scala)"
   },
   {
-    "s": "Scala doc",
+    "s": "Scala (Doc)",
     "d": "www.scala-lang.org",
     "t": "scaladoc",
     "ts": [
@@ -69699,7 +69699,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Reddit Skincare Addiction",
+    "s": "Reddit (/r/skincareaddiction)",
     "d": "www.reddit.com",
     "t": "sca",
     "u": "https://www.reddit.com/r/skincareaddiction/search?q={{{s}}}&restrict_sr=on",
@@ -69707,7 +69707,7 @@
     "sc": "Social"
   },
   {
-    "s": "Scaruffi Music (Kagi Search)",
+    "s": "Scaruffi (Music, Kagi)",
     "d": "kagi.com",
     "ad": "scaruffi.com",
     "t": "scaruffi",
@@ -69790,7 +69790,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "schema.org",
+    "s": "Schema.org",
     "d": "schema.org",
     "t": "schema",
     "u": "https://schema.org/docs/search_results.html?q={{{s}}}",
@@ -69806,7 +69806,7 @@
     "sc": "Misc"
   },
   {
-    "s": "scholieren.com",
+    "s": "Scholieren",
     "d": "www.scholieren.com",
     "t": "scholieren",
     "u": "https://www.scholieren.com/zoek?q={{{s}}}",
@@ -69862,7 +69862,7 @@
     "sc": "Health"
   },
   {
-    "s": "ScienceBlog.com",
+    "s": "ScienceBlog",
     "d": "scienceblog.com",
     "t": "scienceblog",
     "u": "https://scienceblog.com/?s={{{s}}}",
@@ -69870,7 +69870,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "Science Blogs",
+    "s": "ScienceBlogs",
     "d": "www.google.com",
     "t": "scienceblogs",
     "u": "https://www.google.com/cse?cx=017254414699180528062:uyrcvn__yd0&q={{{s}}}",
@@ -70026,7 +70026,7 @@
     "sc": "Downloads (software)"
   },
   {
-    "s": "scope.dk",
+    "s": "Scope",
     "d": "www.scope.dk",
     "t": "scope.dk",
     "u": "https://www.scope.dk/sogning?sog={{{s}}}",
@@ -70042,7 +70042,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Slant.co",
+    "s": "Slant",
     "d": "www.slant.co",
     "t": "sco",
     "ts": [
@@ -70085,7 +70085,7 @@
     "sc": "Services"
   },
   {
-    "s": "scout.com",
+    "s": "Scout",
     "d": "www.scout.com",
     "t": "scout",
     "u": "https://www.scout.com/news?query={{{s}}}",
@@ -70146,7 +70146,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "scrabblelookup",
+    "s": "Scrabble Lookup",
     "d": "www.scrabblelookup.com",
     "t": "scrabblelookup",
     "u": "https://www.scrabblelookup.com/word/portion/search/{{{s}}}",
@@ -70154,7 +70154,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "scrapy docs",
+    "s": "Scrapy (Docs)",
     "d": "doc.scrapy.org",
     "t": "scrapy",
     "u": "https://doc.scrapy.org/en/latest/search.html?q={{{s}}}",
@@ -70162,7 +70162,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Scratch Forums Search",
+    "s": "Scratch Forums",
     "d": "scratchforums.asun.co",
     "t": "scratchforums",
     "u": "https://scratchforums.asun.co/search?q={{{s}}}",
@@ -70194,7 +70194,7 @@
     "sc": "Online"
   },
   {
-    "s": "Scuba.com",
+    "s": "Scuba",
     "d": "www.scuba.com",
     "t": "scuba",
     "u": "https://www.scuba.com/resources/search1.aspx?Action=Search&Search={{{s}}}",
@@ -70210,7 +70210,7 @@
     "sc": "Search"
   },
   {
-    "s": "syntaxdb.com",
+    "s": "SyntaxDB",
     "d": "syntaxdb.com",
     "t": "sdb",
     "u": "https://syntaxdb.com/reference/search?utf8=%E2%9C%93&search={{{s}}}",
@@ -70304,7 +70304,7 @@
     "sc": "Services"
   },
   {
-    "s": "Seamonkey Add-on",
+    "s": "SeaMonkey (Add-ons)",
     "d": "addons.mozilla.org",
     "t": "seamonkey",
     "u": "https://addons.mozilla.org/en-US/seamonkey/search/?q={{{s}}}&cat=all&lver=any&pid=1&sort=&pp=20&lup=&advanced=",
@@ -70400,7 +70400,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "SEC Edgar",
+    "s": "SEC EDGAR",
     "d": "www.sec.gov",
     "t": "secedgar",
     "u": "https://www.sec.gov/cgi-bin/browse-edgar?CIK={{{s}}}&owner=exclude&action=getcompany",
@@ -70416,7 +70416,7 @@
     "sc": "Programming"
   },
   {
-    "s": "www.sechenovclinic.ru",
+    "s": "Sechenov Clinic",
     "d": "www.sechenovclinic.ru",
     "t": "sechenovclinic",
     "u": "https://www.sechenovclinic.ru/search/index.php?q={{{s}}}",
@@ -70432,7 +70432,7 @@
     "sc": "Search"
   },
   {
-    "s": "infosec-jobs.com",
+    "s": "InfoSec Jobs",
     "d": "infosec-jobs.com",
     "t": "secjobs",
     "u": "https://infosec-jobs.com/?search_keywords={{{s}}}",
@@ -70440,7 +70440,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "SecLists.org",
+    "s": "SecLists",
     "d": "insecure.org",
     "t": "seclists",
     "u": "https://insecure.org/search.html?q={{{s}}}",
@@ -70722,7 +70722,7 @@
     "sc": "Food"
   },
   {
-    "s": "Serienjunkies (Kagi Search)",
+    "s": "Serienjunkies (Kagi)",
     "d": "kagi.com",
     "ad": "www.serienjunkies.de",
     "t": "serjunk",
@@ -70742,7 +70742,7 @@
     "sc": "TV"
   },
   {
-    "s": "servershop24",
+    "s": "ServerShop24",
     "d": "www.servershop24.de",
     "t": "server24",
     "u": "https://www.servershop24.de/?ActionCall=WebActionArticleSearch&BranchId=0&multishop_id=0&customer_class=9&lang=de&Params[SearchParam]={{{s}}}",
@@ -70761,7 +70761,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "service-public.fr",
+    "s": "Service-Public",
     "d": "www.service-public.fr",
     "t": "servicepublic",
     "u": "https://www.service-public.fr/particuliers/recherche?keyword={{{s}}}",
@@ -70796,7 +70796,7 @@
     "sc": "Music (Folk)"
   },
   {
-    "s": "suomienglantisanakirja.fi",
+    "s": "Suomienglantisanakirja",
     "d": "www.suomienglantisanakirja.fi",
     "t": "ses",
     "u": "https://www.suomienglantisanakirja.fi/{{{s}}}",
@@ -70834,7 +70834,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Seznam.cz Slovník En-Cz",
+    "s": "Seznam Slovník (en-cz)",
     "d": "slovnik.seznam.cz",
     "t": "sezs",
     "u": "https://slovnik.seznam.cz/en-cz/word/?q={{{s}}}",
@@ -70925,7 +70925,7 @@
     "sc": "Programming"
   },
   {
-    "s": "stopforumspam.com",
+    "s": "Stop Forum Spam",
     "d": "www.stopforumspam.com",
     "t": "sfs",
     "u": "https://www.stopforumspam.com/search?q={{{s}}}",
@@ -70949,7 +70949,7 @@
     "sc": "Online"
   },
   {
-    "s": "Sound Effects Search",
+    "s": "Sound Effects",
     "d": "soundeffectssearch.com",
     "t": "sfxsearch",
     "u": "https://soundeffectssearch.com/find-a-sound-library/?library={{{s}}}",
@@ -71004,7 +71004,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Hebcal.com",
+    "s": "Hebcal (Shabbat)",
     "d": "www.hebcal.com",
     "t": "shabbat",
     "u": "https://www.hebcal.com/shabbat/?cfg=json&m=50&b=18&zip={{{s}}}&a=on",
@@ -71012,7 +71012,7 @@
     "sc": "Tools"
   },
   {
-    "s": "shadertoy.com",
+    "s": "Shadertoy",
     "d": "www.shadertoy.com",
     "t": "shadertoy",
     "u": "https://www.shadertoy.com/results?query={{{s}}}",
@@ -71052,7 +71052,7 @@
     "sc": "Forum"
   },
   {
-    "s": "sheetmusicdirect.com",
+    "s": "Sheet Music Direct",
     "d": "www.sheetmusicdirect.com",
     "t": "sheetmusicdirect",
     "ts": [
@@ -71163,7 +71163,7 @@
     "sc": "Academic"
   },
   {
-    "s": "shodan",
+    "s": "Shodan",
     "d": "www.shodan.io",
     "t": "shodan",
     "ts": [
@@ -71174,7 +71174,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Shoop.de",
+    "s": "Shoop",
     "d": "www.shoop.de",
     "t": "shoopde",
     "u": "https://www.shoop.de/suche?q={{{s}}}",
@@ -71233,7 +71233,7 @@
     "sc": "Companies"
   },
   {
-    "s": "ShopTo.net",
+    "s": "ShopTo",
     "d": "www.shopto.net",
     "t": "shopto",
     "u": "https://www.shopto.net/search/newSearchPage?Filter_department=&newsearch={{{s}}}",
@@ -71375,7 +71375,7 @@
     "sc": "Search"
   },
   {
-    "s": "staticICE",
+    "s": "StaticICE",
     "d": "www.staticice.com.au",
     "t": "sice",
     "u": "https://www.staticice.com.au/cgi-bin/search.cgi?q={{{s}}}",
@@ -71431,7 +71431,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Silvergames.com",
+    "s": "Silvergames",
     "d": "www.silvergames.com",
     "t": "silvergames",
     "u": "https://www.silvergames.com/en/s?q={{{s}}}",
@@ -71487,7 +71487,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Simkl Anime",
+    "s": "Simkl (Anime)",
     "d": "simkl.com",
     "t": "simkla",
     "u": "https://simkl.com/search/?type=anime&q={{{s}}}",
@@ -71495,7 +71495,7 @@
     "sc": "TV"
   },
   {
-    "s": "Simkl Lists",
+    "s": "Simkl (Lists)",
     "d": "simkl.com",
     "t": "simkll",
     "u": "https://simkl.com/search/lists/?favorites=false&q={{{s}}}",
@@ -71503,7 +71503,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Simkl Movies",
+    "s": "Simkl (Movies)",
     "d": "simkl.com",
     "t": "simklm",
     "u": "https://simkl.com/search/?type=movies&q={{{s}}}",
@@ -71511,7 +71511,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Simkl TV Shows",
+    "s": "Simkl (TV Shows)",
     "d": "simkl.com",
     "t": "simklt",
     "u": "https://simkl.com/search/?type=tv&q={{{s}}}",
@@ -71527,7 +71527,7 @@
     "sc": "Design"
   },
   {
-    "s": "Simplicité.io",
+    "s": "Simplicité",
     "d": "www.simplicite.io",
     "t": "simplicite",
     "u": "https://www.simplicite.io/resources/search?q={{{s}}}",
@@ -71567,7 +71567,7 @@
     "sc": "TV"
   },
   {
-    "s": "Dicionário de Sinônimos",
+    "s": "Sinônimos",
     "d": "www.sinonimos.com.br",
     "t": "sin",
     "ts": [
@@ -71610,7 +71610,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Sinonimi.it",
+    "s": "Sinonimi",
     "d": "sinonimi.it",
     "t": "sinonimit",
     "u": "https://sinonimi.it/{{{s}}}",
@@ -71634,7 +71634,7 @@
     "sc": "Downloads"
   },
   {
-    "s": "白ごはん.com",
+    "s": "白ごはん",
     "d": "www.sirogohan.com",
     "t": "sirogohan",
     "u": "https://www.sirogohan.com/recipe/index/keyword:{{{s}}}",
@@ -71669,7 +71669,7 @@
     "sc": "Sports"
   },
   {
-    "s": "SITAG - swiss style at work",
+    "s": "SITAG",
     "d": "www.sitag.ch",
     "t": "sitag",
     "u": "https://www.sitag.ch/suchen/?tx_indexedsearch[sword]={{{s}}}",
@@ -71685,7 +71685,7 @@
     "sc": "Programming"
   },
   {
-    "s": "siteslike",
+    "s": "Sites Like",
     "d": "www.siteslike.com",
     "t": "siteslike",
     "u": "https://www.siteslike.com/similar/{{{s}}}",
@@ -71693,7 +71693,7 @@
     "sc": "Search"
   },
   {
-    "s": "schoolido.lu",
+    "s": "Schoolido",
     "d": "schoolido.lu",
     "t": "sit",
     "u": "https://schoolido.lu/cards/?search={{{s}}}&name=&rarity=&attribute=&is_promo=&is_special=&is_event=&skill=&translated_collection=&collection=&main_unit=&sub_unit=&idol_school=&idol_year=&release_after=&release_before=&view=cards&albumbuilder_account=15585&account=&ordering=id&reverse_order=on",
@@ -71741,7 +71741,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Soc Job Rumors (Kagi Search)",
+    "s": "Soc Job Rumors (Kagi)",
     "d": "kagi.com",
     "ad": "socjobrumors.com",
     "t": "sjmr",
@@ -71766,7 +71766,7 @@
     "sc": "Academic"
   },
   {
-    "s": "sitejabber",
+    "s": "SmartCustomer",
     "d": "www.sitejabber.com",
     "t": "sj",
     "u": "https://www.sitejabber.com/search?q={{{s}}}",
@@ -71782,7 +71782,7 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "sportkopf24",
+    "s": "Sportkopf24",
     "d": "www.sportkopf24.de",
     "t": "sk24",
     "u": "https://www.sportkopf24.de/?ActionCall=WebActionArticleSearch&Params[SearchParam]={{{s}}}",
@@ -71814,7 +71814,7 @@
     "sc": "Online"
   },
   {
-    "s": "Skąpiec.pl",
+    "s": "Skąpiec",
     "d": "www.skapiec.pl",
     "t": "skapiec",
     "u": "https://www.skapiec.pl/szukaj/w_calym_serwisie/{{{s}}}",
@@ -71838,7 +71838,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Sanakirja.org en-fi",
+    "s": "Sanakirja (en-fi)",
     "d": "www.sanakirja.org",
     "t": "skenfi",
     "u": "https://www.sanakirja.org/search.php?l=3&l2=17&q={{{s}}}",
@@ -71857,7 +71857,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Skeptic's Dictionary (Kagi Search)",
+    "s": "Skeptic's Dictionary (Kagi)",
     "d": "kagi.com",
     "ad": "skepdic.com",
     "t": "skepdic",
@@ -71949,7 +71949,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Scikit-Learn (Kagi Search)",
+    "s": "Scikit-Learn (Kagi)",
     "d": "kagi.com",
     "ad": "scikit-learn.org/stable/",
     "t": "sklearn",
@@ -71977,7 +71977,7 @@
     "sc": "Audio"
   },
   {
-    "s": "sketchappsources",
+    "s": "Sketch App Sources",
     "d": "www.sketchappsources.com",
     "t": "sktr",
     "u": "https://www.sketchappsources.com/search_{{{s}}}.html",
@@ -72001,7 +72001,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Skyscanner (Kagi Search)",
+    "s": "Skyscanner (Kagi)",
     "d": "kagi.com",
     "ad": "www.skyscanner.net",
     "t": "skyscan",
@@ -72058,7 +72058,7 @@
     "sc": "Search (Real-time)"
   },
   {
-    "s": "SLANG.gr",
+    "s": "SLANG",
     "d": "www.slang.gr",
     "t": "slanggr",
     "u": "https://www.slang.gr/lemmas?q={{{s}}}",
@@ -72086,7 +72086,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "Slate.fr",
+    "s": "Slate (France)",
     "d": "www.slate.fr",
     "t": "slatefr",
     "u": "https://www.slate.fr/search?mot-cle={{{s}}}",
@@ -72193,7 +72193,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Searchlock Images",
+    "s": "SearchLock (Images)",
     "d": "www.searchlock.com",
     "t": "slocki",
     "u": "https://www.searchlock.com/search?tbm=isch&q={{{s}}}",
@@ -72268,7 +72268,7 @@
     "sc": "Music (Lyrics)"
   },
   {
-    "s": "sciencemag",
+    "s": "Science Magazine",
     "d": "science.sciencemag.org",
     "t": "smag",
     "u": "https://science.sciencemag.org/search/{{{s}}}",
@@ -72367,7 +72367,7 @@
     "sc": "Search (Real-time)"
   },
   {
-    "s": "Smogon Dex Sun and Moon",
+    "s": "Smogon (Sun/Moon)",
     "d": "www.smogon.com",
     "t": "smgsm",
     "ts": [
@@ -72378,7 +72378,7 @@
     "sc": "Games (Pokemon)"
   },
   {
-    "s": "SMHI - Swedish Meteorological and Hydrological Institute",
+    "s": "SMHI",
     "d": "www.smhi.se",
     "t": "smhi",
     "u": "https://www.smhi.se/sok?query={{{s}}}",
@@ -72394,7 +72394,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Posteo S/MIME Certificate Search",
+    "s": "Posteo (S/MIME Certificate)",
     "d": "api.posteo.de",
     "t": "smime",
     "u": "https://api.posteo.de/v1/public-keys/{{{s}}}?type=smime",
@@ -72418,7 +72418,7 @@
     "sc": "Academic"
   },
   {
-    "s": "smithsfoodanddrug",
+    "s": "Smith's Food and Drug",
     "d": "www.smithsfoodanddrug.com",
     "t": "smiths",
     "u": "https://www.smithsfoodanddrug.com/search?query={{{s}}}&searchType=natural",
@@ -72434,7 +72434,7 @@
     "sc": "Food"
   },
   {
-    "s": "songmeanings",
+    "s": "SongMeanings",
     "d": "songmeanings.com",
     "t": "smn",
     "ts": [
@@ -72446,7 +72446,7 @@
     "sc": "Music (Lyrics)"
   },
   {
-    "s": "Strategy Pokedex Black and White Smogon",
+    "s": "Smogon (Black/White)",
     "d": "www.smogon.com",
     "t": "smogonbw",
     "u": "https://www.smogon.com/dex/bw/pokemon/{{{s}}}",
@@ -72454,7 +72454,7 @@
     "sc": "Games (Pokemon)"
   },
   {
-    "s": "Strategy Pokedex Diamond Perl Smogon",
+    "s": "Smogon (Diamond/Pearl)",
     "d": "www.smogon.com",
     "t": "smogondp",
     "u": "https://www.smogon.com/dex/dp/pokemon/{{{s}}}",
@@ -72462,7 +72462,7 @@
     "sc": "Games (Pokemon)"
   },
   {
-    "s": "Strategy Pokedex Gold Silver Smogon",
+    "s": "Smogon (Gold/Silver)",
     "d": "www.smogon.com",
     "t": "smogongs",
     "u": "https://www.smogon.com/dex/gs/pokemon/{{{s}}}",
@@ -72470,7 +72470,7 @@
     "sc": "Games (Pokemon)"
   },
   {
-    "s": "Strategy Pokedex Re Blue Smogon",
+    "s": "Smogon (Red/Blue)",
     "d": "www.smogon.com",
     "t": "smogonrb",
     "u": "https://www.smogon.com/dex/rb/pokemon/{{{s}}}",
@@ -72486,7 +72486,7 @@
     "sc": "Games (Pokemon)"
   },
   {
-    "s": "Smogon X/Y strategydex",
+    "s": "Smogon (X/Y)",
     "d": "www.smogon.com",
     "t": "smogonxy",
     "u": "https://www.smogon.com/dex/xy/pokemon/{{{s}}}",
@@ -72494,7 +72494,7 @@
     "sc": "Games (Pokemon)"
   },
   {
-    "s": "Smogon R_S",
+    "s": "Smogon (Ruby/Sapphire)",
     "d": "www.smogon.com",
     "t": "smogrs",
     "u": "https://www.smogon.com/dex/rs/pokemon/{{{s}}}/",
@@ -72518,7 +72518,7 @@
     "sc": "Academic"
   },
   {
-    "s": "swissmilk - Rezepte",
+    "s": "Swissmilk (Rezepte)",
     "d": "www.swissmilk.ch",
     "t": "smre",
     "u": "https://www.swissmilk.ch/de/alle-rezepte/suche/?qt={{{s}}}&cat=Rezept+Suche&qd=1",
@@ -72635,7 +72635,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "StartPage Web Search(Japanese)",
+    "s": "Startpage (Japanese)",
     "d": "www.startpage.com",
     "t": "snih",
     "u": "https://www.startpage.com/do/search?q={{{s}}}&l=nihongo",
@@ -72643,7 +72643,7 @@
     "sc": "Search"
   },
   {
-    "s": "Sinonimi - Contrari",
+    "s": "Sinonimi (Contrari)",
     "d": "www.sinonimi-contrari.it",
     "t": "snit",
     "u": "https://www.sinonimi-contrari.it/{{{s}}}/",
@@ -72667,7 +72667,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Skyrim NexusMods",
+    "s": "Nexus Mods (Skyrim)",
     "d": "www.nexusmods.com",
     "t": "snm",
     "u": "https://www.nexusmods.com/skyrim/search/?gsearch={{{s}}}&gsearchtype=mods",
@@ -72683,7 +72683,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Snogard.de",
+    "s": "Snogard",
     "d": "www.snogard.de",
     "t": "snogard",
     "u": "https://www.snogard.de/suche.html?suchwort={{{s}}}",
@@ -72710,7 +72710,7 @@
     "sc": "Sysadmin (network)"
   },
   {
-    "s": "StartPage.com (Norwegian)",
+    "s": "Startpage (Norwegian)",
     "d": "www.startpage.com",
     "t": "sno",
     "u": "https://www.startpage.com/do/search?cmd=process_search&query={{{s}}}&with_region=countryNO",
@@ -72766,7 +72766,7 @@
     "sc": "Topical"
   },
   {
-    "s": "Stack Overflow Bash Search",
+    "s": "Stack Overflow (Bash)",
     "d": "stackoverflow.com",
     "t": "sobash",
     "u": "https://stackoverflow.com/search?q=[bash]+{{{s}}}",
@@ -72798,7 +72798,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Socialblade",
+    "s": "Social Blade",
     "d": "socialblade.com",
     "t": "socialblade",
     "u": "https://socialblade.com/search/{{{s}}}",
@@ -72806,7 +72806,7 @@
     "sc": "Misc"
   },
   {
-    "s": "societe.com",
+    "s": "Societe.com",
     "d": "www.societe.com",
     "t": "societe",
     "u": "https://www.societe.com/cgi-bin/search?champs={{{s}}}",
@@ -72822,7 +72822,7 @@
     "sc": "Online"
   },
   {
-    "s": "StackOverflow Companies",
+    "s": "Stack Overflow (Companies)",
     "d": "stackoverflow.com",
     "t": "socompanies",
     "u": "https://stackoverflow.com/jobs/companies?q={{{s}}}",
@@ -72846,7 +72846,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "stackoverflow.com",
+    "s": "Stack Overflow (LabWindows)",
     "d": "stackoverflow.com",
     "t": "socvi",
     "u": "https://stackoverflow.com/search?q=[labwindows]+{{{s}}}",
@@ -72854,7 +72854,7 @@
     "sc": "Languages (other)"
   },
   {
-    "s": "Socwall - Social Wallpapering",
+    "s": "Socwall",
     "d": "www.socwall.com",
     "t": "socwall",
     "u": "https://www.socwall.com/wallpapers/search:{{{s}}}",
@@ -72932,7 +72932,7 @@
     "sc": "Search"
   },
   {
-    "s": "Stack Overflow via Google",
+    "s": "Stack Overflow (Google)",
     "d": "www.google.com",
     "t": "sog",
     "u": "https://www.google.com/search?q=site:stackoverflow.com+{{{s}}}",
@@ -72940,7 +72940,7 @@
     "sc": "Programming"
   },
   {
-    "s": "StackOverflow Jobs",
+    "s": "Stack Overflow (Jobs)",
     "d": "stackoverflow.com",
     "t": "sojob",
     "u": "https://stackoverflow.com/jobs?q={{{s}}}",
@@ -72948,7 +72948,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "Stack Overflow JavaScript",
+    "s": "Stack Overflow (JavaScript)",
     "d": "stackoverflow.com",
     "t": "sojs",
     "u": "https://stackoverflow.com/search?q=[javascript]+{{{s}}}",
@@ -72956,7 +72956,7 @@
     "sc": "Languages (javascript)"
   },
   {
-    "s": "Sokr.ru - словарь сокращений",
+    "s": "Sokr.ru",
     "d": "sokr.ru",
     "t": "sokr",
     "u": "https://sokr.ru/{{{s}}}/",
@@ -72972,7 +72972,7 @@
     "sc": "Health"
   },
   {
-    "s": "SOLO journals",
+    "s": "SOLO (Journals)",
     "d": "solo.bodleian.ox.ac.uk",
     "t": "soloj",
     "u": "https://solo.bodleian.ox.ac.uk/primo-explore/search?query=any,contains,{{{s}}}&tab=local&search_scope=LSCOP_ALL&vid=SOLO&facet=rtype,include,journals&lang=en_US&offset=0",
@@ -72996,7 +72996,7 @@
     "sc": "Services"
   },
   {
-    "s": "SOLO: Search Oxford Libraries Online",
+    "s": "SOLO",
     "d": "solo.bodleian.ox.ac.uk",
     "t": "solo",
     "u": "https://solo.bodleian.ox.ac.uk/primo-explore/search?query=any,contains,{{{s}}}&tab=local&search_scope=LSCOP_ALL&vid=SOLO&lang=en_US&offset=0",
@@ -73012,7 +73012,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "someecards",
+    "s": "Someecards",
     "d": "www.someecards.com",
     "t": "some",
     "u": "https://www.someecards.com/search?q={{{s}}}",
@@ -73052,7 +73052,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "DuckDuckGo Safe Search: On",
+    "s": "DuckDuckGo (Safe On)",
     "d": "duckduckgo.com",
     "t": "s-on",
     "ts": [
@@ -73106,7 +73106,7 @@
     "sc": "Music"
   },
   {
-    "s": "Songtexte.com",
+    "s": "Songtexte",
     "d": "www.songtexte.com",
     "t": "songtext",
     "u": "https://www.songtexte.com/search?q={{{s}}}&c=all",
@@ -73165,7 +73165,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Stack Overflow Python",
+    "s": "Stack Overflow (Python)",
     "d": "stackoverflow.com",
     "t": "sopy",
     "u": "https://stackoverflow.com/search?q=[python]+{{{s}}}",
@@ -73229,7 +73229,7 @@
     "sc": "Audio"
   },
   {
-    "s": "soundonsound.com",
+    "s": "Sound on Sound",
     "d": "www.soundonsound.com",
     "t": "soundonsound",
     "u": "https://www.soundonsound.com/search/all/{{{s}}}",
@@ -73288,7 +73288,7 @@
     "sc": "TV"
   },
   {
-    "s": "Stack Overflow MS Excel Search",
+    "s": "Stack Overflow (Excel)",
     "d": "stackoverflow.com",
     "t": "soxl",
     "u": "https://stackoverflow.com/search?q=[excel]+{{{s}}}",
@@ -73395,7 +73395,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "Speedrun.com",
+    "s": "Speedrun",
     "d": "speedrun.com",
     "t": "speedrun",
     "u": "https://speedrun.com/{{{s}}}",
@@ -73403,7 +73403,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "SpeedSolving Forum",
+    "s": "SpeedSolving (Forum)",
     "d": "www.speedsolving.com",
     "t": "speedsolving",
     "u": "https://www.speedsolving.com/forum/searchresults.php?q={{{s}}}",
@@ -73411,7 +73411,7 @@
     "sc": "Forum"
   },
   {
-    "s": "Speedsolving wiki",
+    "s": "Speedsolving (Wiki)",
     "d": "www.speedsolving.com",
     "t": "speedsolvingwiki",
     "ts": [
@@ -73430,7 +73430,7 @@
     "sc": "Online"
   },
   {
-    "s": "Spektrum Akademischer Verlag - Lexikon der Biologie",
+    "s": "Spektrum Akademischer Verlag (Lexikon der Biologie)",
     "d": "www.spektrum.de",
     "t": "spekbio",
     "u": "https://www.spektrum.de/lexikon/biologie/?q={{{s}}}",
@@ -73438,7 +73438,7 @@
     "sc": "Academic (biology)"
   },
   {
-    "s": "Spektrum",
+    "s": "Spektrum (Lexikon der Geographie)",
     "d": "www.spektrum.de",
     "t": "spekgeo",
     "u": "https://www.spektrum.de/lexikon/geographie/?q={{{s}}}",
@@ -73446,7 +73446,7 @@
     "sc": "Academic"
   },
   {
-    "s": "spele.nl",
+    "s": "Spele.nl",
     "d": "spele.nl",
     "t": "spele",
     "u": "https://spele.nl/zoeken/?q={{{s}}}",
@@ -73481,7 +73481,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "MXToolbox",
+    "s": "MXToolbox (SPF Lookup)",
     "d": "mxtoolbox.com",
     "t": "spf",
     "u": "https://mxtoolbox.com/SuperTool.aspx?action=spf:{{{s}}}&run=toolpage",
@@ -73489,7 +73489,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Speed Guide",
+    "s": "SpeedGuide",
     "d": "www.speedguide.net",
     "t": "spg",
     "u": "https://www.speedguide.net/search_rez.php?seek={{{s}}}&words=yes",
@@ -73521,7 +73521,7 @@
     "sc": "Images"
   },
   {
-    "s": "www.spiegel.de",
+    "s": "Spiegel",
     "d": "www.spiegel.de",
     "t": "spiegel",
     "ts": [
@@ -73567,7 +73567,7 @@
     "sc": "Audio"
   },
   {
-    "s": "Spin.de",
+    "s": "Spin",
     "d": "www.spin.de",
     "t": "spin",
     "u": "https://www.spin.de/search?q={{{s}}}",
@@ -73575,7 +73575,7 @@
     "sc": "Social (intl)"
   },
   {
-    "s": "SPIP (Kagi Search)",
+    "s": "SPIP (Kagi)",
     "d": "kagi.com",
     "ad": "spip.net",
     "t": "spip",
@@ -73655,7 +73655,7 @@
     "sc": "Companies"
   },
   {
-    "s": "splunk",
+    "s": "Splunk",
     "d": "www.splunk.com",
     "t": "splunk",
     "u": "https://www.splunk.com/en_us/search.html?query={{{s}}}",
@@ -73679,7 +73679,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "SpongeBob Wikia",
+    "s": "SpongeBob SquarePants (Wiki)",
     "d": "spongebob.wikia.com",
     "t": "spongebob",
     "u": "https://spongebob.wikia.com/wiki/Special:Search?search={{{s}}}&fulltext=Search",
@@ -73695,7 +73695,7 @@
     "sc": "Reference (fun)"
   },
   {
-    "s": "spoonacular",
+    "s": "Spoonacular",
     "d": "spoonacular.com",
     "t": "spoonacular",
     "u": "https://spoonacular.com/{{{s}}}",
@@ -73748,7 +73748,7 @@
     "sc": "Search (Private)"
   },
   {
-    "s": "Startpage (PL)",
+    "s": "Startpage (Polish)",
     "d": "www.startpage.com",
     "t": "sppl",
     "u": "https://www.startpage.com/do/dsearch?query={{{s}}}&cat=web&pl=opensearch&language=polski",
@@ -73853,7 +73853,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Startpage Videos",
+    "s": "Startpage (Videos)",
     "d": "www.startpage.com",
     "t": "spv",
     "u": "https://www.startpage.com/do/search?cat=video&cmd=process_search&query={{{s}}}",
@@ -73941,7 +73941,7 @@
     "sc": "Government"
   },
   {
-    "s": "admin.ch - Systematische Rechtssammlung",
+    "s": "admin.ch (Systematische Rechtssammlung)",
     "d": "www.admin.ch",
     "t": "srch",
     "u": "https://www.admin.ch/opc/search/?lang=de&language[]=de&product[]=fg&product[]=oc&product[]=cc&product[]=ba&product[]=jcd&date_range_min=&date_range_max=&d_compilation=both&d_is_in_force=yes&text={{{s}}}",
@@ -73989,7 +73989,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Google Translate (srhu)",
+    "s": "Google Translate (sr-hu)",
     "d": "translate.google.com",
     "t": "srhu",
     "u": "https://translate.google.com/#sr/hu/{{{s}}}",
@@ -73997,7 +73997,7 @@
     "sc": "Google"
   },
   {
-    "s": "SteamRep (by ID)",
+    "s": "SteamRep (ID)",
     "d": "steamrep.com",
     "t": "sri",
     "u": "https://steamrep.com/id/{{{s}}}",
@@ -74016,7 +74016,7 @@
     "sc": "Social news/links"
   },
   {
-    "s": "Subreddit sorted top/ all time",
+    "s": "Reddit (Top)",
     "d": "www.reddit.com",
     "t": "srtop",
     "u": "https://www.reddit.com/r/{{{s}}}/top/?sort=top&t=all",
@@ -74032,7 +74032,7 @@
     "sc": "International"
   },
   {
-    "s": "SS64 (Kagi Search)",
+    "s": "SS64 (Kagi)",
     "d": "kagi.com",
     "ad": "www.ss64.com",
     "t": "ss64",
@@ -74049,7 +74049,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Statistisk Sentralby - Statistics Norway",
+    "s": "Statistics Norway",
     "d": "www.ssb.no",
     "t": "ssbno",
     "u": "https://www.ssb.no/sok?sok={{{s}}}",
@@ -74177,7 +74177,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Shutterstock Vector",
+    "s": "Shutterstock (Vector)",
     "d": "www.shutterstock.com",
     "t": "ssv",
     "u": "https://www.shutterstock.com/search?searchterm={{{s}}}&image_type=vector",
@@ -74261,7 +74261,7 @@
     "sc": "Big box/department"
   },
   {
-    "s": "Staples.com",
+    "s": "Staples",
     "d": "www.staples.com",
     "t": "staples",
     "u": "https://www.staples.com/search?query={{{s}}}",
@@ -74459,7 +74459,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "twitch tab bot",
+    "s": "Tab Bot",
     "d": "tab-bot.net",
     "t": "steam2twitch",
     "ts": [
@@ -74478,7 +74478,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Steam Community",
+    "s": "Steam (Community)",
     "d": "steamcommunity.com",
     "t": "steamcommunity",
     "ts": [
@@ -74506,7 +74506,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Steam Greenlight",
+    "s": "Steam (Greenlight)",
     "d": "steamcommunity.com",
     "t": "steamgl",
     "u": "https://steamcommunity.com/workshop/browse/?appid=765&searchtext={{{s}}}",
@@ -74514,7 +74514,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Steam app ID",
+    "s": "Steam (App)",
     "d": "store.steampowered.com",
     "t": "steamid",
     "u": "https://store.steampowered.com/app/{{{s}}}/",
@@ -74522,7 +74522,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "steamid.io",
+    "s": "SteamID.io",
     "d": "steamid.io",
     "t": "steamio",
     "u": "https://steamid.io/lookup/{{{s}}}",
@@ -74530,7 +74530,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Steam Key Redemption",
+    "s": "Steam (Redeem Key)",
     "d": "store.steampowered.com",
     "t": "steamkey",
     "ts": [
@@ -74541,7 +74541,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Steam Community Market",
+    "s": "Steam (Market)",
     "d": "steamcommunity.com",
     "t": "steammarket",
     "u": "https://steamcommunity.com/market/search?q={{{s}}}",
@@ -74609,7 +74609,7 @@
     "sc": "General"
   },
   {
-    "s": "Steigan.no",
+    "s": "Steigan",
     "d": "steigan.no",
     "t": "steigan",
     "u": "https://steigan.no/?s={{{s}}}",
@@ -74681,7 +74681,7 @@
     "sc": "Topical"
   },
   {
-    "s": "stixoi.info",
+    "s": "Stixoi",
     "d": "www.stixoi.info",
     "t": "stixoi",
     "u": "https://www.stixoi.info/stixoi.php?info=SS&keywords={{{s}}}&act=ss",
@@ -74737,7 +74737,7 @@
     "sc": "International"
   },
   {
-    "s": "storybank",
+    "s": "StoryBank",
     "d": "storybank.id",
     "t": "storybank",
     "u": "https://storybank.id/?s={{{s}}}",
@@ -74777,7 +74777,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "TriTrans",
+    "s": "TriTrans (es-no)",
     "d": "www.tritrans.net",
     "t": "strans",
     "u": "https://www.tritrans.net/cgibin/translate.cgi?spraak=Spansk&Fra={{{s}}}",
@@ -74841,7 +74841,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "Strong's Exhaustive Concordance",
+    "s": "Bible Study Tools (Strong's Concordance)",
     "d": "www.biblestudytools.com",
     "t": "strongs",
     "u": "https://www.biblestudytools.com/search/?q={{{s}}}&t=kjv&s=Bibles",
@@ -74849,7 +74849,7 @@
     "sc": "Reference (religion)"
   },
   {
-    "s": "StrumentiMusicali.net",
+    "s": "StrumentiMusicali",
     "d": "www.strumentimusicali.net",
     "t": "strumenti",
     "u": "https://www.strumentimusicali.net/advanced_search_result.php?manufacturers_id=&keywords={{{s}}}&inc_subcat=1",
@@ -74865,7 +74865,7 @@
     "sc": "Tools"
   },
   {
-    "s": "st-takla.org",
+    "s": "St-Takla.org",
     "d": "st-takla.org",
     "t": "sts",
     "u": "https://st-takla.org/Coptic-Search-St-Takla.org/site_search.php?q={{{s}}}&op=and",
@@ -74873,7 +74873,7 @@
     "sc": "Reference (religion)"
   },
   {
-    "s": "stocktwits",
+    "s": "StockTwits",
     "d": "stocktwits.com",
     "t": "st",
     "u": "https://stocktwits.com/search?q={{{s}}}",
@@ -74940,7 +74940,7 @@
     "sc": "Reference (religion)"
   },
   {
-    "s": "stuff.co.nz",
+    "s": "Stuff",
     "d": "www.stuff.co.nz",
     "t": "stuffnz",
     "u": "https://www.stuff.co.nz/searchresults?q={{{s}}}",
@@ -74992,7 +74992,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Subeen.com",
+    "s": "Subeen",
     "d": "subeen.com",
     "t": "subeen",
     "u": "https://subeen.com/?s={{{s}}}",
@@ -75008,7 +75008,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Subito.it",
+    "s": "Subito",
     "d": "www.subito.it",
     "t": "subito",
     "u": "https://www.subito.it/annunci-italia/vendita/usato/?q={{{s}}}",
@@ -75064,7 +75064,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Subnet Calculator - TunnelsUp",
+    "s": "TunnelsUp (Subnet Calculator)",
     "d": "www.tunnelsup.com",
     "t": "subnet",
     "u": "https://www.tunnelsup.com/subnet-calculator?ip={{{s}}}",
@@ -75080,7 +75080,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Suconlavite.it",
+    "s": "Suconlavite",
     "d": "www.suconlavite.it",
     "t": "suconlavite",
     "u": "https://www.suconlavite.it/?s={{{s}}}",
@@ -75104,7 +75104,7 @@
     "sc": "Academic"
   },
   {
-    "s": "sudomod",
+    "s": "SudoMod",
     "d": "sudomod.com",
     "t": "sudomod",
     "u": "https://sudomod.com/?s={{{s}}}",
@@ -75152,7 +75152,7 @@
     "sc": "Government"
   },
   {
-    "s": "Dictionary of Ukrainian Language (Словник української мови)",
+    "s": "Словник української мови",
     "d": "sum.in.ua",
     "t": "dict-ua",
     "u": "https://sum.in.ua/?swrd={{{s}}}",
@@ -75319,7 +75319,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "www.suttacentral.net",
+    "s": "SuttaCentral",
     "d": "suttacentral.net",
     "t": "suttac",
     "u": "https://suttacentral.net/search?query={{{s}}}",
@@ -75351,7 +75351,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Google Translate",
+    "s": "Google Translate (sv-de)",
     "d": "translate.google.com",
     "t": "svde",
     "u": "https://translate.google.com/#sv/de/{{{s}}}",
@@ -75367,7 +75367,7 @@
     "sc": "Newspaper (intl)"
   },
   {
-    "s": "Google Translate (Swedish to English)",
+    "s": "Google Translate (sv-en)",
     "d": "translate.google.com",
     "t": "sven",
     "u": "https://translate.google.com/#sv/en/{{{s}}}",
@@ -75375,7 +75375,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Mozilla Developer Network",
+    "s": "MDN Web Docs (SVG)",
     "d": "developer.mozilla.org",
     "t": "svg",
     "u": "https://developer.mozilla.org/en-US/search?q={{{s}}}&topic=svg",
@@ -75391,7 +75391,7 @@
     "sc": "Images"
   },
   {
-    "s": "svgl",
+    "s": "SVGL",
     "d": "svgl.app",
     "t": "svgl",
     "u": "https://svgl.app/?search={{{s}}}",
@@ -75407,7 +75407,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Google Translate - Swedish to Portoguese",
+    "s": "Google Translate (sv-pt)",
     "d": "translate.google.se",
     "t": "svpt",
     "u": "https://translate.google.se/#sv/pt/{{{s}}}",
@@ -75453,7 +75453,7 @@
     "sc": "Video"
   },
   {
-    "s": "Stardew Valley Wiki Español",
+    "s": "Stardew Valley Wiki (Español)",
     "d": "es.stardewvalleywiki.com",
     "t": "svwe",
     "u": "https://es.stardewvalleywiki.com/{{{s}}}",
@@ -75550,7 +75550,7 @@
     "sc": "Programming"
   },
   {
-    "s": "swissbib",
+    "s": "Swissbib",
     "d": "www.swissbib.ch",
     "t": "swissbib",
     "u": "https://www.swissbib.ch/Search/Results?lookfor={{{s}}}&type=AllFields",
@@ -75604,7 +75604,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Sweet Search",
+    "s": "SweetSearch",
     "d": "www.sweetsearch.com",
     "t": "swtsearch",
     "u": "https://www.sweetsearch.com/search?q={{{s}}}",
@@ -75680,7 +75680,7 @@
     "sc": "Health"
   },
   {
-    "s": "Sync.me",
+    "s": "Sync",
     "d": "sync.me",
     "t": "syncme",
     "u": "https://sync.me/search/?number={{{s}}}",
@@ -75723,7 +75723,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Synonymo.fr",
+    "s": "Synonymo",
     "d": "www.synonymo.fr",
     "t": "syno",
     "u": "https://www.synonymo.fr/syno/{{{s}}}",
@@ -75731,7 +75731,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Synonimy.pl",
+    "s": "Synonimy",
     "d": "www.synonimy.pl",
     "t": "synpl",
     "u": "https://www.synonimy.pl/synonim/{{{s}}}",
@@ -75739,7 +75739,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Systranet English-French",
+    "s": "Systranet (en-fr)",
     "d": "www.systranet.com",
     "t": "sysef",
     "u": "https://www.systranet.com/fr/fr/dictionary/english-french/{{{s}}}?",
@@ -75747,7 +75747,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Systranet English-Swedish",
+    "s": "Systranet (en-sv)",
     "d": "www.systranet.com",
     "t": "sysensw",
     "u": "https://www.systranet.com/fr/fr/dictionary/english-swedish/{{{s}}}?",
@@ -75755,7 +75755,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Systranet French-English",
+    "s": "Systranet (fr-en)",
     "d": "www.systranet.com",
     "t": "sysfe",
     "u": "https://www.systranet.com/fr/fr/dictionary/french-english/{{{s}}}?",
@@ -75779,7 +75779,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Systranet Swedish-English",
+    "s": "Systranet (sv-en)",
     "d": "www.systranet.com",
     "t": "sysswen",
     "u": "https://www.systranet.com/fr/fr/dictionary/swedish-english/{{{s}}}?",
@@ -75806,7 +75806,7 @@
     "sc": "Tools"
   },
   {
-    "s": "slovnik.seznam.cz němčina",
+    "s": "Seznam Slovník (de)",
     "d": "slovnik.seznam.cz",
     "t": "sznsde",
     "u": "https://slovnik.seznam.cz/de/?q={{{s}}}",
@@ -75814,7 +75814,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Seznam.cz slovník Fr-Cz",
+    "s": "Seznam Slovník (fr-cz)",
     "d": "slovnik.seznam.cz",
     "t": "sznsfr",
     "u": "https://slovnik.seznam.cz/fr-cz/?q={{{s}}}",
@@ -75838,7 +75838,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Seznam Zprávy",
+    "s": "Seznam (Zprávy)",
     "d": "www.seznam.cz",
     "t": "szpravy",
     "u": "https://www.seznam.cz/zpravy/hledani?q={{{s}}}&search--active=1",
@@ -75878,7 +75878,7 @@
     "sc": "Specialty"
   },
   {
-    "s": "Taaladvies.net",
+    "s": "Taaladvies",
     "d": "taaladvies.net",
     "t": "taaladvies",
     "ts": [
@@ -75889,7 +75889,7 @@
     "sc": "Tools"
   },
   {
-    "s": "tab4u",
+    "s": "Tab4U",
     "d": "www.tab4u.com",
     "t": "tab4u",
     "u": "https://www.tab4u.com/resultsSimple?tab=songs&type=song&q={{{s}}}",
@@ -75929,7 +75929,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Ultimate Guitar (band)",
+    "s": "Ultimate Guitar (Band)",
     "d": "www.ultimate-guitar.com",
     "t": "tabsb",
     "u": "https://www.ultimate-guitar.com/search.php?search_type=band&value={{{s}}}",
@@ -76004,7 +76004,7 @@
     "sc": "Tools"
   },
   {
-    "s": "taginfo Switzerland",
+    "s": "Taginfo (Switzerland)",
     "d": "taginfo.openstreetmap.ch",
     "t": "taginfoch",
     "u": "https://taginfo.openstreetmap.ch/search?q={{{s}}}",
@@ -76020,7 +76020,7 @@
     "sc": "Search"
   },
   {
-    "s": "tagesanzeiger",
+    "s": "Tagesanzeiger",
     "d": "www.tagesanzeiger.ch",
     "t": "tagi",
     "u": "https://www.tagesanzeiger.ch/service/suche/suche.html?date=alle&order=date&key={{{s}}}",
@@ -76044,7 +76044,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Tails - The Amnesic Incognito Live System",
+    "s": "Tails (The Amnesic Incognito Live System)",
     "d": "tails.boum.org",
     "t": "tails",
     "u": "https://tails.boum.org/ikiwiki.cgi?P={{{s}}}",
@@ -76052,7 +76052,7 @@
     "sc": "Sysadmin (debian)"
   },
   {
-    "s": "Tripadvisor.in",
+    "s": "Tripadvisor (India)",
     "d": "www.tripadvisor.in",
     "t": "tain",
     "u": "https://www.tripadvisor.in/Search?q={{{s}}}",
@@ -76060,7 +76060,7 @@
     "sc": "Social"
   },
   {
-    "s": "Tripadvisor.it",
+    "s": "TripAdvisor (Italy)",
     "d": "www.tripadvisor.it",
     "t": "tait",
     "u": "https://www.tripadvisor.it/Search?q={{{s}}}",
@@ -76068,7 +76068,7 @@
     "sc": "Travel"
   },
   {
-    "s": "takealot.com",
+    "s": "Takealot",
     "d": "www.takealot.com",
     "t": "takealot",
     "u": "https://www.takealot.com/all/?qsearch={{{s}}}",
@@ -76087,7 +76087,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Talaios.net",
+    "s": "Talaios",
     "d": "talaios.net",
     "t": "talaios",
     "u": "https://talaios.net/?s={{{s}}}",
@@ -76111,7 +76111,7 @@
     "sc": "Design"
   },
   {
-    "s": "Talky.io",
+    "s": "Talky",
     "d": "talky.io",
     "t": "talky",
     "u": "https://talky.io/{{{s}}}",
@@ -76138,7 +76138,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "tanishq",
+    "s": "Tanishq",
     "d": "www.tanishq.co.in",
     "t": "tanishq",
     "u": "https://www.tanishq.co.in/search-result/{{{s}}}",
@@ -76154,7 +76154,7 @@
     "sc": "Learning (intl)"
   },
   {
-    "s": "Tanuki.pl",
+    "s": "Tanuki",
     "d": "tanuki.pl",
     "t": "tanuki",
     "u": "https://tanuki.pl/szukaj/{{{s}}}",
@@ -76210,7 +76210,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Tappedout.net",
+    "s": "Tapped Out",
     "d": "tappedout.net",
     "t": "tap",
     "u": "https://tappedout.net/search/?q={{{s}}}",
@@ -76218,7 +76218,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Tapwage.com",
+    "s": "Tapwage",
     "d": "tapwage.com",
     "t": "tapwage",
     "u": "https://tapwage.com/search?q={{{s}}}",
@@ -76299,7 +76299,7 @@
     "sc": "Food"
   },
   {
-    "s": "Taste.com.au",
+    "s": "Taste (Australia)",
     "d": "www.taste.com.au",
     "t": "taste",
     "u": "https://www.taste.com.au/search-recipes/?q={{{s}}}",
@@ -76319,7 +76319,7 @@
     "sc": "Learning"
   },
   {
-    "s": "tripadvisor",
+    "s": "TripAdvisor",
     "d": "www.tripadvisor.com",
     "t": "ta",
     "u": "https://www.tripadvisor.com/Search?q={{{s}}}",
@@ -76343,7 +76343,7 @@
     "sc": "Online"
   },
   {
-    "s": "Taxi.it",
+    "s": "Taxi",
     "d": "www.taxi.it",
     "t": "taxi",
     "u": "https://www.taxi.it/?s={{{s}}}",
@@ -76359,7 +76359,7 @@
     "sc": "Online"
   },
   {
-    "s": "taz.die tageszeitung",
+    "s": "taz",
     "d": "www.taz.de",
     "t": "taz",
     "u": "https://www.taz.de/!s={{{s}}}/",
@@ -76402,7 +76402,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Tesberichte.de",
+    "s": "Testberichte",
     "d": "www.testberichte.de",
     "t": "tbde",
     "u": "https://www.testberichte.de/d/search.php?searchstr={{{s}}}",
@@ -76421,7 +76421,7 @@
     "sc": "Online"
   },
   {
-    "s": "Treccani Biografie",
+    "s": "Treccani (Biografie)",
     "d": "www.treccani.it",
     "t": "tbio",
     "u": "https://www.treccani.it/biografie/?q={{{s}}}",
@@ -76437,7 +76437,7 @@
     "sc": "TV"
   },
   {
-    "s": "OLX.co.id (Tokobagus)",
+    "s": "OLX (Indonesia)",
     "d": "www.olx.co.id",
     "t": "tb",
     "ts": [
@@ -76523,7 +76523,7 @@
     "sc": "Languages (other)"
   },
   {
-    "s": "TedCurran.net",
+    "s": "TedCurran",
     "d": "tedcurran.net",
     "t": "tcnet",
     "u": "https://tedcurran.net/?s={{{s}}}",
@@ -76539,7 +76539,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "todocoleccion",
+    "s": "TodoColeccion",
     "d": "www.todocoleccion.net",
     "t": "tcol",
     "u": "https://www.todocoleccion.net/buscador?bu={{{s}}}",
@@ -76582,7 +76582,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "thecubicle.us",
+    "s": "The Cubicle",
     "d": "thecubicle.us",
     "t": "tcu",
     "u": "https://thecubicle.us/advanced_search_result.php?search_in_description=0&keywords={{{s}}}",
@@ -76641,7 +76641,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "tdnotes",
+    "s": "TD Structured Notes",
     "d": "www.tdstructurednotes.com",
     "t": "tdnotes",
     "u": "https://www.tdstructurednotes.com/snp/searchByKeyword.action?criteria.keyword={{{s}}}",
@@ -76649,7 +76649,7 @@
     "sc": "Business"
   },
   {
-    "s": "TimeAndDate",
+    "s": "timeanddate.com",
     "d": "www.timeanddate.com",
     "t": "td",
     "u": "https://www.timeanddate.com/search/results.html?query={{{s}}}",
@@ -76676,7 +76676,7 @@
     "sc": "Forum"
   },
   {
-    "s": "TeamSnap (Kagi Search)",
+    "s": "TeamSnap (Kagi)",
     "d": "kagi.com",
     "ad": "teamsnap.com",
     "t": "teamsnap",
@@ -76725,7 +76725,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Microsoft TechNet Library",
+    "s": "Microsoft TechNet (Library)",
     "d": "social.technet.microsoft.com",
     "t": "technetlib",
     "u": "https://social.technet.microsoft.com/search/en-us/?query={{{s}}}#refinementChanges=85",
@@ -76813,7 +76813,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "tech-wd.com",
+    "s": "Tech-WD",
     "d": "www.tech-wd.com",
     "t": "tech-wd",
     "u": "https://www.tech-wd.com/wd/?s={{{s}}}",
@@ -76955,7 +76955,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Search.ch Phonebook (Switzerland)",
+    "s": "tel.search.ch (Switzerland)",
     "d": "tel.search.ch",
     "t": "telch",
     "u": "https://tel.search.ch/?q={{{s}}}",
@@ -77019,7 +77019,7 @@
     "sc": "Broadcast"
   },
   {
-    "s": "Telkku.com",
+    "s": "Telkku",
     "d": "www.telkku.com",
     "t": "telkku",
     "u": "https://www.telkku.com/search?searchText={{{s}}}",
@@ -77027,7 +77027,7 @@
     "sc": "TV"
   },
   {
-    "s": "Schweizer Telefonbuch tel.search.ch",
+    "s": "tel.search.ch",
     "d": "tel.search.ch",
     "t": "telsearch",
     "u": "https://tel.search.ch/{{{s}}}",
@@ -77043,7 +77043,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Telsu.fi",
+    "s": "Telsu",
     "d": "www.telsu.fi",
     "t": "telsu",
     "u": "https://www.telsu.fi/{{{s}}}",
@@ -77083,7 +77083,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Treccani Enciclopedia",
+    "s": "Treccani (Enciclopedia)",
     "d": "www.treccani.it",
     "t": "tenc",
     "ts": [
@@ -77113,7 +77113,7 @@
     "sc": "Weather"
   },
   {
-    "s": "tenor",
+    "s": "Tenor",
     "d": "tenor.com",
     "t": "tenor",
     "u": "https://tenor.com/search/{{{s}}}",
@@ -77149,7 +77149,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "teratail",
+    "s": "Teratail",
     "d": "teratail.com",
     "t": "terat",
     "u": "https://teratail.com/questions/search?q={{{s}}}&conditions=and",
@@ -77181,7 +77181,7 @@
     "sc": "Tools"
   },
   {
-    "s": "BrettTerpstra.com",
+    "s": "Brett Terpstra",
     "d": "brettterpstra.com",
     "t": "terp",
     "u": "https://brettterpstra.com/search/?q={{{s}}}",
@@ -77237,7 +77237,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Testberichte.de",
+    "s": "Testberichte (Search)",
     "d": "www.testberichte.de",
     "t": "testberichte",
     "u": "https://www.testberichte.de/d/search.php?searchstr={{{s}}}&submit=Suchen",
@@ -77253,7 +77253,7 @@
     "sc": "Blogs (intl)"
   },
   {
-    "s": "The Elder Scrolls WIki",
+    "s": "The Elder Scrolls Wiki",
     "d": "elderscrolls.wikia.com",
     "t": "teswiki",
     "u": "https://elderscrolls.wikia.com/wiki/Special:Search?search={{{s}}}",
@@ -77277,7 +77277,7 @@
     "sc": "Languages (latex)"
   },
   {
-    "s": "tex.stackexchange",
+    "s": "TeX Stack Exchange",
     "d": "tex.stackexchange.com",
     "t": "texse",
     "ts": [
@@ -77312,7 +77312,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Team Fortress 2 subreddit",
+    "s": "Reddit (/r/tf2)",
     "d": "www.reddit.com",
     "t": "tf2r",
     "u": "https://www.reddit.com/r/tf2/search?q={{{s}}}&restrict_sr=on",
@@ -77471,7 +77471,7 @@
     "sc": "Reference (fun)"
   },
   {
-    "s": "Tangorin Japanese Dictionary",
+    "s": "Tangorin (General)",
     "d": "tangorin.com",
     "t": "tgr",
     "u": "https://tangorin.com/general/{{{s}}}",
@@ -77495,7 +77495,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Thalia.de",
+    "s": "Thalia",
     "d": "www.thalia.de",
     "t": "thalia",
     "u": "https://www.thalia.de/suche?sq={{{s}}}",
@@ -77575,7 +77575,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Reddit r/the_donald",
+    "s": "Reddit (/r/the_donald)",
     "d": "www.reddit.com",
     "t": "thedonald",
     "u": "https://www.reddit.com/r/the_donald/search?q={{{s}}}&restrict_sr=on&sort=relevance&t=all",
@@ -77663,7 +77663,7 @@
     "sc": "Social"
   },
   {
-    "s": "TheMovieDB.org",
+    "s": "TMDB",
     "d": "www.themoviedb.org",
     "t": "themoviedb",
     "ts": [
@@ -77674,7 +77674,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Google Translate (TH-EN)",
+    "s": "Google Translate (th-en)",
     "d": "translate.google.com",
     "t": "then",
     "u": "https://translate.google.com/#th/en/{{{s}}}",
@@ -77706,7 +77706,7 @@
     "sc": "Academic"
   },
   {
-    "s": "TEL - Thèses en ligne",
+    "s": "TEL (Thèses en ligne)",
     "d": "tel.archives-ouvertes.fr",
     "t": "thesetel",
     "u": "https://tel.archives-ouvertes.fr/search/index/?q={{{s}}}",
@@ -77859,7 +77859,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Thomann en Español",
+    "s": "Thomann (Spanish)",
     "d": "www.thomann.de",
     "t": "thme",
     "u": "https://www.thomann.de/es/search_dir.html?sw={{{s}}}&smcs=80cfba",
@@ -77867,7 +77867,7 @@
     "sc": "Online"
   },
   {
-    "s": "thomann.de",
+    "s": "Thomann",
     "d": "www.thomann.de",
     "t": "thm",
     "ts": [
@@ -77929,7 +77929,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Thousand-Sunny.org",
+    "s": "Thousand Sunny",
     "d": "www.thousand-sunny.org",
     "t": "thousand",
     "u": "https://www.thousand-sunny.org/?s={{{s}}}",
@@ -78001,7 +78001,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Touhouwiki (English)",
+    "s": "Touhou Wiki (English)",
     "d": "en.touhouwiki.net",
     "t": "thwiki",
     "ts": [
@@ -78167,7 +78167,7 @@
     "sc": "Aggregators"
   },
   {
-    "s": "DuckDuckGo Timer",
+    "s": "DuckDuckGo (Timer)",
     "d": "duckduckgo.com",
     "t": "ddg-tim",
     "ts": [
@@ -78212,7 +78212,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Time and Date (time zone)",
+    "s": "Time and Date (Time Zone)",
     "d": "www.timeanddate.com",
     "t": "timezone",
     "u": "https://www.timeanddate.com/time/zones/{{{s}}}",
@@ -78228,7 +78228,7 @@
     "sc": "Companies"
   },
   {
-    "s": "tindie",
+    "s": "Tindie",
     "d": "www.tindie.com",
     "t": "tindie",
     "u": "https://www.tindie.com/search/?q={{{s}}}",
@@ -78316,7 +78316,7 @@
     "sc": "Business"
   },
   {
-    "s": "tipeee",
+    "s": "Tipeee",
     "d": "www.tipeee.com",
     "t": "tip",
     "u": "https://www.tipeee.com/creators?search={{{s}}}",
@@ -78332,7 +78332,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "tiss.tuwien.ac.at",
+    "s": "TISS",
     "d": "tiss.tuwien.ac.at",
     "t": "tiss",
     "u": "https://tiss.tuwien.ac.at/adressbuch/adressbuch/suche?suchtext={{{s}}}",
@@ -78391,7 +78391,7 @@
     "sc": "Music"
   },
   {
-    "s": "Trakt IMDb",
+    "s": "Trakt (IMDb)",
     "d": "trakt.tv",
     "t": "tki",
     "u": "https://trakt.tv/search/imdb?query={{{s}}}",
@@ -78399,7 +78399,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Tradukka Google Translate (to spanish)",
+    "s": "Tradukka (auto-es)",
     "d": "tradukka.com",
     "t": "tkk2es",
     "u": "https://tradukka.com/translate/es/{{{s}}}",
@@ -78407,7 +78407,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "tkkrlab",
+    "s": "TkkrLab",
     "d": "tkkrlab.nl",
     "t": "tkkrlab",
     "u": "https://tkkrlab.nl/wiki/Special:Search?search={{{s}}}&go=Go",
@@ -78415,7 +78415,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Tradukka Google Translate (to English)",
+    "s": "Tradukka (auto-en)",
     "d": "tradukka.com",
     "t": "tkk",
     "u": "https://tradukka.com/translate/en/{{{s}}}",
@@ -78423,7 +78423,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Trakt Movies",
+    "s": "Trakt (Movies)",
     "d": "trakt.tv",
     "t": "tkm",
     "u": "https://trakt.tv/search/movies?q={{{s}}}",
@@ -78443,7 +78443,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Trakt Shows",
+    "s": "Trakt (Shows)",
     "d": "trakt.tv",
     "t": "tks",
     "u": "https://trakt.tv/search/shows?q={{{s}}}",
@@ -78562,7 +78562,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Team Liquid Wiki",
+    "s": "Liquipedia (StarCraft 2)",
     "d": "wiki.teamliquid.net",
     "t": "tlw",
     "u": "https://wiki.teamliquid.net/starcraft2/index.php?title=Special:Search&search={{{s}}}",
@@ -78570,7 +78570,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "天猫",
+    "s": "Tmall",
     "d": "list.tmall.com",
     "t": "tmall",
     "u": "https://list.tmall.com/search_product.htm?q={{{s}}}",
@@ -78594,7 +78594,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Justia.com trademarks",
+    "s": "Justia (Trademarks)",
     "d": "trademarks.justia.com",
     "t": "tmark",
     "u": "https://trademarks.justia.com/search.php?q={{{s}}}",
@@ -78618,7 +78618,7 @@
     "sc": "Music"
   },
   {
-    "s": "Transfermarkt.com",
+    "s": "Transfermarkt (.com)",
     "d": "www.transfermarkt.com",
     "t": "tmen",
     "u": "https://www.transfermarkt.com/schnellsuche/ergebnis/schnellsuche?query={{{s}}}",
@@ -78685,7 +78685,7 @@
     "sc": "Music"
   },
   {
-    "s": "Transfermarkt",
+    "s": "Transfermarkt (UK)",
     "d": "www.transfermarkt.co.uk",
     "t": "tmuk",
     "ts": [
@@ -78792,7 +78792,7 @@
     "sc": "Tools"
   },
   {
-    "s": "TN.com.ar",
+    "s": "TN",
     "d": "tn.com.ar",
     "t": "todonoticias",
     "u": "https://tn.com.ar/buscar/{{{s}}}",
@@ -78808,7 +78808,7 @@
     "sc": "Reference (science)"
   },
   {
-    "s": "to [icon]",
+    "s": "To [icon]",
     "d": "www.toicon.com",
     "t": "toicon",
     "u": "https://www.toicon.com/icons?query={{{s}}}",
@@ -78894,7 +78894,7 @@
     "sc": "Search (Private)"
   },
   {
-    "s": "tonymacx86",
+    "s": "TonyMacx86",
     "d": "www.tonymacx86.com",
     "t": "tonymacx86",
     "u": "https://www.tonymacx86.com/search/48223690/?q={{{s}}}&o=date",
@@ -78902,7 +78902,7 @@
     "sc": "Downloads (software)"
   },
   {
-    "s": "tookapic",
+    "s": "Tookapic",
     "d": "stock.tookapic.com",
     "t": "tookapic",
     "u": "https://stock.tookapic.com/search?q={{{s}}}",
@@ -78966,7 +78966,7 @@
     "sc": "Services"
   },
   {
-    "s": "toramp.com",
+    "s": "Toramp",
     "d": "www.toramp.com",
     "t": "toramp",
     "u": "https://www.toramp.com/search.php?search={{{s}}}",
@@ -79030,7 +79030,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "TotalCmd.Net",
+    "s": "TotalCMD",
     "d": "www.totalcmd.net",
     "t": "totalcmd",
     "u": "https://www.totalcmd.net/search.php?s={{{s}}}",
@@ -79054,7 +79054,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Touslesprix.com",
+    "s": "Touslesprix",
     "d": "www.touslesprix.com",
     "t": "touslesprix",
     "u": "https://www.touslesprix.com/achat,{{{s}}}.html",
@@ -79086,7 +79086,7 @@
     "sc": "Images"
   },
   {
-    "s": "ProTinkerToys.com",
+    "s": "ProTinkerToys",
     "d": "protinkertoys.com",
     "t": "toy",
     "u": "https://protinkertoys.com/search?type=product&q={{{s}}}",
@@ -79102,7 +79102,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "transperth",
+    "s": "Transperth",
     "d": "www.transperth.wa.gov.au",
     "t": "tperth",
     "u": "https://www.transperth.wa.gov.au/Search-Results?Search={{{s}}}",
@@ -79166,7 +79166,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "tracemyip",
+    "s": "TraceMyIP",
     "d": "tools.tracemyip.org",
     "t": "tracemyip",
     "u": "https://tools.tracemyip.org/lookup/{{{s}}}",
@@ -79268,7 +79268,7 @@
     "sc": "TV"
   },
   {
-    "s": "transfermarkt.de",
+    "s": "Transfermarkt (Germany)",
     "d": "www.transfermarkt.de",
     "t": "transfermarkt",
     "ts": [
@@ -79279,7 +79279,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Microsoft Translator (for websites)",
+    "s": "Microsoft Translator (Websites)",
     "d": "www.microsofttranslator.com",
     "t": "translatesite",
     "u": "https://www.microsofttranslator.com/bv.aspx?from=&to=en&a={{{s}}}",
@@ -79551,7 +79551,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "Trovaprezzi.it",
+    "s": "Trovaprezzi",
     "d": "www.trovaprezzi.it",
     "t": "trovaprezzi",
     "u": "https://www.trovaprezzi.it/categoria.aspx?libera={{{s}}}&id=-1&prezzomin=&prezzomax=",
@@ -79559,7 +79559,7 @@
     "sc": "Services"
   },
   {
-    "s": "Trove - National Library of Australia",
+    "s": "Trove (National Library of Australia)",
     "d": "trove.nla.gov.au",
     "t": "trove",
     "u": "https://trove.nla.gov.au/result?q={{{s}}}",
@@ -79655,7 +79655,7 @@
     "sc": "Reference"
   },
   {
-    "s": "teeshirt21",
+    "s": "Teeshirt21",
     "d": "teeshirt21.com",
     "t": "ts21",
     "u": "https://teeshirt21.com/shop/{{{s}}}",
@@ -79663,7 +79663,7 @@
     "sc": "Online"
   },
   {
-    "s": "TechSupportAlert.com",
+    "s": "TechSupportAlert",
     "d": "www.techsupportalert.com",
     "t": "tsa",
     "u": "https://www.techsupportalert.com/search/google?query={{{s}}}",
@@ -79703,7 +79703,7 @@
     "sc": "Online"
   },
   {
-    "s": "Treccani Sinonimi e Contrari",
+    "s": "Treccani (Sinonimi e Contrari)",
     "d": "www.treccani.it",
     "t": "tsin",
     "u": "https://www.treccani.it/sinonimi/?q={{{s}}}",
@@ -79759,7 +79759,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "talk to books",
+    "s": "Google Books (Talk to Books)",
     "d": "books.google.com",
     "t": "ttbooks",
     "u": "https://books.google.com/talktobooks/query?q={{{s}}}",
@@ -79823,7 +79823,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "DuckDuckGo TTY",
+    "s": "DuckDuckGo (TTY)",
     "d": "duckduckgo.com",
     "t": "tty",
     "u": "https://duckduckgo.com/tty/#q={{{s}}}",
@@ -79855,7 +79855,7 @@
     "sc": "Academic"
   },
   {
-    "s": "TU Chemnitz (Kagi Search)",
+    "s": "TU Chemnitz (Kagi)",
     "d": "kagi.com",
     "ad": "www.tu-chemnitz.de",
     "t": "tuc",
@@ -79904,7 +79904,7 @@
     "sc": "Academic"
   },
   {
-    "s": "tuhh.de",
+    "s": "TUHH",
     "d": "www.tuhh.de",
     "t": "tuhh",
     "u": "https://www.tuhh.de/tuhh/suche/suchergebnis.html?cx=013498366615220259019:ljc1ircsxvi&ie=utf8&hl=de&q={{{s}}}",
@@ -79971,7 +79971,7 @@
     "sc": "Movies"
   },
   {
-    "s": "TutorialsPoint (Kagi Search)",
+    "s": "TutorialsPoint (Kagi)",
     "d": "kagi.com",
     "ad": "www.tutorialspoint.com",
     "t": "tupo",
@@ -79996,7 +79996,7 @@
     "sc": "Reference"
   },
   {
-    "s": "tuerenmarkt24",
+    "s": "Tuerenmarkt24",
     "d": "tuerenmarkt24.de",
     "t": "türen",
     "u": "https://tuerenmarkt24.de/suche?controller=search&orderby=position&orderway=desc&search_query=deur{{{s}}}",
@@ -80140,7 +80140,7 @@
     "sc": "Images"
   },
   {
-    "s": "Tweakers Vraag & Aanbod",
+    "s": "Tweakers (Vraag & Aanbod)",
     "d": "tweakers.net",
     "t": "tva",
     "u": "https://tweakers.net/aanbod/zoeken/?keyword={{{s}}}",
@@ -80148,7 +80148,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "TheTVDB",
+    "s": "TheTVDB (French)",
     "d": "www.thetvdb.com",
     "t": "tvdbfr",
     "u": "https://www.thetvdb.com/search?q={{{s}}}&l=fr",
@@ -80156,7 +80156,7 @@
     "sc": "Misc"
   },
   {
-    "s": "TheTVDB.com",
+    "s": "TheTVDB",
     "d": "www.thetvdb.com",
     "t": "tvdb",
     "u": "https://www.thetvdb.com/search?query={{{s}}}&l=en",
@@ -80180,7 +80180,7 @@
     "sc": "TV"
   },
   {
-    "s": "tvi24",
+    "s": "TVI24",
     "d": "www.tvi24.iol.pt",
     "t": "tvi",
     "u": "https://www.tvi24.iol.pt/pesquisa/{{{s}}}",
@@ -80212,7 +80212,7 @@
     "sc": "TV"
   },
   {
-    "s": "Treccani Vocabolario",
+    "s": "Treccani (Vocabolario)",
     "d": "www.treccani.it",
     "t": "tvoc",
     "u": "https://www.treccani.it/vocabolario/tag/{{{s}}}/",
@@ -80252,7 +80252,7 @@
     "sc": "TV"
   },
   {
-    "s": "Wirecutter (A New York Times Company)",
+    "s": "Wirecutter",
     "d": "thewirecutter.com",
     "t": "twc",
     "u": "https://thewirecutter.com/?s={{{s}}}",
@@ -80260,7 +80260,7 @@
     "sc": "Online"
   },
   {
-    "s": "tweakers.net",
+    "s": "Tweakers (Nieuws)",
     "d": "tweakers.net",
     "t": "tweakers",
     "u": "https://tweakers.net/nieuws/zoeken/?keyword={{{s}}}",
@@ -80276,7 +80276,7 @@
     "sc": "International"
   },
   {
-    "s": "Twitch game search",
+    "s": "Twitch (Games)",
     "d": "www.twitch.tv",
     "t": "twg",
     "ts": [
@@ -80319,7 +80319,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Twitch Chat",
+    "s": "Twitch (Chat)",
     "d": "www.twitch.tv",
     "t": "twitchchat",
     "u": "https://www.twitch.tv/{{{s}}}/chat?popout=",
@@ -80338,7 +80338,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Twitch.tv",
+    "s": "Twitch (Player)",
     "d": "player.twitch.tv",
     "t": "twitchpop",
     "u": "https://player.twitch.tv/?volume=0.5&channel={{{s}}}",
@@ -80346,7 +80346,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Twitter User",
+    "s": "X (User)",
     "d": "x.com",
     "t": "twitters",
     "ts": [
@@ -80374,7 +80374,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Twitter Latest",
+    "s": "X (Latest)",
     "d": "x.com",
     "t": "twl",
     "u": "https://x.com/search?f=tweets&vertical=news&q={{{s}}}",
@@ -80429,7 +80429,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Twitter users",
+    "s": "X (User Search)",
     "d": "x.com",
     "t": "twuser",
     "u": "https://x.com/search/users?q={{{s}}}",
@@ -80461,7 +80461,7 @@
     "sc": "TV"
   },
   {
-    "s": "Tyda.se Dictionary (Swedish-German)",
+    "s": "Tyda (sv-de)",
     "d": "tyda.se",
     "t": "tydade",
     "u": "https://tyda.se/search/{{{s}}}?lang[0]=de&lang[1]=sv",
@@ -80469,7 +80469,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Tyda.se Dictionary (Swedish-Latin)",
+    "s": "Tyda (sv-la)",
     "d": "tyda.se",
     "t": "tydala",
     "u": "https://tyda.se/search/{{{s}}}?lang[0]=la&lang[1]=sv",
@@ -80477,7 +80477,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Tyda.se",
+    "s": "Tyda",
     "d": "tyda.se",
     "t": "tyda",
     "ts": [
@@ -80494,7 +80494,7 @@
     "sc": "Reference (religion)"
   },
   {
-    "s": "TypeScript (Kagi Search)",
+    "s": "TypeScript (Kagi)",
     "d": "kagi.com",
     "ad": "www.typescriptlang.org",
     "t": "typescript",
@@ -80503,7 +80503,7 @@
     "sc": "Languages (other)"
   },
   {
-    "s": "typo3.org",
+    "s": "TYPO3",
     "d": "typo3.org",
     "t": "typo3",
     "u": "https://typo3.org/search/?tx_solr[q]={{{s}}}",
@@ -80511,7 +80511,7 @@
     "sc": "Programming"
   },
   {
-    "s": "TinyUrl",
+    "s": "TinyURL",
     "d": "tinyurl.com",
     "t": "tyurl",
     "u": "https://tinyurl.com/create.php?source=indexpage&url={{{s}}}&submit=Make+TinyURL!&alias=",
@@ -80552,7 +80552,7 @@
     "sc": "Video"
   },
   {
-    "s": "YouTube Video",
+    "s": "YouTube (Video)",
     "d": "www.youtube.com",
     "t": "ytd",
     "ts": [
@@ -80563,7 +80563,7 @@
     "sc": "Video"
   },
   {
-    "s": "timeanddate",
+    "s": "Time and Date",
     "d": "www.timeanddate.com",
     "t": "tz",
     "u": "https://www.timeanddate.com/worldclock/results.html?query={{{s}}}",
@@ -80638,7 +80638,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Göteborgs universitetsbibliotek / University of Gothenburg library",
+    "s": "Göteborgs universitetsbibliotek",
     "d": "gu-se-primo.hosted.exlibrisgroup.com",
     "t": "ub",
     "u": "https://gu-se-primo.hosted.exlibrisgroup.com/primo-explore/search?query=any,contains,{{{s}}}&tab=default_tab&search_scope=default_scope&vid=46GUB_VU1&lang=sv_SE&offset=0",
@@ -80654,7 +80654,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Ubuntu Hungary (Kagi Search)",
+    "s": "Ubuntu Hungary (Kagi)",
     "d": "kagi.com",
     "ad": "ubuntu.hu",
     "t": "ubhu",
@@ -80679,7 +80679,7 @@
     "sc": "Sysadmin (network)"
   },
   {
-    "s": "Universitätsbibliothek Mainz",
+    "s": "JGU Mainz Library",
     "d": "hds.hebis.de",
     "t": "ubjgu",
     "u": "https://hds.hebis.de/ubmz/Search/Results?lookfor={{{s}}}&trackSearchEvent=Einfache+Suche&type=allfields&search=new&submit=Suchen",
@@ -80687,7 +80687,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Universitätsbibliothek Kassel",
+    "s": "University of Kassel Library",
     "d": "hds.hebis.de",
     "t": "ubks",
     "u": "https://hds.hebis.de/ubks/Discover/EBSCO?lookfor={{{s}}}",
@@ -80703,7 +80703,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Ubottu.com",
+    "s": "Ubottu",
     "d": "ubottu.com",
     "t": "ubottu",
     "u": "https://ubottu.com/factoids.cgi?search={{{s}}}",
@@ -80719,7 +80719,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Ubuntu France (Kagi Search)",
+    "s": "Ubuntu France (Kagi)",
     "d": "kagi.com",
     "ad": "ubuntu-fr.org",
     "t": "ubufr",
@@ -80767,7 +80767,7 @@
     "sc": "Sysadmin (packages)"
   },
   {
-    "s": "Ubuntu Türkiye",
+    "s": "Ubuntu Forum (Turkey)",
     "d": "forum.ubuntu-tr.net",
     "t": "ubuntutr",
     "u": "https://forum.ubuntu-tr.net/index.php?action=search;q={{{s}}}",
@@ -80844,7 +80844,7 @@
     "sc": "Programming"
   },
   {
-    "s": "U.GG Champion",
+    "s": "U.GG (Champion)",
     "d": "u.gg",
     "t": "uchamp",
     "u": "https://u.gg/lol/champions/{{{s}}}",
@@ -80996,7 +80996,7 @@
     "sc": "Sports"
   },
   {
-    "s": "u:find - Universität Wien",
+    "s": "u:find (Universität Wien)",
     "d": "ufind.univie.ac.at",
     "t": "ufind",
     "u": "https://ufind.univie.ac.at/de/search.html?filter=all&query={{{s}}}",
@@ -81071,7 +81071,7 @@
     "sc": "Learning"
   },
   {
-    "s": "UiO emnesøk",
+    "s": "UiO",
     "d": "www.uio.no",
     "t": "uio",
     "u": "https://www.uio.no/studier/emner/?course-query={{{s}}}&vrtx=search&searchMode=emne",
@@ -81181,7 +81181,7 @@
     "sc": "Government"
   },
   {
-    "s": "uk.pcpartpicker.com",
+    "s": "PCPartPicker (UK)",
     "d": "uk.pcpartpicker.com",
     "t": "ukppp",
     "u": "https://uk.pcpartpicker.com/search/?cc=uk&q={{{s}}}",
@@ -81256,7 +81256,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "uludağ sözlük",
+    "s": "Uludağ Sözlük",
     "d": "www.uludagsozluk.com",
     "t": "uludagsozluk",
     "u": "https://www.uludagsozluk.com/?q={{{s}}}",
@@ -81387,7 +81387,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Universidade de Brasília / Repositório Institucional",
+    "s": "Universidade de Brasília (Repository)",
     "d": "repositorio.unb.br",
     "t": "unbri",
     "u": "https://repositorio.unb.br/simple-search?query={{{s}}}&submit=Ir",
@@ -81443,7 +81443,7 @@
     "sc": "Academic"
   },
   {
-    "s": "unfpa.org",
+    "s": "UNFPA",
     "d": "www.unfpa.org",
     "t": "unfpa",
     "u": "https://www.unfpa.org/search/node/{{{s}}}",
@@ -81451,7 +81451,7 @@
     "sc": "Learning (intl)"
   },
   {
-    "s": "UNHCR (Kagi Search)",
+    "s": "UNHCR (Kagi)",
     "d": "kagi.com",
     "ad": "www.unhcr.org/",
     "t": "unhcr",
@@ -81493,7 +81493,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Unicode Character Search",
+    "s": "FileFormat.info (Unicode)",
     "d": "www.fileformat.info",
     "t": "unicode",
     "ts": [
@@ -81560,7 +81560,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Search for character(s) in Unicode",
+    "s": "Unicode Search",
     "d": "unicode-search.net",
     "t": "uni",
     "u": "https://unicode-search.net/unicode-namesearch.pl?term={{{s}}}",
@@ -81568,7 +81568,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Unity3D answers",
+    "s": "Unity (Answers)",
     "d": "unity3d.com",
     "t": "unityans",
     "u": "https://unity3d.com/search?refinement=answers&gq={{{s}}}",
@@ -81584,7 +81584,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Unity3D Scripting API",
+    "s": "Unity (Scripting API)",
     "d": "docs.unity3d.com",
     "t": "unityapi",
     "ts": [
@@ -81604,7 +81604,7 @@
     "sc": "Downloads (add-ons)"
   },
   {
-    "s": "Unity Manual",
+    "s": "Unity (Manual)",
     "d": "docs.unity3d.com",
     "t": "unitym",
     "u": "https://docs.unity3d.com/Manual/30_search.html?q={{{s}}}",
@@ -81668,7 +81668,7 @@
     "sc": "Search"
   },
   {
-    "s": "unkompliziert.eu",
+    "s": "Unkompliziert",
     "d": "unkompliziert.eu",
     "t": "unkompliziert",
     "u": "https://unkompliziert.eu/index.php?search={{{s}}}",
@@ -81732,7 +81732,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Unshorten.me",
+    "s": "Unshorten",
     "d": "unshorten.me",
     "t": "unshorten",
     "u": "https://unshorten.me/s/{{{s}}}",
@@ -81775,7 +81775,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "UN terminology search portal",
+    "s": "UNTERM",
     "d": "unterm.un.org",
     "t": "unterm",
     "u": "https://unterm.un.org/unterm2/en/search?searchTerm={{{s}}}",
@@ -81791,7 +81791,7 @@
     "sc": "Topical"
   },
   {
-    "s": "reddit.com/r/unixporn",
+    "s": "Reddit (/r/unixporn)",
     "d": "www.reddit.com",
     "t": "unxprn",
     "u": "https://www.reddit.com/r/unixporn/search?q={{{s}}}&restrict_sr=1",
@@ -81842,7 +81842,7 @@
     "sc": "Academic"
   },
   {
-    "s": "University of Toronto Library Onesearch",
+    "s": "University of Toronto Libraries (OneSearch)",
     "d": "onesearch.library.utoronto.ca",
     "t": "uoft",
     "ts": [
@@ -81885,7 +81885,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Ubuntu Launchpad Package Page",
+    "s": "Launchpad (Ubuntu Package)",
     "d": "launchpad.net",
     "t": "upkg",
     "u": "https://launchpad.net/ubuntu/+source/{{{s}}}",
@@ -81984,7 +81984,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "urbaneffect.net",
+    "s": "Urban Effect",
     "d": "urbaneffect.net",
     "t": "urbanfx",
     "u": "https://urbaneffect.net/?s={{{s}}}",
@@ -82096,7 +82096,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Unity Script Reference",
+    "s": "Unity (Script Reference)",
     "d": "docs.unity3d.com",
     "t": "uscript",
     "u": "https://docs.unity3d.com/Documentation/ScriptReference/30_search.html?q={{{s}}}",
@@ -82104,7 +82104,7 @@
     "sc": "Languages (csharp)"
   },
   {
-    "s": "XE (usd2brl)",
+    "s": "XE (USD-BRL)",
     "d": "www.xe.com",
     "t": "usd2brl",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=USD&To=BRL",
@@ -82112,7 +82112,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "XE (usd2cop)",
+    "s": "XE (USD-COP)",
     "d": "www.xe.com",
     "t": "usd2cop",
     "u": "https://www.xe.com/currencyconverter/convert/?From=USD&To=COP&Amount={{{s}}}",
@@ -82120,7 +82120,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Xe.com",
+    "s": "XE (USD-EUR)",
     "d": "www.xe.com",
     "t": "usd2eur",
     "u": "https://www.xe.com/currencyconverter/convert/?From=USD&To=EUR&Amount={{{s}}}",
@@ -82128,7 +82128,7 @@
     "sc": "Reference"
   },
   {
-    "s": "xe",
+    "s": "XE (USD-GBP)",
     "d": "www.xe.com",
     "t": "usd2gbp",
     "u": "https://www.xe.com/currencyconverter/convert/?Amount={{{s}}}&From=USD&To=GBP",
@@ -82136,7 +82136,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Machineseeker.com - Used machinery search engine",
+    "s": "Machineseeker (Used)",
     "d": "www.machineseeker.com",
     "t": "used",
     "u": "https://www.machineseeker.com/fy/inserat/inseratliste/index?stichwort={{{s}}}&submit=",
@@ -82184,7 +82184,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Usite.hu",
+    "s": "Usite",
     "d": "usite.hu",
     "t": "usite",
     "u": "https://usite.hu/{{{s}}}",
@@ -82280,7 +82280,7 @@
     "sc": "Government"
   },
   {
-    "s": "University of Texas in Austin - Library",
+    "s": "University of Texas at Austin (Library)",
     "d": "catalog.lib.utexas.edu",
     "t": "utlibrary",
     "u": "https://catalog.lib.utexas.edu/search/?searchtype=X&SORT=D&searcharg={{{s}}}&searchscope=29",
@@ -82288,7 +82288,7 @@
     "sc": "Academic"
   },
   {
-    "s": "UT.no - Outdoors for all",
+    "s": "UT",
     "d": "ut.no",
     "t": "utno",
     "u": "https://ut.no/finn?search={{{s}}}",
@@ -82328,7 +82328,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Ubuntu Users DE (Kagi Search)",
+    "s": "Ubuntu Users DE (Kagi)",
     "d": "kagi.com",
     "ad": "ubuntuusers.de",
     "t": "uude",
@@ -82434,7 +82434,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Ein Templatesystem Für Templatesysteme",
+    "s": "Uxul",
     "d": "uxul.de",
     "t": "uxul",
     "u": "https://uxul.de/find?search={{{s}}}",
@@ -82466,7 +82466,7 @@
     "sc": "Academic"
   },
   {
-    "s": "V2EX (Kagi Search)",
+    "s": "V2EX (Kagi)",
     "d": "kagi.com",
     "ad": "v2ex.com/t",
     "t": "v2ex",
@@ -82483,7 +82483,7 @@
     "sc": "Blogs (intl)"
   },
   {
-    "s": "VAGAS.com.br",
+    "s": "VAGAS",
     "d": "www.vagas.com.br",
     "t": "vagas",
     "u": "https://www.vagas.com.br/vagas-de-{{{s}}}?",
@@ -82499,7 +82499,7 @@
     "sc": "Downloads"
   },
   {
-    "s": "ProCarManuals.com",
+    "s": "ProCarManuals",
     "d": "procarmanuals.com",
     "t": "vagssp",
     "u": "https://procarmanuals.com/?s={{{s}}}",
@@ -82585,7 +82585,7 @@
     "sc": "Online"
   },
   {
-    "s": "Valve Developer Wiki",
+    "s": "Valve (Developer Wiki)",
     "d": "developer.valvesoftware.com",
     "t": "valve",
     "u": "https://developer.valvesoftware.com/w/index.php?title=Special:Search&search={{{s}}}",
@@ -82747,7 +82747,7 @@
     "sc": "Downloads (add-ons)"
   },
   {
-    "s": "Office VBA Reference (Kagi Search)",
+    "s": "Office VBA Reference (Kagi)",
     "d": "kagi.com",
     "ad": "msdn.microsoft.com/en-us/vba",
     "t": "vba",
@@ -82812,7 +82812,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Valve Developer Community",
+    "s": "Valve (Developer Community)",
     "d": "developer.valvesoftware.com",
     "t": "vdc",
     "u": "https://developer.valvesoftware.com/w/index.php?search={{{s}}}",
@@ -82820,7 +82820,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Vandale français-néerlandais",
+    "s": "Van Dale (fr-nl)",
     "d": "www.vandale.nl",
     "t": "vdfn",
     "u": "https://www.vandale.nl/opzoeken?pattern={{{s}}}&lang=fn",
@@ -82828,7 +82828,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "微盘",
+    "s": "Weibo VDisk",
     "d": "vdisk.weibo.com",
     "t": "vdisk",
     "u": "https://vdisk.weibo.com/search/?type=public&keyword={{{s}}}",
@@ -82836,7 +82836,7 @@
     "sc": "General"
   },
   {
-    "s": "Vandale",
+    "s": "Van Dale (nl-fr)",
     "d": "www.vandale.nl",
     "t": "vdnf",
     "u": "https://www.vandale.nl/opzoeken?pattern={{{s}}}&lang=nf",
@@ -82844,7 +82844,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "DuckDuckGo video search",
+    "s": "DuckDuckGo (Videos)",
     "d": "duckduckgo.com",
     "t": "ddg-v",
     "ts": [
@@ -82998,7 +82998,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Verbix (English conjugation verb)",
+    "s": "Verbix (English)",
     "d": "www.verbix.com",
     "t": "verbixeng",
     "u": "https://www.verbix.com/webverbix/English/{{{s}}}r.html",
@@ -83006,7 +83006,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Verbix Spanish",
+    "s": "Verbix (Spanish)",
     "d": "www.verbix.com",
     "t": "verbixes",
     "u": "https://www.verbix.com/webverbix/Spanish/{{{s}}}.html",
@@ -83014,7 +83014,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Verbix (pt)",
+    "s": "Verbix (Portuguese)",
     "d": "www.verbix.com",
     "t": "verbixpt",
     "u": "https://www.verbix.com/webverbix/Portuguese/{{{s}}}.html",
@@ -83074,7 +83074,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Vertalen.nu",
+    "s": "Vertalen.nu (en-nl)",
     "d": "www.vertalen.nu",
     "t": "vertalennu",
     "u": "https://www.vertalen.nu/vertaal?vertaal={{{s}}}&van=en&naar=nl",
@@ -83082,7 +83082,7 @@
     "sc": "Tools"
   },
   {
-    "s": "vertalen.nu",
+    "s": "Vertalen.nu (nl-en)",
     "d": "www.vertalen.nu",
     "t": "vertalen",
     "u": "https://www.vertalen.nu/vertaal?van=nl&naar=en&vertaal={{{s}}}",
@@ -83106,7 +83106,7 @@
     "sc": "Movies"
   },
   {
-    "s": "Vevo",
+    "s": "YouTube (Vevo)",
     "d": "www.youtube.com",
     "t": "vevo",
     "u": "https://www.youtube.com/user/VEVO/search?query={{{s}}}",
@@ -83186,7 +83186,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "victorhckinthefreeworld",
+    "s": "Victorhck in the Free World",
     "d": "victorhckinthefreeworld.wordpress.com",
     "t": "vhck",
     "u": "https://victorhckinthefreeworld.wordpress.com/?s={{{s}}}",
@@ -83194,7 +83194,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "visualhunt.com",
+    "s": "VisualHunt",
     "d": "visualhunt.com",
     "t": "vhunt",
     "ts": [
@@ -83304,7 +83304,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Videnskab.dk",
+    "s": "Videnskab",
     "d": "videnskab.dk",
     "t": "viden",
     "u": "https://videnskab.dk/search/+{{{s}}}",
@@ -83400,7 +83400,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "Viki.com",
+    "s": "Viki",
     "d": "www.viki.com",
     "t": "vik",
     "u": "https://www.viki.com/search?q={{{s}}}",
@@ -83440,7 +83440,7 @@
     "sc": "Downloads (add-ons)"
   },
   {
-    "s": "Vim.org",
+    "s": "Vim",
     "d": "www.google.com",
     "t": "vim",
     "u": "https://www.google.com/cse?cx=partner-pub-3005259998294962:bvyni59kjr1&q={{{s}}}",
@@ -83499,7 +83499,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Virtus (Kagi Search)",
+    "s": "Virtus (Kagi)",
     "d": "kagi.com",
     "ad": "virtus.com",
     "t": "virtus",
@@ -83615,7 +83615,7 @@
     "sc": "Search"
   },
   {
-    "s": "Vkontakte",
+    "s": "VK",
     "d": "vk.com",
     "t": "vk",
     "u": "https://vk.com/search?c[q]={{{s}}}&c[section]=auto",
@@ -83623,7 +83623,7 @@
     "sc": "Social"
   },
   {
-    "s": "Vkontakte video",
+    "s": "VK (Video)",
     "d": "vk.com",
     "t": "vkv",
     "u": "https://vk.com/video?q={{{s}}}",
@@ -83750,7 +83750,7 @@
     "sc": "Companies"
   },
   {
-    "s": "Vodafone.it",
+    "s": "Vodafone (Italy)",
     "d": "www.vodafone.it",
     "t": "voda",
     "u": "https://www.vodafone.it/area-utente/appmanager/fai-da-te/Common?_nfpb=true&_pageLabel=P5000626721379247340997&categoryId=&pageNumber=&slideNumber=&defaultView=true&searchQuery={{{s}}}",
@@ -83758,7 +83758,7 @@
     "sc": "Online (deals)"
   },
   {
-    "s": "Voedingswaardetabel.nl",
+    "s": "Voedingswaardetabel",
     "d": "www.voedingswaardetabel.nl",
     "t": "voedingswaarde",
     "u": "https://www.voedingswaardetabel.nl/voedingswaarde/?q={{{s}}}",
@@ -83766,7 +83766,7 @@
     "sc": "Health"
   },
   {
-    "s": "Vogue.co.uk",
+    "s": "Vogue (UK)",
     "d": "www.vogue.co.uk",
     "t": "vogueuk",
     "u": "https://www.vogue.co.uk/search?q={{{s}}}",
@@ -83774,7 +83774,7 @@
     "sc": "Magazine"
   },
   {
-    "s": "Vogue.com",
+    "s": "Vogue",
     "d": "www.vogue.com",
     "t": "vogue",
     "u": "https://www.vogue.com/?s={{{s}}}",
@@ -83798,7 +83798,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Void GNU/Linux",
+    "s": "Void Linux",
     "d": "wiki.voidlinux.org",
     "t": "void",
     "ts": [
@@ -83809,7 +83809,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Karl Voit Blog (Kagi Search)",
+    "s": "Karl Voit Blog (Kagi)",
     "d": "kagi.com",
     "ad": "Karl-Voit.at",
     "t": "voit",
@@ -83842,7 +83842,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "vortaro.nl",
+    "s": "Vortaro",
     "d": "vortaro.nl",
     "t": "vortaronl",
     "u": "https://vortaro.nl/?v={{{s}}}",
@@ -83850,7 +83850,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Vossey.com",
+    "s": "Vossey",
     "d": "www.vossey.com",
     "t": "vossey",
     "u": "https://www.vossey.com/recherche/index.php?ac=recherche&titre={{{s}}}",
@@ -83858,7 +83858,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "voteformost",
+    "s": "VoteForMost",
     "d": "voteformost.net",
     "t": "voteformost",
     "u": "https://voteformost.net/?s={{{s}}}",
@@ -83890,7 +83890,7 @@
     "sc": "General"
   },
   {
-    "s": "Vox.com",
+    "s": "Vox",
     "d": "www.vox.com",
     "t": "vox",
     "u": "https://www.vox.com/search?q={{{s}}}",
@@ -83962,7 +83962,7 @@
     "sc": "Academic"
   },
   {
-    "s": "vsChart.com",
+    "s": "VSChart.com",
     "d": "vschart.com",
     "t": "vschart",
     "u": "https://vschart.com/search?q={{{s}}}",
@@ -83978,7 +83978,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Virgilio - Sinonimi e Contrari",
+    "s": "Virgilio (Sinonimi e Contrari)",
     "d": "sapere.virgilio.it",
     "t": "vsc",
     "u": "https://sapere.virgilio.it/parole/sinonimi-e-contrari/{{{s}}}",
@@ -84050,7 +84050,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "www.virustotal.com",
+    "s": "VirusTotal (IP)",
     "d": "www.virustotal.com",
     "t": "vtip",
     "u": "https://www.virustotal.com/en/ip-address/{{{s}}}/information/",
@@ -84066,7 +84066,7 @@
     "sc": "Programming"
   },
   {
-    "s": "vtluug wiki",
+    "s": "VTLUUG Wiki",
     "d": "vtluug.org",
     "t": "vtluug",
     "u": "https://vtluug.org/w/index.php?title=Special:Search&search={{{s}}}",
@@ -84074,7 +84074,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Vampire: The Masquerade - Blooslines wiki",
+    "s": "Vampire: The Masquerade - Bloodlines (Wiki)",
     "d": "vtmb.wikia.com",
     "t": "vtmb",
     "u": "https://vtmb.wikia.com/wiki/Special:Search?query={{{s}}}",
@@ -84130,7 +84130,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Vulners.com",
+    "s": "Vulners",
     "d": "vulners.com",
     "t": "vulners",
     "u": "https://vulners.com/search?query={{{s}}}",
@@ -84178,7 +84178,7 @@
     "sc": "Online"
   },
   {
-    "s": "Void Linux Wiki",
+    "s": "Void Linux (Wiki)",
     "d": "wiki.voidlinux.org",
     "t": "vw",
     "u": "https://wiki.voidlinux.org/index.php?search={{{s}}}&title=Special:Search&go=Go",
@@ -84246,7 +84246,7 @@
     "sc": "Jobs"
   },
   {
-    "s": "W3Schools Tag Attributes",
+    "s": "W3Schools (Tag Attributes)",
     "d": "www.w3schools.com",
     "t": "w3satt",
     "u": "https://www.w3schools.com/tags/att_{{{s}}}.asp",
@@ -84254,7 +84254,7 @@
     "sc": "Languages (html)"
   },
   {
-    "s": "W3Schools (Kagi Search)",
+    "s": "W3Schools (Kagi)",
     "d": "kagi.com",
     "ad": "w3schools.com",
     "t": "w3schools",
@@ -84266,7 +84266,7 @@
     "sc": "Search (DDG)"
   },
   {
-    "s": "w3school中文",
+    "s": "W3School (Chinese)",
     "d": "www.google.com",
     "ad": "w3school.com.cn",
     "t": "w3scn",
@@ -84275,7 +84275,7 @@
     "sc": "Programming"
   },
   {
-    "s": "W3 Schools Tag",
+    "s": "W3Schools (Tag)",
     "d": "www.w3schools.com",
     "t": "w3stag",
     "u": "https://www.w3schools.com/tags/tag_{{{s}}}.asp",
@@ -84401,7 +84401,7 @@
     "sc": "Images"
   },
   {
-    "s": "Google Images (wallpapers)",
+    "s": "Google (Wallpapers)",
     "d": "google.com",
     "t": "wallpaper",
     "u": "https://google.com/search?tbm=isch&imgsz=xxlarge&gbv=2&safe=off&q={{{s}}}+wallpaper&btnG=Search+Images&tbs=imgo:1",
@@ -84511,7 +84511,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "World-Art.ru",
+    "s": "World-Art",
     "d": "www.world-art.ru",
     "t": "waru",
     "ts": [
@@ -84538,7 +84538,7 @@
     "sc": "Online"
   },
   {
-    "s": "WatchCount.com",
+    "s": "WatchCount",
     "d": "www.watchcount.com",
     "t": "watchcount",
     "u": "https://www.watchcount.com/completed.php?bkw={{{s}}}&bcat=0&bcts=&sfsb=Show+Me!&csbin=all&cssrt=ts&bslr=&bnp=&bxp="
@@ -84601,7 +84601,7 @@
     "u": "https://wolframalpha.com/input?i={{{s}}}"
   },
   {
-    "s": "Wayfair.ca",
+    "s": "Wayfair (Canada)",
     "d": "www.wayfair.ca",
     "t": "wayfairca",
     "u": "https://www.wayfair.ca/keyword.php?keyword={{{s}}}&command=dosearch&new_keyword_search=true",
@@ -84628,7 +84628,7 @@
     "sc": "Academic"
   },
   {
-    "s": "web3data",
+    "s": "Web3Data",
     "d": "wb3.io",
     "t": "wb3",
     "u": "https://wb3.io/{{{s}}}",
@@ -84652,7 +84652,7 @@
     "sc": "Academic"
   },
   {
-    "s": "r/worldbuilding",
+    "s": "Reddit (/r/worldbuilding)",
     "d": "www.reddit.com",
     "t": "wbd",
     "u": "https://www.reddit.com/r/worldbuilding/?q={{{s}}}&restrict_sr=on&include_over_18=on&sort=relevance&t=all",
@@ -84660,7 +84660,7 @@
     "sc": "Misc"
   },
   {
-    "s": "Wooledge - Greg's Wiki",
+    "s": "Greg's Wiki",
     "d": "mywiki.wooledge.org",
     "t": "wbgw",
     "u": "https://mywiki.wooledge.org/EnglishFrontPage?action=fullsearch&context=180&value={{{s}}}&titlesearch=Titles",
@@ -84692,7 +84692,7 @@
     "sc": "Learning (intl)"
   },
   {
-    "s": "Webmasterparadies.de",
+    "s": "Webmasterparadies",
     "d": "webmasterparadies.de",
     "t": "wbmp",
     "u": "https://webmasterparadies.de/?s={{{s}}}",
@@ -84743,7 +84743,7 @@
     "sc": "Books"
   },
   {
-    "s": "World Cat Identities",
+    "s": "WorldCat (Identities)",
     "d": "www.worldcat.org",
     "t": "wci",
     "u": "https://www.worldcat.org/identities/find?fullName={{{s}}}",
@@ -84794,7 +84794,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Wordreference (es)",
+    "s": "WordReference (es)",
     "d": "www.wordreference.com",
     "t": "wdr",
     "ts": [
@@ -84815,7 +84815,7 @@
     "sc": "Government"
   },
   {
-    "s": "Fr. Z's Blog (Wdtprs.com)",
+    "s": "Fr. Z's Blog",
     "d": "wdtprs.com",
     "t": "wdtprs",
     "u": "https://wdtprs.com/blog/?s={{{s}}}",
@@ -84961,7 +84961,7 @@
     "sc": "Design"
   },
   {
-    "s": "WebExtension Docs",
+    "s": "MDN Web Docs (WebExtensions)",
     "d": "developer.mozilla.org",
     "t": "webext",
     "u": "https://developer.mozilla.org/en-US/search?q={{{s}}}&topic=addons",
@@ -84977,7 +84977,7 @@
     "sc": "Tech"
   },
   {
-    "s": "weblio 英和辞典",
+    "s": "Weblio (en-ja)",
     "d": "ejje.weblio.jp",
     "t": "weblioe",
     "u": "https://ejje.weblio.jp/content/{{{s}}}",
@@ -85095,7 +85095,7 @@
     "sc": "Online"
   },
   {
-    "s": "Webtender (Kagi Search)",
+    "s": "Webtender (Kagi)",
     "d": "kagi.com",
     "ad": "webtender.com",
     "t": "webtender",
@@ -85124,7 +85124,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "Webxicon -> English",
+    "s": "Webxicon (auto-en)",
     "d": "webxicon.org",
     "t": "webxiconen",
     "u": "https://webxicon.org/search.php?l=-1&l2=3&q={{{s}}}",
@@ -85132,7 +85132,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Webxicon -> Finnish",
+    "s": "Webxicon (auto-fi)",
     "d": "webxicon.org",
     "t": "webxiconfi",
     "ts": [
@@ -85143,7 +85143,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Webxicon -> Swedish",
+    "s": "Webxicon (auto-sv)",
     "d": "webxicon.org",
     "t": "webxiconse",
     "ts": [
@@ -85154,7 +85154,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "webxicon",
+    "s": "Webxicon",
     "d": "webxicon.org",
     "t": "webxicon",
     "u": "https://webxicon.org/search.php?q={{{s}}}",
@@ -85234,7 +85234,7 @@
     "sc": "Online"
   },
   {
-    "s": "Wordreference (en-fr)",
+    "s": "WordReference (en-fr)",
     "d": "www.wordreference.com",
     "t": "wenfr",
     "ts": [
@@ -85246,7 +85246,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "WerStreamt.es",
+    "s": "werStreamt.es",
     "d": "www.werstreamt.es",
     "t": "werstreamt",
     "u": "https://www.werstreamt.es/filme-serien?q={{{s}}}",
@@ -85254,7 +85254,7 @@
     "sc": "Movies"
   },
   {
-    "s": "werstreamt.es",
+    "s": "WerStreamt.es",
     "d": "www.werstreamt.es",
     "t": "wer",
     "u": "https://www.werstreamt.es/filme-serien?q={{{s}}}&action_results=suchen",
@@ -85324,7 +85324,7 @@
     "sc": "Weather"
   },
   {
-    "s": "Webfordítás de-hu",
+    "s": "Webfordítás (de-hu)",
     "d": "www.webforditas.hu",
     "t": "wfdehu",
     "u": "https://www.webforditas.hu/szotar.php?S={{{s}}}&l1=de&l2=hu",
@@ -85332,7 +85332,7 @@
     "sc": "Tools"
   },
   {
-    "s": "weltfussball.de (trainer)",
+    "s": "Weltfussball (Trainer)",
     "d": "www.weltfussball.de",
     "t": "wfdep",
     "u": "https://www.weltfussball.de/suche/?q={{{s}}}&kind=1",
@@ -85340,7 +85340,7 @@
     "sc": "Sports"
   },
   {
-    "s": "weltfussball.de",
+    "s": "Weltfussball",
     "d": "www.weltfussball.de",
     "t": "wfdet",
     "u": "https://www.weltfussball.de/suche/?q={{{s}}}&kind=2",
@@ -85356,7 +85356,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Webfordítás en-hu",
+    "s": "Webfordítás (en-hu)",
     "d": "www.webforditas.hu",
     "t": "wfenhu",
     "u": "https://www.webforditas.hu/szotar.php?S={{{s}}}&l1=en&l2=hu",
@@ -85364,7 +85364,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Webfordítás hu-de",
+    "s": "Webfordítás (hu-de)",
     "d": "www.webforditas.hu",
     "t": "wfhude",
     "u": "https://www.webforditas.hu/szotar.php?S={{{s}}}&l1=hu&l2=de",
@@ -85372,7 +85372,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Webfordítás hu-en",
+    "s": "Webfordítás (hu-en)",
     "d": "www.webforditas.hu",
     "t": "wfhuen",
     "u": "https://www.webforditas.hu/szotar.php?S={{{s}}}&l1=hu&l2=en",
@@ -85396,7 +85396,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Wordreference (fren)",
+    "s": "WordReference (fr-en)",
     "d": "www.wordreference.com",
     "t": "wfren",
     "ts": [
@@ -85408,7 +85408,7 @@
     "sc": "Tools"
   },
   {
-    "s": "warframe.market",
+    "s": "Warframe Market",
     "d": "warframe.market",
     "t": "wft",
     "u": "https://warframe.market/items/{{{s}}}",
@@ -85444,7 +85444,7 @@
     "sc": "Weather"
   },
   {
-    "s": "Wargaming.net Wiki",
+    "s": "Wargaming Wiki",
     "d": "wiki.wargaming.net",
     "t": "wgw",
     "ts": [
@@ -85480,7 +85480,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "WhatIs.com",
+    "s": "WhatIs",
     "d": "whatis.techtarget.com",
     "t": "whatis",
     "u": "https://whatis.techtarget.com/wsearchResults/1,290214,sid9,00.html?query={{{s}}}",
@@ -85496,7 +85496,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Wikihow DE",
+    "s": "wikiHow (German)",
     "d": "de.wikihow.com",
     "t": "whde",
     "u": "https://de.wikihow.com/wikiHowTo?search={{{s}}}:",
@@ -85504,7 +85504,7 @@
     "sc": "Search"
   },
   {
-    "s": "Wikihow Español",
+    "s": "wikiHow (Spanish)",
     "d": "es.wikihow.com",
     "t": "whes",
     "ts": [
@@ -85523,7 +85523,7 @@
     "sc": "Food"
   },
   {
-    "s": "wikiHow France",
+    "s": "wikiHow (French)",
     "d": "fr.wikihow.com",
     "t": "whfr",
     "u": "https://fr.wikihow.com/wikiHowTo?search={{{s}}}",
@@ -85593,7 +85593,7 @@
     "sc": "Social"
   },
   {
-    "s": "Whitaker's Words English",
+    "s": "Whitaker's Words (English)",
     "d": "www.archives.nd.edu",
     "t": "whitakers",
     "u": "https://www.archives.nd.edu/cgi-bin/wordz.pl?english={{{s}}}",
@@ -85609,7 +85609,7 @@
     "sc": "Online (marketplace)"
   },
   {
-    "s": "wikiHow Dutch",
+    "s": "wikiHow (Dutch)",
     "d": "nl.wikihow.com",
     "t": "whnl",
     "u": "https://nl.wikihow.com/wikiHowTo?search={{{s}}}",
@@ -85810,7 +85810,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Wiki Cookbook",
+    "s": "Wikibooks (Cookbook)",
     "d": "en.wikibooks.org",
     "t": "wikicook",
     "u": "https://en.wikibooks.org/wiki/Special:Search?search={{{s}}}&prefix=Cookbook:&fulltext=Search+Cookbook&fulltext=Search",
@@ -86024,7 +86024,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Wikivoyage (Ελληνικά)",
+    "s": "Wikivoyage (Greek)",
     "d": "el.wikivoyage.org",
     "t": "wikivoyageel",
     "u": "https://el.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
@@ -86059,7 +86059,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Wikivoyage (עברית)",
+    "s": "Wikivoyage (Hebrew)",
     "d": "he.wikivoyage.org",
     "t": "wikivoyagehe",
     "u": "https://he.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
@@ -86099,7 +86099,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Wikivoyage (Română)",
+    "s": "Wikivoyage (ro)",
     "d": "ro.wikivoyage.org",
     "t": "wikivoyagero",
     "u": "https://ro.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
@@ -86123,7 +86123,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Wikivoyage (Українська)",
+    "s": "Wikivoyage (Ukrainian)",
     "d": "uk.wikivoyage.org",
     "t": "wikivoyageuk",
     "u": "https://uk.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
@@ -86131,7 +86131,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Wikivoyage (Tiếng Việt)",
+    "s": "Wikivoyage (Vietnamese)",
     "d": "vi.wikivoyage.org",
     "t": "wikivoyagevi",
     "u": "https://vi.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
@@ -86158,7 +86158,7 @@
     "sc": "Travel"
   },
   {
-    "s": "WikiWand",
+    "s": "Wikiwand",
     "d": "www.wikiwand.com",
     "t": "wikiwand",
     "ts": [
@@ -86199,7 +86199,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Викисловарь",
+    "s": "Wiktionary (Russian)",
     "d": "ru.wiktionary.org",
     "t": "wikru",
     "ts": [
@@ -86263,7 +86263,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Wikrionary(GR)",
+    "s": "Wiktionary (el)",
     "d": "el.m.wiktionary.org",
     "t": "wiktgr",
     "u": "https://el.m.wiktionary.org/wiki{{{s}}}",
@@ -86626,7 +86626,7 @@
     "sc": "Tools (URLs)"
   },
   {
-    "s": "Lithuanian Wiktionary (Vikižodynas)",
+    "s": "Lithuanian Wiktionary",
     "d": "lt.wiktionary.org",
     "t": "wklt",
     "u": "https://lt.wiktionary.org/w/index.php?search={{{s}}}",
@@ -86634,7 +86634,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Wykop.pl",
+    "s": "Wykop",
     "d": "www.wykop.pl",
     "t": "wkp",
     "ts": [
@@ -86659,7 +86659,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Wiktionary German",
+    "s": "Wiktionary (German)",
     "d": "de.wiktionary.org",
     "t": "wktde",
     "ts": [
@@ -86702,7 +86702,7 @@
     "sc": "Search"
   },
   {
-    "s": "Wikimedia Commons Category",
+    "s": "Wikimedia Commons (Categories)",
     "d": "commons.wikimedia.org",
     "t": "wmcc",
     "u": "https://commons.wikimedia.org/w/index.php?search={{{s}}}&ns14=1",
@@ -86810,7 +86810,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "WNP.pl",
+    "s": "WNP",
     "d": "www.wnp.pl",
     "t": "wnp",
     "u": "https://www.wnp.pl/wyszukiwanie.html?szukaj={{{s}}}",
@@ -87005,7 +87005,7 @@
     "sc": "Tools"
   },
   {
-    "s": "WordPress.org",
+    "s": "WordPress",
     "d": "wordpress.org",
     "t": "wordpress",
     "ts": [
@@ -87072,7 +87072,7 @@
     "sc": "Games (offline)"
   },
   {
-    "s": "RootsWorld Magazine and Radio (Kagi Search)",
+    "s": "RootsWorld (Kagi)",
     "d": "kagi.com",
     "ad": "rootsworld.com",
     "t": "worldmusic",
@@ -87175,7 +87175,7 @@
     "sc": "Events"
   },
   {
-    "s": "WOW Armory (EU)",
+    "s": "WoW Armory (EU)",
     "d": "eu.battle.net",
     "t": "wowarmoryeu",
     "ts": [
@@ -87186,7 +87186,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Battle.net",
+    "s": "Battle.net (US)",
     "d": "us.battle.net",
     "t": "wowarmoryus",
     "ts": [
@@ -87205,7 +87205,7 @@
     "sc": "Online"
   },
   {
-    "s": "Word of Warcraft Database - WOWDB",
+    "s": "WOWDB (World of Warcraft Database)",
     "d": "www.wowdb.com",
     "t": "wowdb",
     "u": "https://www.wowdb.com/search?search={{{s}}}",
@@ -87243,7 +87243,7 @@
     "sc": "Games (WOW)"
   },
   {
-    "s": "Wowhead (Español)",
+    "s": "Wowhead (Spanish)",
     "d": "es.wowhead.com",
     "t": "wowhes",
     "u": "https://es.wowhead.com/search?q={{{s}}}",
@@ -87374,7 +87374,7 @@
     "sc": "Tools"
   },
   {
-    "s": "wordpress.org",
+    "s": "WordPress (Plugins)",
     "d": "wordpress.org",
     "t": "wpplugs",
     "ts": [
@@ -87401,7 +87401,7 @@
     "sc": "Libraries/Frameworks (wordpress)"
   },
   {
-    "s": "WordPress.org Themes",
+    "s": "WordPress (Themes)",
     "d": "wordpress.org",
     "t": "wpthemes",
     "u": "https://wordpress.org/extend/themes/search.php?q={{{s}}}",
@@ -87433,7 +87433,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Wikiquote Español",
+    "s": "Wikiquote (Spanish)",
     "d": "es.wikiquote.org",
     "t": "wqes",
     "u": "https://es.wikiquote.org/w/?search={{{s}}}",
@@ -87468,7 +87468,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "WordReference (deen)",
+    "s": "WordReference (de-en)",
     "d": "www.wordreference.com",
     "t": "wrdeen",
     "ts": [
@@ -87479,7 +87479,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "WordReference DE -> FR",
+    "s": "WordReference (fr-de)",
     "d": "www.wordreference.com",
     "t": "wrdefr",
     "ts": [
@@ -87498,7 +87498,7 @@
     "sc": "Music (Lyrics)"
   },
   {
-    "s": "Word Reference EN-IT",
+    "s": "WordReference (en-it)",
     "d": "www.wordreference.com",
     "t": "wrei",
     "ts": [
@@ -87509,7 +87509,7 @@
     "sc": "Learning"
   },
   {
-    "s": "WordReference en->de",
+    "s": "WordReference (en-de)",
     "d": "www.wordreference.com",
     "t": "wrende",
     "u": "https://www.wordreference.com/ende/{{{s}}}",
@@ -87525,7 +87525,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "wordreference english to greek translation",
+    "s": "WordReference (en-gr)",
     "d": "www.wordreference.com",
     "t": "wrengr",
     "u": "https://www.wordreference.com/engr/{{{s}}}",
@@ -87533,7 +87533,7 @@
     "sc": "Tools"
   },
   {
-    "s": "WordReference (ennl)",
+    "s": "WordReference (en-nl)",
     "d": "www.wordreference.com",
     "t": "wrennl",
     "u": "https://www.wordreference.com/ennl/{{{s}}}",
@@ -87541,7 +87541,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "WordReference (enpl)",
+    "s": "WordReference (en-pl)",
     "d": "www.wordreference.com",
     "t": "wrenpl",
     "u": "https://www.wordreference.com/enpl/{{{s}}}",
@@ -87549,7 +87549,7 @@
     "sc": "Tools"
   },
   {
-    "s": "WordReference (enpt)",
+    "s": "WordReference (en-pt)",
     "d": "www.wordreference.com",
     "t": "wrenpt",
     "ts": [
@@ -87560,7 +87560,7 @@
     "sc": "Learning (intl)"
   },
   {
-    "s": "WordReference en->sv",
+    "s": "WordReference (en-sv)",
     "d": "www.wordreference.com",
     "t": "wrensv",
     "ts": [
@@ -87571,7 +87571,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "WordReference.com English Synonyms",
+    "s": "WordReference (English Synonyms)",
     "d": "www.wordreference.com",
     "t": "wrensyn",
     "u": "https://www.wordreference.com/thesaurus/{{{s}}}",
@@ -87579,7 +87579,7 @@
     "sc": "Tools"
   },
   {
-    "s": "WordReference (EN)",
+    "s": "WordReference (en)",
     "d": "www.wordreference.com",
     "t": "wren",
     "ts": [
@@ -87591,7 +87591,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Word Reference English to Portuguese",
+    "s": "WordReference (pt-en)",
     "d": "www.wordreference.com",
     "t": "wrep",
     "ts": [
@@ -87602,7 +87602,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "WordReference (esconj)",
+    "s": "WordReference (Spanish Conjugation)",
     "d": "www.wordreference.com",
     "t": "wresconj",
     "ts": [
@@ -87613,7 +87613,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "WordReference (esen)",
+    "s": "WordReference (es-en)",
     "d": "www.wordreference.com",
     "t": "wresen",
     "u": "https://www.wordreference.com/es/en/translation.asp?spen={{{s}}}",
@@ -87621,7 +87621,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "WordReference (esfr)",
+    "s": "WordReference (es-fr)",
     "d": "www.wordreference.com",
     "t": "wresfr",
     "ts": [
@@ -87632,7 +87632,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "WordReference es > it",
+    "s": "WordReference (es-it)",
     "d": "www.wordreference.com",
     "t": "wresit",
     "u": "https://www.wordreference.com/esit/{{{s}}}",
@@ -87640,7 +87640,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "WordReference (espt)",
+    "s": "WordReference (es-pt)",
     "d": "www.wordreference.com",
     "t": "wrespt",
     "u": "https://www.wordreference.com/espt/{{{s}}}",
@@ -87656,7 +87656,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "wordreference greek to english translation",
+    "s": "WordReference (gr-en)",
     "d": "www.wordreference.com",
     "t": "wrgren",
     "u": "https://www.wordreference.com/gren/{{{s}}}",
@@ -87672,7 +87672,7 @@
     "sc": "International"
   },
   {
-    "s": "Word Reference IT-EN",
+    "s": "WordReference (it-en)",
     "d": "www.wordreference.com",
     "t": "wrie",
     "ts": [
@@ -87692,7 +87692,7 @@
     "sc": "Academic"
   },
   {
-    "s": "WordReference Italian Conjugator",
+    "s": "WordReference (Italian Conjugator)",
     "d": "www.wordreference.com",
     "t": "writconj",
     "u": "https://www.wordreference.com/conj/ItVerbs.aspx?v={{{s}}}",
@@ -87700,7 +87700,7 @@
     "sc": "Tools"
   },
   {
-    "s": "WordReference (IT definition)",
+    "s": "WordReference (Italian Definition)",
     "d": "www.wordreference.com",
     "t": "writ",
     "u": "https://www.wordreference.com/definizione/{{{s}}}",
@@ -87708,7 +87708,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "WordReference NL -> EN",
+    "s": "WordReference (nl-en)",
     "d": "www.wordreference.com",
     "t": "wrnlen",
     "u": "https://www.wordreference.com/nlen/{{{s}}}",
@@ -87716,7 +87716,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "Word Reference",
+    "s": "WordReference",
     "d": "www.wordreference.com",
     "t": "wrplen",
     "u": "https://www.wordreference.com/plen/{{{s}}}",
@@ -87724,7 +87724,7 @@
     "sc": "Tools"
   },
   {
-    "s": "WordReference Português-Español",
+    "s": "WordReference (pt-es)",
     "d": "www.wordreference.com",
     "t": "wrptes",
     "u": "https://www.wordreference.com/ptes/{{{s}}}",
@@ -87740,7 +87740,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Wordreference (en-es)",
+    "s": "WordReference (en-es)",
     "d": "www.wordreference.com",
     "t": "wrse",
     "u": "https://www.wordreference.com/enes/{{{s}}}",
@@ -87748,7 +87748,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Word Reference Spanish Synonym",
+    "s": "WordReference (Spanish Synonym)",
     "d": "www.wordreference.com",
     "t": "wrsyes",
     "u": "https://www.wordreference.com/sinonimos//{{{s}}}",
@@ -87876,7 +87876,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Wiktkionary e brezhoneg",
+    "s": "Wiktionary (Breton)",
     "d": "br.wiktionary.org",
     "t": "wtbr",
     "u": "https://br.wiktionary.org/wiki/{{{s}}}",
@@ -87924,7 +87924,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "MirBSD Acronyms Database",
+    "s": "MirBSD (Acronyms)",
     "d": "www.mirbsd.org",
     "t": "wtf",
     "u": "https://www.mirbsd.org/wtf.cgi?q={{{s}}}",
@@ -88018,7 +88018,7 @@
     "sc": "Online"
   },
   {
-    "s": "Wiktionary (SV)",
+    "s": "Wiktionary (Swedish)",
     "d": "sv.wiktionary.org",
     "t": "wtsv",
     "u": "https://sv.wiktionary.org/w/index.php?search={{{s}}}&button=&title=Special:Sök",
@@ -88026,7 +88026,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "விக்சனரி (Wiktionary Tamil)",
+    "s": "Wiktionary (Tamil)",
     "d": "ta.wiktionary.org",
     "t": "wtta",
     "u": "https://ta.wiktionary.org/wiki/Special:Search?search={{{s}}}&go=Go",
@@ -88045,7 +88045,7 @@
     "sc": "Weather"
   },
   {
-    "s": "Wiktionary tiếng Việt",
+    "s": "Wiktionary (Vietnamese)",
     "d": "vi.wiktionary.org",
     "t": "wtvi",
     "u": "https://vi.wiktionary.org/w/index.php?search={{{s}}}",
@@ -88069,7 +88069,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "wuage",
+    "s": "Wuage",
     "d": "s.wuage.com",
     "t": "wuage",
     "u": "https://s.wuage.com/product/search?keywords={{{s}}}",
@@ -88117,7 +88117,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Walmart US",
+    "s": "Walmart (US)",
     "d": "www.walmart.com",
     "t": "wus",
     "u": "https://www.walmart.com/search/?query={{{s}}}&country=US",
@@ -88125,7 +88125,7 @@
     "sc": "Search"
   },
   {
-    "s": "Wikivoyage Deutsch",
+    "s": "Wikivoyage (German)",
     "d": "de.wikivoyage.org",
     "t": "wvde",
     "u": "https://de.wikivoyage.org/w/index.php?search={{{s}}}",
@@ -88133,7 +88133,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Wikivoyage español",
+    "s": "Wikivoyage (es)",
     "d": "es.wikivoyage.org",
     "t": "wves",
     "u": "https://es.wikivoyage.org/w/index.php?search={{{s}}}",
@@ -88141,7 +88141,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Wikivoyage Français",
+    "s": "Wikivoyage (French)",
     "d": "fr.wikivoyage.org",
     "t": "wvfr",
     "u": "https://fr.wikivoyage.org/w/index.php?search={{{s}}}",
@@ -88173,7 +88173,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Wikivoyage Português",
+    "s": "Wikivoyage (pt)",
     "d": "pt.wikivoyage.org",
     "t": "wvpt",
     "u": "https://pt.wikivoyage.org/w/index.php?search={{{s}}}",
@@ -88189,7 +88189,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Wikivoyage Svenska",
+    "s": "Wikivoyage (sv)",
     "d": "sv.wikivoyage.org",
     "t": "wvsv",
     "u": "https://sv.wikivoyage.org/w/index.php?search={{{s}}}",
@@ -88213,7 +88213,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Wikiwand in Deutsch",
+    "s": "Wikiwand (de)",
     "d": "www.wikiwand.com",
     "t": "wwde",
     "u": "https://www.wikiwand.com/de/{{{s}}}",
@@ -88221,7 +88221,7 @@
     "sc": "Reference"
   },
   {
-    "s": "WikiWand en Español",
+    "s": "Wikiwand (es)",
     "d": "www.wikiwand.com",
     "t": "wwes",
     "u": "https://www.wikiwand.com/es/{{{s}}}",
@@ -88237,7 +88237,7 @@
     "sc": "Sports"
   },
   {
-    "s": "Wikiwand",
+    "s": "Wikiwand (fr)",
     "d": "www.wikiwand.com",
     "t": "wwfr",
     "u": "https://www.wikiwand.com/fr/{{{s}}}",
@@ -88261,7 +88261,7 @@
     "sc": "Travel"
   },
   {
-    "s": "WikiWand in Dutch",
+    "s": "Wikiwand (nl)",
     "d": "www.wikiwand.com",
     "t": "wwnl",
     "u": "https://www.wikiwand.com/nl/{{{s}}}",
@@ -88269,7 +88269,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Wwoof.net",
+    "s": "WWOOF",
     "d": "www.wwoof.net",
     "t": "wwoof",
     "u": "https://www.wwoof.net/?s={{{s}}}",
@@ -88277,7 +88277,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Wikiwand em Portugês",
+    "s": "Wikiwand (pt)",
     "d": "www.wikiwand.com",
     "t": "wwpt",
     "u": "https://www.wikiwand.com/pt/{{{s}}}",
@@ -88285,7 +88285,7 @@
     "sc": "Academic"
   },
   {
-    "s": "WikiWand Türkçe",
+    "s": "Wikiwand (tr)",
     "d": "www.wikiwand.com",
     "t": "wwtr",
     "u": "https://www.wikiwand.com/tr/{{{s}}}",
@@ -88301,7 +88301,7 @@
     "sc": "Reference"
   },
   {
-    "s": "WikiWand in Chinese",
+    "s": "Wikiwand (zh)",
     "d": "www.wikiwand.com",
     "t": "wwzh",
     "u": "https://www.wikiwand.com/zh/{{{s}}}",
@@ -88309,7 +88309,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Weixin Dev (Kagi Search)",
+    "s": "Weixin Dev (Kagi)",
     "d": "kagi.com",
     "ad": "developers.weixin.qq.com/miniprogram/dev",
     "t": "wxdev",
@@ -88326,7 +88326,7 @@
     "sc": "Forum"
   },
   {
-    "s": "search wechat miniprogram documents",
+    "s": "WeChat Developers (Mini Program)",
     "d": "developers.weixin.qq.com",
     "t": "wxmp",
     "u": "https://developers.weixin.qq.com/doc/search.html?query={{{s}}}",
@@ -88334,7 +88334,7 @@
     "sc": "Programming"
   },
   {
-    "s": "wxWidgets Documentation",
+    "s": "wxWidgets (Docs)",
     "d": "docs.wxwidgets.org",
     "t": "wxw",
     "u": "https://docs.wxwidgets.org/trunk/search.php?query={{{s}}}",
@@ -88400,7 +88400,7 @@
     "sc": "Social"
   },
   {
-    "s": "x86 Opcode & Instruction Reference",
+    "s": "x86asm.net",
     "d": "ref.x86asm.net",
     "t": "x86",
     "u": "https://ref.x86asm.net/geek.html#{{{s}}}",
@@ -88432,7 +88432,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Void Packages",
+    "s": "GitHub (Void Packages)",
     "d": "github.com",
     "t": "xbps",
     "u": "https://github.com/void-linux/void-packages/search?q[]=filename:template+path:/srcpkgs&q[]={{{s}}}&s=indexed",
@@ -88544,7 +88544,7 @@
     "sc": "Audio"
   },
   {
-    "s": "Xing.de",
+    "s": "XING",
     "d": "www.xing.com",
     "t": "xing",
     "u": "https://www.xing.com/app/search?op=combined;keywords={{{s}}}",
@@ -88676,7 +88676,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "XXL.no",
+    "s": "XXL",
     "d": "xxl.no",
     "t": "xxl",
     "u": "https://xxl.no/search?q={{{s}}}",
@@ -88775,7 +88775,7 @@
     "sc": "Social"
   },
   {
-    "s": "Yandex Maps",
+    "s": "Yandex (Maps)",
     "d": "yandex.ru",
     "t": "yandexmaps",
     "ts": [
@@ -88834,7 +88834,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Yandex Video",
+    "s": "Yandex (Video)",
     "d": "yandex.ru",
     "t": "yav",
     "u": "https://yandex.ru/video/search?text={{{s}}}",
@@ -88939,7 +88939,7 @@
     "sc": "Tools"
   },
   {
-    "s": "Yelp.de",
+    "s": "Yelp (Germany)",
     "d": "www.yelp.de",
     "t": "yelpde",
     "u": "https://www.yelp.de/search?find_desc={{{s}}}&ns=1&rpp=10&find_loc=",
@@ -88988,7 +88988,7 @@
     "skip_tests": true
   },
   {
-    "s": "Yahoo Finance Charts",
+    "s": "Yahoo Finance (Charts)",
     "d": "finance.yahoo.com",
     "t": "yfc",
     "u": "https://finance.yahoo.com/chart/{{{s}}}",
@@ -89015,7 +89015,7 @@
     "sc": "Business"
   },
   {
-    "s": "Yahoo Finance (Company Profile)",
+    "s": "Yahoo Finance (Profile)",
     "d": "finance.yahoo.com",
     "t": "yfp",
     "u": "https://finance.yahoo.com/quote/{{{s}}}/profile",
@@ -89058,7 +89058,7 @@
     "sc": "Languages (php)"
   },
   {
-    "s": "Yahoo! Images",
+    "s": "Yahoo (Images)",
     "d": "images.search.yahoo.com",
     "t": "yim",
     "ts": [
@@ -89194,7 +89194,7 @@
     "sc": "Search"
   },
   {
-    "s": "Yodobashi.com",
+    "s": "Yodobashi",
     "d": "www.yodobashi.com",
     "t": "yodobashi",
     "u": "https://www.yodobashi.com/ec/category/index.html?word={{{s}}}",
@@ -89301,7 +89301,7 @@
     "sc": "Video"
   },
   {
-    "s": "Yourei.jp",
+    "s": "Yourei",
     "d": "yourei.jp",
     "t": "yourei",
     "u": "https://yourei.jp/{{{s}}}",
@@ -89384,7 +89384,7 @@
     "sc": "Search"
   },
   {
-    "s": "Yandex Reverse Image Search",
+    "s": "Yandex Images (Reverse)",
     "d": "yandex.com",
     "t": "yri",
     "u": "https://yandex.com/images/search?url={{{s}}}&rpt=imageview",
@@ -89424,7 +89424,7 @@
     "sc": "Video"
   },
   {
-    "s": "YouTube Channel Videos",
+    "s": "YouTube (Channel Videos)",
     "d": "www.youtube.com",
     "t": "ytcv",
     "u": "https://www.youtube.com/user/{{{s}}}/videos",
@@ -89432,7 +89432,7 @@
     "sc": "Video"
   },
   {
-    "s": "YouTube Channel",
+    "s": "YouTube (Channel)",
     "d": "www.youtube.com",
     "t": "ytc",
     "u": "https://www.youtube.com/user/{{{s}}}",
@@ -89440,7 +89440,7 @@
     "sc": "Misc"
   },
   {
-    "s": "YouTube (sort by date)",
+    "s": "YouTube (Sort by Date)",
     "d": "www.youtube.com",
     "t": "ytdate",
     "u": "https://www.youtube.com/results?search_query={{{s}}}&search_sort=video_date_uploaded",
@@ -89448,7 +89448,7 @@
     "sc": "Video"
   },
   {
-    "s": "YouTube (past day)",
+    "s": "YouTube (Past Day)",
     "d": "www.youtube.com",
     "t": "ytday",
     "ts": [
@@ -89494,7 +89494,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "YouTube History",
+    "s": "YouTube (History)",
     "d": "www.youtube.com",
     "t": "yth",
     "u": "https://www.youtube.com/feed/history?query={{{s}}}",
@@ -89518,7 +89518,7 @@
     "sc": "Tools"
   },
   {
-    "s": "YouTube Playlist",
+    "s": "YouTube (Playlist)",
     "d": "www.youtube.com",
     "t": "ytlist",
     "u": "https://www.youtube.com/results?filters=playlist&lclk=playlist&search_query={{{s}}}",
@@ -89526,7 +89526,7 @@
     "sc": "Video"
   },
   {
-    "s": "YouTube - long",
+    "s": "YouTube (Long)",
     "d": "www.youtube.com",
     "t": "ytl",
     "u": "https://www.youtube.com/results?search_type=videos&search_query={{{s}}}&search_duration=long&uni=3",
@@ -89550,7 +89550,7 @@
     "sc": "Google"
   },
   {
-    "s": "YouTube Playlists",
+    "s": "YouTube (Playlists)",
     "d": "www.youtube.com",
     "t": "ytp",
     "u": "https://www.youtube.com/results?q={{{s}}}&sp=EgIQAw==",
@@ -89588,7 +89588,7 @@
     "sc": "TV"
   },
   {
-    "s": "YouTube United States",
+    "s": "YouTube (US)",
     "d": "www.youtube.com",
     "t": "ytus",
     "u": "https://www.youtube.com/results?search_query={{{s}}}&gl=US",
@@ -89647,7 +89647,7 @@
     "sc": "Travel"
   },
   {
-    "s": "Yahoo Video Search",
+    "s": "Yahoo (Video)",
     "d": "video.search.yahoo.com",
     "t": "yv",
     "u": "https://video.search.yahoo.com/search/video?p={{{s}}}",
@@ -89655,7 +89655,7 @@
     "sc": "Video"
   },
   {
-    "s": "Yahoo Weather (Kagi Search)",
+    "s": "Yahoo (Weather) (Kagi)",
     "d": "kagi.com",
     "ad": "weather.yahoo.com",
     "t": "yw",
@@ -89712,7 +89712,7 @@
     "sc": "Law"
   },
   {
-    "s": "Zalando.de",
+    "s": "Zalando (Germany)",
     "d": "www.zalando.de",
     "t": "zalandode",
     "u": "https://www.zalando.de/katalog/?q={{{s}}}",
@@ -89736,7 +89736,7 @@
     "sc": "Online"
   },
   {
-    "s": "ZAM - EQ2",
+    "s": "ZAM (EQ2)",
     "d": "eq2.zam.com",
     "t": "zameq2",
     "u": "https://eq2.zam.com/search.html?q={{{s}}}",
@@ -89744,7 +89744,7 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "ZAM - EQ",
+    "s": "ZAM (EQ)",
     "d": "everquest.allakhazam.com",
     "t": "zameq",
     "u": "https://everquest.allakhazam.com/search.html?q={{{s}}}",
@@ -89888,7 +89888,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Zelda Dungeon Wiki",
+    "s": "Zelda Dungeon (Wiki)",
     "d": "www.zeldadungeon.net",
     "t": "zdw",
     "u": "https://www.zeldadungeon.net/wiki/Special:Search/{{{s}}}",
@@ -90023,7 +90023,7 @@
     "sc": "Search"
   },
   {
-    "s": "Zurb Foundation Forum",
+    "s": "Foundation (Forum)",
     "d": "foundation.zurb.com",
     "t": "zff",
     "u": "https://foundation.zurb.com/forum/posts?utf8=%E2%9C%93&search={{{s}}}&button=",
@@ -90031,7 +90031,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Zend Framework (Kagi Search)",
+    "s": "Zend Framework (Kagi)",
     "d": "kagi.com",
     "ad": "framework.zend.com",
     "t": "zf",
@@ -90210,7 +90210,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Zurb Foundation",
+    "s": "Foundation",
     "d": "foundation.zurb.com",
     "t": "zurbfoundation",
     "ts": [
@@ -90229,7 +90229,7 @@
     "sc": "Online"
   },
   {
-    "s": "ZVON.org",
+    "s": "ZVON",
     "d": "zvon.org",
     "t": "zvon",
     "u": "https://zvon.org/comp/m/{{{s}}}.html",
@@ -90237,7 +90237,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "Zephyr Cross Reference",
+    "s": "Elixir Bootlin (Zephyr)",
     "d": "elixir.bootlin.com",
     "t": "zxr",
     "u": "https://elixir.bootlin.com/zephyr/latest/ident/{{{s}}}",
@@ -90245,7 +90245,7 @@
     "sc": "Programming"
   },
   {
-    "s": "Zythom Blog (Kagi Search)",
+    "s": "Zythom Blog (Kagi)",
     "d": "kagi.com",
     "ad": "zythom.blogspot.com",
     "t": "zythom",
@@ -90310,7 +90310,7 @@
     "sc": "Learning"
   },
   {
-    "s": "викиновости",
+    "s": "Wikinews (Russian)",
     "d": "ru.wikinews.org",
     "t": "вн",
     "u": "https://ru.wikinews.org/wiki/Служебная:Поиск?search={{{s}}}",
@@ -90318,7 +90318,7 @@
     "sc": "Newspaper"
   },
   {
-    "s": "Google Ru",
+    "s": "Google (Russia)",
     "d": "google.com",
     "t": "г",
     "u": "https://google.com/search?hl=ru&q={{{s}}}",
@@ -90326,7 +90326,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Images Russian",
+    "s": "Google Images (Russia)",
     "d": "www.google.ru",
     "t": "гк",
     "u": "https://www.google.ru/search?q={{{s}}}&tbm=isch",
@@ -90334,7 +90334,7 @@
     "sc": "Google"
   },
   {
-    "s": "docs.cntd.ru",
+    "s": "CNTD",
     "d": "docs.cntd.ru",
     "t": "гост",
     "u": "https://docs.cntd.ru/search/intellectual?q={{{s}}}",
@@ -90350,7 +90350,7 @@
     "sc": "Online"
   },
   {
-    "s": "Google Maps BG",
+    "s": "Google Maps (Bulgaria)",
     "d": "www.google.bg",
     "t": "мапс",
     "u": "https://www.google.bg/maps/search/{{{s}}}/",
@@ -90374,7 +90374,7 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "Yandex Images",
+    "s": "Yandex (Images)",
     "d": "yandex.ru",
     "t": "yai",
     "ts": [
@@ -90418,7 +90418,7 @@
     "sc": "Books"
   },
   {
-    "s": "NixOS Packages Search",
+    "s": "NixOS (Packages)",
     "d": "search.nixos.org",
     "t": "nixpkgs",
     "u": "https://search.nixos.org/packages?query={{{s}}}",
@@ -90426,7 +90426,7 @@
     "sc": "Languages (nix)"
   },
   {
-    "s": "NixOS Options Search",
+    "s": "NixOS (Options)",
     "d": "search.nixos.org",
     "t": "nixopt",
     "u": "https://search.nixos.org/options?query={{{s}}}",
@@ -90567,7 +90567,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Russian Wikipedia",
+    "s": "Wikipedia (Russian)",
     "d": "ru.wikipedia.org",
     "t": "wru",
     "ts": [
@@ -90647,7 +90647,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Arabic Wikipedia",
+    "s": "Wikipedia (Arabic)",
     "d": "ar.wikipedia.org",
     "t": "war",
     "ts": [
@@ -92328,7 +92328,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Google de.Wikipedia",
+    "s": "Google (de.Wikipedia)",
     "d": "www.google.de",
     "ad": "de.wikipedia.org",
     "t": "gwpde",
@@ -92337,7 +92337,7 @@
     "sc": "Google"
   },
   {
-    "s": "Google Wikipedia",
+    "s": "Google (Wikipedia)",
     "d": "www.google.com",
     "ad": "wikipedia.org",
     "t": "gwp",
@@ -92362,7 +92362,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Wikipedia (BR)",
+    "s": "Wikipedia (PT)",
     "d": "pt.wikipedia.org",
     "t": "w.br",
     "u": "https://pt.wikipedia.org/wiki/{{{s}}}",
@@ -92410,7 +92410,7 @@
     "sc": "Learning"
   },
   {
-    "s": "Wikipedia in Japanese",
+    "s": "Wikipedia (Japan)",
     "d": "ja.wikipedia.org",
     "t": "wj",
     "u": "https://ja.wikipedia.org/wiki/{{{s}}}",
@@ -92458,7 +92458,7 @@
     "sc": "Learning (intl)"
   },
   {
-    "s": "Wikipedia – Friddje diehtosátnegirji",
+    "s": "Wikipedia (Northern Sami)",
     "d": "se.wikipedia.org",
     "t": "wse",
     "u": "https://se.wikipedia.org/w/index.php?search={{{s}}}",
@@ -92482,7 +92482,7 @@
     "sc": "Learning"
   },
   {
-    "s": "greek wikipedia",
+    "s": "Wikipedia (Greek)",
     "d": "el.wikipedia.org",
     "t": "ςγρ",
     "u": "https://el.wikipedia.org/wiki/?search={{{s}}}",
@@ -92509,7 +92509,7 @@
     "sc": "Docs"
   },
   {
-    "s": "Βικιπαίδεια",
+    "s": "Wikipedia (Greek, Mobile)",
     "d": "el.m.wikipedia.org",
     "t": "βικι",
     "u": "https://el.m.wikipedia.org/wiki/{{{s}}}",
@@ -92517,7 +92517,7 @@
     "sc": "Academic"
   },
   {
-    "s": "Wikipedia (BG)",
+    "s": "Wikipedia (Bulgarian)",
     "d": "bg.wikipedia.org",
     "t": "уики",
     "u": "https://bg.wikipedia.org/wiki/{{{s}}}",
@@ -92751,7 +92751,7 @@
     "sc": "Online"
   },
   {
-    "s": "Startech",
+    "s": "StarTech",
     "d": "www.startech.com",
     "t": "startech",
     "ts": [
@@ -92762,7 +92762,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Canada",
+    "s": "StarTech (Canada)",
     "d": "www.startech.com",
     "t": "startechca",
     "u": "https://www.startech.com/en-ca/search?search_term={{{s}}}",
@@ -92770,7 +92770,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech United Kingdom",
+    "s": "StarTech (UK)",
     "d": "www.startech.com",
     "t": "startechuk",
     "u": "https://www.startech.com/en-gb/search?search_term={{{s}}}",
@@ -92778,7 +92778,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Republic of Ireland",
+    "s": "StarTech (Ireland)",
     "d": "www.startech.com",
     "t": "startechie",
     "u": "https://www.startech.com/en-ie/search?search_term={{{s}}}",
@@ -92786,7 +92786,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Europe",
+    "s": "StarTech (Europe)",
     "d": "www.startech.com",
     "t": "startecheu",
     "u": "https://www.startech.com/en-eu/search?search_term={{{s}}}",
@@ -92794,7 +92794,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Australia",
+    "s": "StarTech (Australia)",
     "d": "www.startech.com",
     "t": "startechau",
     "u": "https://www.startech.com/en-au/search?search_term={{{s}}}",
@@ -92802,7 +92802,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Austria",
+    "s": "StarTech (Austria)",
     "d": "www.startech.com",
     "t": "startechat",
     "u": "https://www.startech.com/de-at/search?search_term={{{s}}}",
@@ -92810,7 +92810,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Belgium",
+    "s": "StarTech (Belgium)",
     "d": "www.startech.com",
     "t": "startechbe",
     "u": "https://www.startech.com/en-be/search?search_term={{{s}}}",
@@ -92818,7 +92818,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Chile",
+    "s": "StarTech (Chile)",
     "d": "www.startech.com",
     "t": "startechcl",
     "u": "https://www.startech.com/es-cl/search?search_term={{{s}}}",
@@ -92826,7 +92826,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Colombia",
+    "s": "StarTech (Colombia)",
     "d": "www.startech.com",
     "t": "startechco",
     "u": "https://www.startech.com/es-co/search?search_term={{{s}}}",
@@ -92834,7 +92834,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Denmark",
+    "s": "StarTech (Denmark)",
     "d": "www.startech.com",
     "t": "startechdk",
     "u": "https://www.startech.com/en-dk/search?search_term={{{s}}}",
@@ -92842,7 +92842,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Finland",
+    "s": "StarTech (Finland)",
     "d": "www.startech.com",
     "t": "startechfi",
     "u": "https://www.startech.com/en-fi/search?search_term={{{s}}}",
@@ -92850,7 +92850,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech France",
+    "s": "StarTech (France)",
     "d": "www.startech.com",
     "t": "startechfr",
     "u": "https://www.startech.com/fr-fr/search?search_term={{{s}}}",
@@ -92858,7 +92858,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Germany",
+    "s": "StarTech (Germany)",
     "d": "www.startech.com",
     "t": "startechde",
     "u": "https://www.startech.com/de-de/search?search_term={{{s}}}",
@@ -92866,7 +92866,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Italy",
+    "s": "StarTech (Italy)",
     "d": "www.startech.com",
     "t": "startechit",
     "u": "https://www.startech.com/it-it/search?search_term={{{s}}}",
@@ -92874,7 +92874,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Japan",
+    "s": "StarTech (Japan)",
     "d": "www.startech.com",
     "t": "startechjp",
     "u": "https://www.startech.com/ja-jp/search?search_term={{{s}}}",
@@ -92882,7 +92882,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Mexico",
+    "s": "StarTech (Mexico)",
     "d": "www.startech.com",
     "t": "startechmx",
     "u": "https://www.startech.com/es-mx/search?search_term={{{s}}}",
@@ -92890,7 +92890,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Netherlands",
+    "s": "StarTech (Netherlands)",
     "d": "www.startech.com",
     "t": "startechnl",
     "u": "https://www.startech.com/nl-nl/search?search_term={{{s}}}",
@@ -92898,7 +92898,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech New Zealand",
+    "s": "StarTech (New Zealand)",
     "d": "www.startech.com",
     "t": "startechnz",
     "u": "https://www.startech.com/en-nz/search?search_term={{{s}}}",
@@ -92906,7 +92906,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Peru",
+    "s": "StarTech (Peru)",
     "d": "www.startech.com",
     "t": "startechpe",
     "u": "https://www.startech.com/es-pe/search?search_term={{{s}}}",
@@ -92914,7 +92914,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Singapore",
+    "s": "StarTech (Singapore)",
     "d": "www.startech.com",
     "t": "startechsg",
     "u": "https://www.startech.com/en-sg/search?search_term={{{s}}}",
@@ -92922,7 +92922,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Spain",
+    "s": "StarTech (Spain)",
     "d": "www.startech.com",
     "t": "starteches",
     "u": "https://www.startech.com/es-es/search?search_term={{{s}}}",
@@ -92930,7 +92930,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Sweden",
+    "s": "StarTech (Sweden)",
     "d": "www.startech.com",
     "t": "startechse",
     "u": "https://www.startech.com/sv-se/search?search_term={{{s}}}",
@@ -92938,7 +92938,7 @@
     "sc": "Tech"
   },
   {
-    "s": "Startech Switzerland",
+    "s": "StarTech (Switzerland)",
     "d": "www.startech.com",
     "t": "startechch",
     "u": "https://www.startech.com/de-ch/search?search_term={{{s}}}",
@@ -92959,7 +92959,7 @@
     ]
   },
   {
-    "s": "Kagi Translate (discussions)",
+    "s": "Kagi Translate (Discussions)",
     "d": "translate.kagi.com",
     "t": "ktr",
     "u": "https://translate.kagi.com/$1/$2",
@@ -93024,7 +93024,7 @@
     ]
   },
   {
-    "s": "Kagi Knowledgebase - Search API",
+    "s": "Kagi Knowledgebase (API)",
     "d": "help.kagi.com",
     "t": "api",
     "u": "https://help.kagi.com/kagi/api/search.html#{{{s}}}"
@@ -93092,7 +93092,7 @@
     ]
   },
   {
-    "s": "Hugging Face Datasets",
+    "s": "Hugging Face (Datasets)",
     "d": "huggingface.co",
     "t": "hfd",
     "u": "https://huggingface.co/datasets?search={{{s}}}",
@@ -93100,7 +93100,7 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Hugging Face Models",
+    "s": "Hugging Face (Models)",
     "d": "huggingface.co",
     "t": "hfm",
     "u": "https://huggingface.co/models?search={{{s}}}",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -6557,7 +6557,7 @@
     "sc": "Reference (words)"
   },
   {
-    "s": "flightaware",
+    "s": "FlightAware (Airport)",
     "d": "flightaware.com",
     "t": "aware",
     "u": "https://flightaware.com/live/airport/{{{s}}}",
@@ -7192,7 +7192,7 @@
     "sc": "Learning"
   },
   {
-    "s": "cryotography.cc",
+    "s": "Cryptography.cc (Base64 Encode)",
     "d": "cryptography.cc",
     "t": "base64e",
     "u": "https://cryptography.cc/convert?text={{{s}}}&algorithm=base64encode",
@@ -15069,7 +15069,7 @@
     "sc": "General"
   },
   {
-    "s": "UK Companies House",
+    "s": "Companies House (UK, Companies)",
     "d": "beta.companieshouse.gov.uk",
     "t": "companieshouse",
     "u": "https://beta.companieshouse.gov.uk/search/companies?q={{{s}}}",
@@ -28106,7 +28106,7 @@
     "sc": "Social"
   },
   {
-    "s": "finviz.com",
+    "s": "Finviz (Search)",
     "d": "finviz.com",
     "t": "fin",
     "u": "https://finviz.com/search.ashx?p={{{s}}}",
@@ -31435,7 +31435,7 @@
     "sc": "Online"
   },
   {
-    "s": "geizhals.de",
+    "s": "Geizhals (Germany)",
     "d": "geizhals.de",
     "t": "geizhalsde",
     "u": "https://geizhals.de/?fs={{{s}}}&in=",
@@ -34616,7 +34616,7 @@
     "sc": "Online"
   },
   {
-    "s": "GrubHub",
+    "s": "Grubhub (Search)",
     "d": "www.grubhub.com",
     "t": "grubhub",
     "u": "https://www.grubhub.com/search?queryText={{{s}}}",
@@ -40791,7 +40791,7 @@
     "sc": "Reference"
   },
   {
-    "s": "infogalactic.com",
+    "s": "Infogalactic (Page)",
     "d": "infogalactic.com",
     "t": "infog",
     "u": "https://infogalactic.com/info/{{{s}}}",
@@ -44230,7 +44230,7 @@
     "sc": "Books"
   },
   {
-    "s": "Amazon Kindle (China)",
+    "s": "Amazon (Kindle, China)",
     "d": "www.amazon.cn",
     "t": "kindlecn",
     "u": "https://www.amazon.cn/s?k={{{s}}}&i=digital-text",
@@ -61914,7 +61914,7 @@
     "sc": "Tech"
   },
   {
-    "s": "pinboard.in",
+    "s": "Pinboard (All Bookmarks)",
     "d": "pinboard.in",
     "t": "pina",
     "u": "https://pinboard.in/search/?query={{{s}}}&all=Search+All",
@@ -68846,7 +68846,7 @@
     "sc": "Books"
   },
   {
-    "s": "Rate Your Music genre search",
+    "s": "Rate Your Music (Genre Search)",
     "d": "rateyourmusic.com",
     "t": "rymgenre",
     "u": "https://rateyourmusic.com/search?searchtype=g&searchterm={{{s}}}",
@@ -68878,7 +68878,7 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Rozetka.com.ua",
+    "s": "Rozetka (Ukrainian)",
     "d": "rozetka.com.ua",
     "t": "rztk",
     "u": "https://rozetka.com.ua/ua/search/?text={{{s}}}",
@@ -72502,7 +72502,7 @@
     "sc": "Games (Pokemon)"
   },
   {
-    "s": "Smogon University",
+    "s": "Smogon (Search)",
     "d": "www.smogon.com",
     "t": "smog",
     "u": "https://www.smogon.com/search/?q={{{s}}}",
@@ -77827,7 +77827,7 @@
     "sc": "Blogs"
   },
   {
-    "s": "thinkwiki.de",
+    "s": "ThinkWiki (German)",
     "d": "thinkwiki.de",
     "t": "thinkwikide",
     "u": "https://thinkwiki.de/index.php?search={{{s}}}",
@@ -84042,7 +84042,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "VTFC - vatefaireconjuguer.com",
+    "s": "Va te faire conjuguer (Conjugation)",
     "d": "www.vatefaireconjuguer.com",
     "t": "vtf",
     "u": "https://www.vatefaireconjuguer.com/conjugaison/verbe/{{{s}}}",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -25387,14 +25387,6 @@
     "sc": "Languages (javascript)"
   },
   {
-    "s": "duckduckgo",
-    "d": "duckduckgo.com",
-    "t": "ddg-es",
-    "u": "https://duckduckgo.com/?q={{{s}}}&kl=xl-es&kad=es_ES&ia=about",
-    "c": "Online Services",
-    "sc": "Search (non-US)"
-  },
-  {
     "s": "ESEA",
     "d": "play.esea.net",
     "t": "esea",
@@ -26082,22 +26074,6 @@
     "sc": "Music (Lyrics)"
   },
   {
-    "s": "EVE University Wiki",
-    "d": "wiki.eveuniversity.org",
-    "t": "eveu",
-    "u": "https://wiki.eveuniversity.org/w/index.php?title=Special:Search&search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (specific)"
-  },
-  {
-    "s": "Eve University Wiki",
-    "d": "wiki.eveuniversity.org",
-    "t": "eveuni",
-    "u": "https://wiki.eveuniversity.org/index.php?title=Special:Search&search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (general)"
-  },
-  {
     "s": "e-ville.com",
     "d": "www.e-ville.com",
     "t": "evillecom",
@@ -26575,17 +26551,6 @@
     "u": "https://mods.factorio.com/search?query={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
-  },
-  {
-    "s": "Film Affinity",
-    "d": "www.filmaffinity.com",
-    "t": "faff",
-    "ts": [
-      "fa"
-    ],
-    "u": "https://www.filmaffinity.com/es/search.php?stext={{{s}}}&stype=all",
-    "c": "Entertainment",
-    "sc": "Movies"
   },
   {
     "s": "FilmAffinity (Spanish, Advanced Search)",
@@ -33073,14 +33038,6 @@
     "u": "https://www.gme.cz/vysledky-vyhledavani?search_keyword={{{s}}}",
     "c": "Shopping",
     "sc": "Tech"
-  },
-  {
-    "s": "maps.google.com",
-    "d": "www.google.fr",
-    "t": "gmfr",
-    "u": "https://www.google.fr/maps/search/{{{s}}}",
-    "c": "Online Services",
-    "sc": "Maps"
   },
   {
     "s": "greenmangaming.com",
@@ -56816,14 +56773,6 @@
     ]
   },
   {
-    "s": "DuckDuckGo (safeoff)",
-    "d": "duckduckgo.com",
-    "t": "ns",
-    "u": "https://duckduckgo.com/?q=!safeoff+{{{s}}}",
-    "c": "Online Services",
-    "sc": "Search"
-  },
-  {
     "s": "National Stock Exchange of India",
     "d": "www.nseindia.com",
     "t": "nse",
@@ -72870,25 +72819,6 @@
     "sc": "Sports"
   },
   {
-    "s": "DuckDuckGo SafeOff",
-    "d": "duckduckgo.com",
-    "t": "soff",
-    "u": "https://duckduckgo.com/?kp=-2&q={{{s}}}",
-    "c": "Online Services",
-    "sc": "Search (DDG)"
-  },
-  {
-    "s": "DuckDuckGo Safe Search Off",
-    "d": "duckduckgo.com",
-    "t": "s-off",
-    "ts": [
-      "ssoff"
-    ],
-    "u": "https://duckduckgo.com/?q={{{s}}}&kp=-2",
-    "c": "Online Services",
-    "sc": "Search (DDG)"
-  },
-  {
     "s": "SOFIFA",
     "d": "sofifa.com",
     "t": "sofifa",
@@ -81634,14 +81564,6 @@
     "u": "https://ufind.univie.ac.at/en/search.html?query={{{s}}}",
     "c": "Research",
     "sc": "Academic"
-  },
-  {
-    "s": "UniWiki",
-    "d": "wiki.eveuniversity.org",
-    "t": "uniwiki",
-    "u": "https://wiki.eveuniversity.org/index.php?title=Special:Search&search={{{s}}}&button=",
-    "c": "Entertainment",
-    "sc": "Games (specific)"
   },
   {
     "s": "The Unix Tree",

--- a/data/kagi_bangs.json
+++ b/data/kagi_bangs.json
@@ -1,6 +1,6 @@
 [
   {
-    "s": "Kagi Search",
+    "s": "Kagi",
     "d": "kagi.com",
     "t": "k",
     "ts": [
@@ -48,7 +48,7 @@
     ]
   },
   {
-    "s": "Kagi Images",
+    "s": "Kagi (Images)",
     "d": "kagi.com",
     "t": "i",
     "ts": [
@@ -96,7 +96,7 @@
     ]
   },
   {
-    "s": "Kagi Search (verbatim)",
+    "s": "Kagi (Verbatim)",
     "d": "kagi.com",
     "t": "vrb",
     "ts": [
@@ -126,574 +126,574 @@
     ]
   },
   {
-    "s": "Search in International",
+    "s": "Kagi Search (International)",
     "d": "kagi.com",
     "t": "int",
     "u": "/search?q={{{s}}}&r=no_region",
     "c": "Region search"
   },
   {
-    "s": "Search in Antarctica",
+    "s": "Kagi Search (Antarctica)",
     "d": "kagi.com",
     "t": "aq",
     "u": "/search?q={{{s}}}&r=aq",
     "c": "Region search"
   },
   {
-    "s": "Search in Argentina",
+    "s": "Kagi Search (Argentina)",
     "d": "kagi.com",
     "t": "ar",
     "u": "/search?q={{{s}}}&r=ar",
     "c": "Region search"
   },
   {
-    "s": "Search in Australia",
+    "s": "Kagi Search (Australia)",
     "d": "kagi.com",
     "t": "au",
     "u": "/search?q={{{s}}}&r=au",
     "c": "Region search"
   },
   {
-    "s": "Search in Austria",
+    "s": "Kagi Search (Austria)",
     "d": "kagi.com",
     "t": "at",
     "u": "/search?q={{{s}}}&r=at",
     "c": "Region search"
   },
   {
-    "s": "Search in Belarus",
+    "s": "Kagi Search (Belarus)",
     "d": "kagi.com",
     "t": "by",
     "u": "/search?q={{{s}}}&r=by",
     "c": "Region search"
   },
   {
-    "s": "Search in Belgium (fr)",
+    "s": "Kagi Search (Belgium, French)",
     "d": "kagi.com",
     "t": "be_fr",
     "u": "/search?q={{{s}}}&r=be_fr",
     "c": "Region search"
   },
   {
-    "s": "Search in Belgium (nl)",
+    "s": "Kagi Search (Belgium, Dutch)",
     "d": "kagi.com",
     "t": "be",
     "u": "/search?q={{{s}}}&r=be",
     "c": "Region search"
   },
   {
-    "s": "Search in Belize",
+    "s": "Kagi Search (Belize)",
     "d": "kagi.com",
     "t": "bz",
     "u": "/search?q={{{s}}}&r=bz",
     "c": "Region search"
   },
   {
-    "s": "Search in Benin",
+    "s": "Kagi Search (Benin)",
     "d": "kagi.com",
     "t": "bj",
     "u": "/search?q={{{s}}}&r=bj",
     "c": "Region search"
   },
   {
-    "s": "Search in Brazil",
+    "s": "Kagi Search (Brazil)",
     "d": "kagi.com",
     "t": "br",
     "u": "/search?q={{{s}}}&r=br",
     "c": "Region search"
   },
   {
-    "s": "Search in British Indian Ocean Territory",
+    "s": "Kagi Search (British Indian Ocean Territory)",
     "d": "kagi.com",
     "t": "io",
     "u": "/search?q={{{s}}}&r=io",
     "c": "Region search"
   },
   {
-    "s": "Search in Cameroon",
+    "s": "Kagi Search (Cameroon)",
     "d": "kagi.com",
     "t": "cm",
     "u": "/search?q={{{s}}}&r=cm",
     "c": "Region search"
   },
   {
-    "s": "Search in Canada (en)",
+    "s": "Kagi Search (Canada, English)",
     "d": "kagi.com",
     "t": "ca",
     "u": "/search?q={{{s}}}&r=ca",
     "c": "Region search"
   },
   {
-    "s": "Search in Canada (fr)",
+    "s": "Kagi Search (Canada, French)",
     "d": "kagi.com",
     "t": "ca_fr",
     "u": "/search?q={{{s}}}&r=ca_fr",
     "c": "Region search"
   },
   {
-    "s": "Search in Cayman Islands",
+    "s": "Kagi Search (Cayman Islands)",
     "d": "kagi.com",
     "t": "ky",
     "u": "/search?q={{{s}}}&r=ky",
     "c": "Region search"
   },
   {
-    "s": "Search in Central African Republic",
+    "s": "Kagi Search (Central African Republic)",
     "d": "kagi.com",
     "t": "cf",
     "u": "/search?q={{{s}}}&r=cf",
     "c": "Region search"
   },
   {
-    "s": "Search in China",
+    "s": "Kagi Search (China)",
     "d": "kagi.com",
     "t": "cn",
     "u": "/search?q={{{s}}}&r=cn",
     "c": "Region search"
   },
   {
-    "s": "Search in Christmas Island",
+    "s": "Kagi Search (Christmas Island)",
     "d": "kagi.com",
     "t": "cx",
     "u": "/search?q={{{s}}}&r=cx",
     "c": "Region search"
   },
   {
-    "s": "Search in Colombia",
+    "s": "Kagi Search (Colombia)",
     "d": "kagi.com",
     "t": "co",
     "u": "/search?q={{{s}}}&r=co",
     "c": "Region search"
   },
   {
-    "s": "Search in Croatia",
+    "s": "Kagi Search (Croatia)",
     "d": "kagi.com",
     "t": "hr",
     "u": "/search?q={{{s}}}&r=hr",
     "c": "Region search"
   },
   {
-    "s": "Search in Cyprus",
+    "s": "Kagi Search (Cyprus)",
     "d": "kagi.com",
     "t": "cy",
     "u": "/search?q={{{s}}}&r=cy",
     "c": "Region search"
   },
   {
-    "s": "Search in Czechia",
+    "s": "Kagi Search (Czechia)",
     "d": "kagi.com",
     "t": "cz",
     "u": "/search?q={{{s}}}&r=cz",
     "c": "Region search"
   },
   {
-    "s": "Search in Denmark",
+    "s": "Kagi Search (Denmark)",
     "d": "kagi.com",
     "t": "dk",
     "u": "/search?q={{{s}}}&r=dk",
     "c": "Region search"
   },
   {
-    "s": "Search in El Salvador",
+    "s": "Kagi Search (El Salvador)",
     "d": "kagi.com",
     "t": "sv",
     "u": "/search?q={{{s}}}&r=sv",
     "c": "Region search"
   },
   {
-    "s": "Search in Estonia (ee)",
+    "s": "Kagi Search (Estonia)",
     "d": "kagi.com",
     "t": "ee",
     "u": "/search?q={{{s}}}&r=ee",
     "c": "Region search"
   },
   {
-    "s": "Search in Finland",
+    "s": "Kagi Search (Finland)",
     "d": "kagi.com",
     "t": "fi",
     "u": "/search?q={{{s}}}&r=fi",
     "c": "Region search"
   },
   {
-    "s": "Search in France",
+    "s": "Kagi Search (France)",
     "d": "kagi.com",
     "t": "fr",
     "u": "/search?q={{{s}}}&r=fr",
     "c": "Region search"
   },
   {
-    "s": "Search in Germany",
+    "s": "Kagi Search (Germany)",
     "d": "kagi.com",
     "t": "de",
     "u": "/search?q={{{s}}}&r=de",
     "c": "Region search"
   },
   {
-    "s": "Search in Hungary",
+    "s": "Kagi Search (Hungary)",
     "d": "kagi.com",
     "t": "hu",
     "u": "/search?q={{{s}}}&r=hu",
     "c": "Region search"
   },
   {
-    "s": "Search in India",
+    "s": "Kagi Search (India)",
     "d": "kagi.com",
     "t": "in",
     "u": "/search?q={{{s}}}&r=in",
     "c": "Region search"
   },
   {
-    "s": "Search in Indonesia",
+    "s": "Kagi Search (Indonesia)",
     "d": "kagi.com",
     "t": "id",
     "u": "/search?q={{{s}}}&r=id",
     "c": "Region search"
   },
   {
-    "s": "Search in Iran",
+    "s": "Kagi Search (Iran)",
     "d": "kagi.com",
     "t": "ir",
     "u": "/search?q={{{s}}}&r=ir",
     "c": "Region search"
   },
   {
-    "s": "Search in Iraq",
+    "s": "Kagi Search (Iraq)",
     "d": "kagi.com",
     "t": "iq",
     "u": "/search?q={{{s}}}&r=iq",
     "c": "Region search"
   },
   {
-    "s": "Search in Isle of Man",
+    "s": "Kagi Search (Isle of Man)",
     "d": "kagi.com",
     "t": "im",
     "u": "/search?q={{{s}}}&r=im",
     "c": "Region search"
   },
   {
-    "s": "Search in Israel",
+    "s": "Kagi Search (Israel)",
     "d": "kagi.com",
     "t": "il",
     "u": "/search?q={{{s}}}&r=il",
     "c": "Region search"
   },
   {
-    "s": "Search in Italy",
+    "s": "Kagi Search (Italy)",
     "d": "kagi.com",
     "t": "it",
     "u": "/search?q={{{s}}}&r=it",
     "c": "Region search"
   },
   {
-    "s": "Search in Japan",
+    "s": "Kagi Search (Japan)",
     "d": "kagi.com",
     "t": "jp",
     "u": "/search?q={{{s}}}&r=jp",
     "c": "Region search"
   },
   {
-    "s": "Search in Kazakhstan",
+    "s": "Kagi Search (Kazakhstan)",
     "d": "kagi.com",
     "t": "kz",
     "u": "/search?q={{{s}}}&r=kz",
     "c": "Region search"
   },
   {
-    "s": "Search in Kenya",
+    "s": "Kagi Search (Kenya)",
     "d": "kagi.com",
     "t": "ke",
     "u": "/search?q={{{s}}}&r=ke",
     "c": "Region search"
   },
   {
-    "s": "Search in Kosovo",
+    "s": "Kagi Search (Kosovo)",
     "d": "kagi.com",
     "t": "xk",
     "u": "/search?q={{{s}}}&r=xk",
     "c": "Region search"
   },
   {
-    "s": "Search in Kuwait",
+    "s": "Kagi Search (Kuwait)",
     "d": "kagi.com",
     "t": "kw",
     "u": "/search?q={{{s}}}&r=kw",
     "c": "Region search"
   },
   {
-    "s": "Search in Liberia",
+    "s": "Kagi Search (Liberia)",
     "d": "kagi.com",
     "t": "lr",
     "u": "/search?q={{{s}}}&r=lr",
     "c": "Region search"
   },
   {
-    "s": "Search in Libya",
+    "s": "Kagi Search (Libya)",
     "d": "kagi.com",
     "t": "ly",
     "u": "/search?q={{{s}}}&r=ly",
     "c": "Region search"
   },
   {
-    "s": "Search in Madagascar",
+    "s": "Kagi Search (Madagascar)",
     "d": "kagi.com",
     "t": "mg",
     "u": "/search?q={{{s}}}&r=mg",
     "c": "Region search"
   },
   {
-    "s": "Search in Malaysia",
+    "s": "Kagi Search (Malaysia)",
     "d": "kagi.com",
     "t": "my",
     "u": "/search?q={{{s}}}&r=my",
     "c": "Region search"
   },
   {
-    "s": "Search in Netherlands",
+    "s": "Kagi Search (Netherlands)",
     "d": "kagi.com",
     "t": "nl",
     "u": "/search?q={{{s}}}&r=nl",
     "c": "Region search"
   },
   {
-    "s": "Search in New Zealand",
+    "s": "Kagi Search (New Zealand)",
     "d": "kagi.com",
     "t": "nz",
     "u": "/search?q={{{s}}}&r=nz",
     "c": "Region search"
   },
   {
-    "s": "Search in Norway",
+    "s": "Kagi Search (Norway)",
     "d": "kagi.com",
     "t": "no",
     "u": "/search?q={{{s}}}&r=no",
     "c": "Region search"
   },
   {
-    "s": "Search in Oman",
+    "s": "Kagi Search (Oman)",
     "d": "kagi.com",
     "t": "om",
     "u": "/search?q={{{s}}}&r=om",
     "c": "Region search"
   },
   {
-    "s": "Search in Palau",
+    "s": "Kagi Search (Palau)",
     "d": "kagi.com",
     "t": "pw",
     "u": "/search?q={{{s}}}&r=pw",
     "c": "Region search"
   },
   {
-    "s": "Search in Poland",
+    "s": "Kagi Search (Poland)",
     "d": "kagi.com",
     "t": "pl",
     "u": "/search?q={{{s}}}&r=pl",
     "c": "Region search"
   },
   {
-    "s": "Search in Portugal",
+    "s": "Kagi Search (Portugal)",
     "d": "kagi.com",
     "t": "pt",
     "u": "/search?q={{{s}}}&r=pt",
     "c": "Region search"
   },
   {
-    "s": "Search in Qatar",
+    "s": "Kagi Search (Qatar)",
     "d": "kagi.com",
     "t": "qa",
     "u": "/search?q={{{s}}}&r=qa",
     "c": "Region search"
   },
   {
-    "s": "Search in Réunion",
+    "s": "Kagi Search (Réunion)",
     "d": "kagi.com",
     "t": "re",
     "u": "/search?q={{{s}}}&r=re",
     "c": "Region search"
   },
   {
-    "s": "Search in Serbia",
+    "s": "Kagi Search (Serbia)",
     "d": "kagi.com",
     "t": "rs",
     "u": "/search?q={{{s}}}&r=rs",
     "c": "Region search"
   },
   {
-    "s": "Search in Slovenia",
+    "s": "Kagi Search (Slovenia)",
     "d": "kagi.com",
     "t": "si",
     "u": "/search?q={{{s}}}&r=si",
     "c": "Region search"
   },
   {
-    "s": "Search in South Africa",
+    "s": "Kagi Search (South Africa)",
     "d": "kagi.com",
     "t": "za",
     "u": "/search?q={{{s}}}&r=za",
     "c": "Region search"
   },
   {
-    "s": "Search in South Korea",
+    "s": "Kagi Search (South Korea)",
     "d": "kagi.com",
     "t": "kr",
     "u": "/search?q={{{s}}}&r=kr",
     "c": "Region search"
   },
   {
-    "s": "Search in Spain (es)",
+    "s": "Kagi Search (Spain)",
     "d": "kagi.com",
     "t": "es",
     "u": "/search?q={{{s}}}&r=es",
     "c": "Region search"
   },
   {
-    "s": "Search in Span (ca)",
+    "s": "Kagi Search (Spain, Catalan)",
     "d": "kagi.com",
     "t": "es_ca",
     "u": "/search?q={{{s}}}&r=es_ca",
     "c": "Region search"
   },
   {
-    "s": "Search in Sweden",
+    "s": "Kagi Search (Sweden)",
     "d": "kagi.com",
     "t": "se",
     "u": "/search?q={{{s}}}&r=se",
     "c": "Region search"
   },
   {
-    "s": "Search in Switzerland (de)",
+    "s": "Kagi Search (Switzerland, German)",
     "d": "kagi.com",
     "t": "ch",
     "u": "/search?q={{{s}}}&r=ch",
     "c": "Region search"
   },
   {
-    "s": "Search in Switzerland (fr)",
+    "s": "Kagi Search (Switzerland, French)",
     "d": "kagi.com",
     "t": "ch_fr",
     "u": "/search?q={{{s}}}&r=ch_fr",
     "c": "Region search"
   },
   {
-    "s": "Search in Taiwan",
+    "s": "Kagi Search (Taiwan)",
     "d": "kagi.com",
     "t": "tw",
     "u": "/search?q={{{s}}}&r=tw",
     "c": "Region search"
   },
   {
-    "s": "Search in Thailand",
+    "s": "Kagi Search (Thailand)",
     "d": "kagi.com",
     "t": "th",
     "u": "/search?q={{{s}}}&r=th",
     "c": "Region search"
   },
   {
-    "s": "Search in Togo",
+    "s": "Kagi Search (Togo)",
     "d": "kagi.com",
     "t": "tg",
     "u": "/search?q={{{s}}}&r=tg",
     "c": "Region search"
   },
   {
-    "s": "Search in Tokelau",
+    "s": "Kagi Search (Tokelau)",
     "d": "kagi.com",
     "t": "tk",
     "u": "/search?q={{{s}}}&r=tk",
     "c": "Region search"
   },
   {
-    "s": "Search in Tonga",
+    "s": "Kagi Search (Tonga)",
     "d": "kagi.com",
     "t": "to",
     "u": "/search?q={{{s}}}&r=to",
     "c": "Region search"
   },
   {
-    "s": "Search in Turkey",
+    "s": "Kagi Search (Turkey)",
     "d": "kagi.com",
     "t": "tur",
     "u": "/search?q={{{s}}}&r=tr",
     "c": "Region search"
   },
   {
-    "s": "Search in U.S. Virgin Islands",
+    "s": "Kagi Search (US Virgin Islands)",
     "d": "kagi.com",
     "t": "vi",
     "u": "/search?q={{{s}}}&r=vi",
     "c": "Region search"
   },
   {
-    "s": "Search in Ukraine",
+    "s": "Kagi Search (Ukraine)",
     "d": "kagi.com",
     "t": "ua",
     "u": "/search?q={{{s}}}&r=ua",
     "c": "Region search"
   },
   {
-    "s": "Search in United Kingdom",
+    "s": "Kagi Search (United Kingdom)",
     "d": "kagi.com",
     "t": "gb",
     "u": "/search?q={{{s}}}&r=gb",
     "c": "Region search"
   },
   {
-    "s": "Search in United States",
+    "s": "Kagi Search (United States)",
     "d": "kagi.com",
     "t": "us",
     "u": "/search?q={{{s}}}&r=us",
     "c": "Region search"
   },
   {
-    "s": "Search in United States Minor Outlying Islands",
+    "s": "Kagi Search (US Minor Outlying Islands)",
     "d": "kagi.com",
     "t": "um",
     "u": "/search?q={{{s}}}&r=um",
     "c": "Region search"
   },
   {
-    "s": "Search in Uruguay",
+    "s": "Kagi Search (Uruguay)",
     "d": "kagi.com",
     "t": "uy",
     "u": "/search?q={{{s}}}&r=uy",
     "c": "Region search"
   },
   {
-    "s": "Search in Uzbekistan",
+    "s": "Kagi Search (Uzbekistan)",
     "d": "kagi.com",
     "t": "uz",
     "u": "/search?q={{{s}}}&r=uz",
     "c": "Region search"
   },
   {
-    "s": "Search in Vanuatu",
+    "s": "Kagi Search (Vanuatu)",
     "d": "kagi.com",
     "t": "vu",
     "u": "/search?q={{{s}}}&r=vu",
     "c": "Region search"
   },
   {
-    "s": "Search in Vietnam",
+    "s": "Kagi Search (Vietnam)",
     "d": "kagi.com",
     "t": "vn",
     "u": "/search?q={{{s}}}&r=vn",
     "c": "Region search"
   },
   {
-    "s": "Search in Yemen",
+    "s": "Kagi Search (Yemen)",
     "d": "kagi.com",
     "t": "ye",
     "u": "/search?q={{{s}}}&r=ye",
     "c": "Region search"
   },
   {
-    "s": "Search in Zambia",
+    "s": "Kagi Search (Zambia)",
     "d": "kagi.com",
     "t": "zm",
     "u": "/search?q={{{s}}}&r=zm",
     "c": "Region search"
   },
   {
-    "s": "Kagi (past day)",
+    "s": "Kagi (Past Day)",
     "d": "kagi.com",
     "t": "recent",
     "ts": [
@@ -703,19 +703,19 @@
     "u": "/search?q={{{s}}}&dr=1"
   },
   {
-    "s": "Kagi (past week)",
+    "s": "Kagi (Past Week)",
     "d": "kagi.com",
     "t": "week",
     "u": "/search?q={{{s}}}&dr=2"
   },
   {
-    "s": "Kagi (past month)",
+    "s": "Kagi (Past Month)",
     "d": "kagi.com",
     "t": "month",
     "u": "/search?q={{{s}}}&dr=3"
   },
   {
-    "s": "Kagi (past year)",
+    "s": "Kagi (Past Year)",
     "d": "kagi.com",
     "t": "year",
     "u": "/search?q={{{s}}}&dr=4"
@@ -730,7 +730,7 @@
     "u": "/search?q=calc+{{{s}}}"
   },
   {
-    "s": "Kagi (timer)",
+    "s": "Kagi (Timer)",
     "d": "kagi.com",
     "t": "tim",
     "ts": [
@@ -739,13 +739,13 @@
     "u": "/search?q=timer+{{{s}}}"
   },
   {
-    "s": "Region search",
+    "s": "Kagi Search (Region)",
     "d": "kagi.com",
     "t": "reg",
     "u": "/search?q={{{s}}}&r=detected"
   },
   {
-    "s": "PDFs",
+    "s": "Kagi (PDFs)",
     "d": "kagi.com",
     "t": "pdf",
     "u": "/search?q={{{s}}}+filetype:pdf",
@@ -753,7 +753,7 @@
     "sc": "Search"
   },
   {
-    "s": "News in International",
+    "s": "Kagi News (International)",
     "d": "kagi.com",
     "t": "knint",
     "u": "/news?q={{{s}}}&r=no_region",
@@ -762,7 +762,7 @@
     ]
   },
   {
-    "s": "News in Albania (AL)",
+    "s": "Kagi News (Albania)",
     "d": "kagi.com",
     "t": "knal",
     "u": "/news?q={{{s}}}&r=al",
@@ -771,7 +771,7 @@
     ]
   },
   {
-    "s": "News in Afghanistan (AF)",
+    "s": "Kagi News (Afghanistan)",
     "d": "kagi.com",
     "t": "knaf",
     "u": "/news?q={{{s}}}&r=af",
@@ -780,7 +780,7 @@
     ]
   },
   {
-    "s": "News in Algeria (DZ)",
+    "s": "Kagi News (Algeria)",
     "d": "kagi.com",
     "t": "kndz",
     "u": "/news?q={{{s}}}&r=dz",
@@ -789,7 +789,7 @@
     ]
   },
   {
-    "s": "News in American Samoa (AS)",
+    "s": "Kagi News (American Samoa)",
     "d": "kagi.com",
     "t": "knas",
     "u": "/news?q={{{s}}}&r=as",
@@ -798,7 +798,7 @@
     ]
   },
   {
-    "s": "News in Andorra (AD)",
+    "s": "Kagi News (Andorra)",
     "d": "kagi.com",
     "t": "knad",
     "u": "/news?q={{{s}}}&r=ad",
@@ -807,7 +807,7 @@
     ]
   },
   {
-    "s": "News in Angola (AO)",
+    "s": "Kagi News (Angola)",
     "d": "kagi.com",
     "t": "knao",
     "u": "/news?q={{{s}}}&r=ao",
@@ -816,7 +816,7 @@
     ]
   },
   {
-    "s": "News in Anguilla (AI)",
+    "s": "Kagi News (Anguilla)",
     "d": "kagi.com",
     "t": "knai",
     "u": "/news?q={{{s}}}&r=ai",
@@ -825,7 +825,7 @@
     ]
   },
   {
-    "s": "News in Antarctica (AQ)",
+    "s": "Kagi News (Antarctica)",
     "d": "kagi.com",
     "t": "knaq",
     "u": "/news?q={{{s}}}&r=aq",
@@ -834,7 +834,7 @@
     ]
   },
   {
-    "s": "News in Antigua and Barbuda (AG)",
+    "s": "Kagi News (Antigua and Barbuda)",
     "d": "kagi.com",
     "t": "knag",
     "u": "/news?q={{{s}}}&r=ag",
@@ -843,7 +843,7 @@
     ]
   },
   {
-    "s": "News in Argentina (AR)",
+    "s": "Kagi News (Argentina)",
     "d": "kagi.com",
     "t": "knar",
     "u": "/news?q={{{s}}}&r=ar",
@@ -852,7 +852,7 @@
     ]
   },
   {
-    "s": "News in Armenia (AM)",
+    "s": "Kagi News (Armenia)",
     "d": "kagi.com",
     "t": "knam",
     "u": "/news?q={{{s}}}&r=am",
@@ -861,7 +861,7 @@
     ]
   },
   {
-    "s": "News in Aruba (AW)",
+    "s": "Kagi News (Aruba)",
     "d": "kagi.com",
     "t": "knaw",
     "u": "/news?q={{{s}}}&r=aw",
@@ -870,7 +870,7 @@
     ]
   },
   {
-    "s": "News in Ascension Island (AC)",
+    "s": "Kagi News (Ascension Island)",
     "d": "kagi.com",
     "t": "knac",
     "u": "/news?q={{{s}}}&r=ac",
@@ -879,7 +879,7 @@
     ]
   },
   {
-    "s": "News in Australia (AU)",
+    "s": "Kagi News (Australia)",
     "d": "kagi.com",
     "t": "knau",
     "u": "/news?q={{{s}}}&r=au",
@@ -888,7 +888,7 @@
     ]
   },
   {
-    "s": "News in Austria (AT)",
+    "s": "Kagi News (Austria)",
     "d": "kagi.com",
     "t": "knat",
     "u": "/news?q={{{s}}}&r=at",
@@ -897,7 +897,7 @@
     ]
   },
   {
-    "s": "News in Azerbaijan (AZ)",
+    "s": "Kagi News (Azerbaijan)",
     "d": "kagi.com",
     "t": "knaz",
     "u": "/news?q={{{s}}}&r=az",
@@ -906,7 +906,7 @@
     ]
   },
   {
-    "s": "News in Bahamas (BS)",
+    "s": "Kagi News (Bahamas)",
     "d": "kagi.com",
     "t": "knbs",
     "u": "/news?q={{{s}}}&r=bs",
@@ -915,7 +915,7 @@
     ]
   },
   {
-    "s": "News in Bahrain (BH)",
+    "s": "Kagi News (Bahrain)",
     "d": "kagi.com",
     "t": "knbh",
     "u": "/news?q={{{s}}}&r=bh",
@@ -924,7 +924,7 @@
     ]
   },
   {
-    "s": "News in Bangladesh (BD)",
+    "s": "Kagi News (Bangladesh)",
     "d": "kagi.com",
     "t": "knbd",
     "u": "/news?q={{{s}}}&r=bd",
@@ -933,7 +933,7 @@
     ]
   },
   {
-    "s": "News in Barbados (BB)",
+    "s": "Kagi News (Barbados)",
     "d": "kagi.com",
     "t": "knbb",
     "u": "/news?q={{{s}}}&r=bb",
@@ -942,7 +942,7 @@
     ]
   },
   {
-    "s": "News in Belarus (BY)",
+    "s": "Kagi News (Belarus)",
     "d": "kagi.com",
     "t": "knby",
     "u": "/news?q={{{s}}}&r=by",
@@ -951,7 +951,7 @@
     ]
   },
   {
-    "s": "News in Belgium (BE - nl)",
+    "s": "Kagi News (Belgium, Dutch)",
     "d": "kagi.com",
     "t": "knbe",
     "u": "/news?q={{{s}}}&r=be",
@@ -960,7 +960,7 @@
     ]
   },
   {
-    "s": "News in Belgium (BE - fr)",
+    "s": "Kagi News (Belgium, French)",
     "d": "kagi.com",
     "t": "knbe_fr",
     "u": "/news?q={{{s}}}&r=be_fr",
@@ -969,7 +969,7 @@
     ]
   },
   {
-    "s": "News in Belize (BZ)",
+    "s": "Kagi News (Belize)",
     "d": "kagi.com",
     "t": "knbz",
     "u": "/news?q={{{s}}}&r=bz",
@@ -978,7 +978,7 @@
     ]
   },
   {
-    "s": "News in Benin (BJ)",
+    "s": "Kagi News (Benin)",
     "d": "kagi.com",
     "t": "knbj",
     "u": "/news?q={{{s}}}&r=bj",
@@ -987,7 +987,7 @@
     ]
   },
   {
-    "s": "News in Bermuda (BM)",
+    "s": "Kagi News (Bermuda)",
     "d": "kagi.com",
     "t": "knbm",
     "u": "/news?q={{{s}}}&r=bm",
@@ -996,7 +996,7 @@
     ]
   },
   {
-    "s": "News in Bhutan (BT)",
+    "s": "Kagi News (Bhutan)",
     "d": "kagi.com",
     "t": "knbt",
     "u": "/news?q={{{s}}}&r=bt",
@@ -1005,7 +1005,7 @@
     ]
   },
   {
-    "s": "News in Bolivia (BO)",
+    "s": "Kagi News (Bolivia)",
     "d": "kagi.com",
     "t": "knbo",
     "u": "/news?q={{{s}}}&r=bo",
@@ -1014,7 +1014,7 @@
     ]
   },
   {
-    "s": "News in Bonaire, Sint Eustatius and Saba (BQ)",
+    "s": "Kagi News (Bonaire, Sint Eustatius and Saba)",
     "d": "kagi.com",
     "t": "knbq",
     "u": "/news?q={{{s}}}&r=bq",
@@ -1023,7 +1023,7 @@
     ]
   },
   {
-    "s": "News in Bosnia and Herzegovina (BA)",
+    "s": "Kagi News (Bosnia and Herzegovina)",
     "d": "kagi.com",
     "t": "knba",
     "u": "/news?q={{{s}}}&r=ba",
@@ -1032,7 +1032,7 @@
     ]
   },
   {
-    "s": "News in Botswana (BW)",
+    "s": "Kagi News (Botswana)",
     "d": "kagi.com",
     "t": "knbw",
     "u": "/news?q={{{s}}}&r=bw",
@@ -1041,7 +1041,7 @@
     ]
   },
   {
-    "s": "News in Bouvet Island (BV)",
+    "s": "Kagi News (Bouvet Island)",
     "d": "kagi.com",
     "t": "knbv",
     "u": "/news?q={{{s}}}&r=bv",
@@ -1050,7 +1050,7 @@
     ]
   },
   {
-    "s": "News in Brazil (BR)",
+    "s": "Kagi News (Brazil)",
     "d": "kagi.com",
     "t": "knbr",
     "u": "/news?q={{{s}}}&r=br",
@@ -1059,7 +1059,7 @@
     ]
   },
   {
-    "s": "News in British Indian Ocean Territory (IO)",
+    "s": "Kagi News (British Indian Ocean Territory)",
     "d": "kagi.com",
     "t": "knio",
     "u": "/news?q={{{s}}}&r=io",
@@ -1068,7 +1068,7 @@
     ]
   },
   {
-    "s": "News in British Virgin Islands (VG)",
+    "s": "Kagi News (British Virgin Islands)",
     "d": "kagi.com",
     "t": "knvg",
     "u": "/news?q={{{s}}}&r=vg",
@@ -1077,7 +1077,7 @@
     ]
   },
   {
-    "s": "News in Brunei (BN)",
+    "s": "Kagi News (Brunei)",
     "d": "kagi.com",
     "t": "knbn",
     "u": "/news?q={{{s}}}&r=bn",
@@ -1086,7 +1086,7 @@
     ]
   },
   {
-    "s": "News in Bulgaria (BG)",
+    "s": "Kagi News (Bulgaria)",
     "d": "kagi.com",
     "t": "knbg",
     "u": "/news?q={{{s}}}&r=bg",
@@ -1095,7 +1095,7 @@
     ]
   },
   {
-    "s": "News in Burkina Faso (BF)",
+    "s": "Kagi News (Burkina Faso)",
     "d": "kagi.com",
     "t": "knbf",
     "u": "/news?q={{{s}}}&r=bf",
@@ -1104,7 +1104,7 @@
     ]
   },
   {
-    "s": "News in Burundi (BI)",
+    "s": "Kagi News (Burundi)",
     "d": "kagi.com",
     "t": "knbi",
     "u": "/news?q={{{s}}}&r=bi",
@@ -1113,7 +1113,7 @@
     ]
   },
   {
-    "s": "News in Cabo Verde (CV)",
+    "s": "Kagi News (Cabo Verde)",
     "d": "kagi.com",
     "t": "kncv",
     "u": "/news?q={{{s}}}&r=cv",
@@ -1122,7 +1122,7 @@
     ]
   },
   {
-    "s": "News in Cambodia (KH)",
+    "s": "Kagi News (Cambodia)",
     "d": "kagi.com",
     "t": "knkh",
     "u": "/news?q={{{s}}}&r=kh",
@@ -1131,7 +1131,7 @@
     ]
   },
   {
-    "s": "News in Cameroon (CM)",
+    "s": "Kagi News (Cameroon)",
     "d": "kagi.com",
     "t": "kncm",
     "u": "/news?q={{{s}}}&r=cm",
@@ -1140,7 +1140,7 @@
     ]
   },
   {
-    "s": "News in Canada (CA - en)",
+    "s": "Kagi News (Canada, English)",
     "d": "kagi.com",
     "t": "knca",
     "u": "/news?q={{{s}}}&r=ca",
@@ -1149,7 +1149,7 @@
     ]
   },
   {
-    "s": "News in Canada (CA - fr)",
+    "s": "Kagi News (Canada, French)",
     "d": "kagi.com",
     "t": "knca_fr",
     "u": "/news?q={{{s}}}&r=ca_fr",
@@ -1158,7 +1158,7 @@
     ]
   },
   {
-    "s": "News in Cayman Islands (KY)",
+    "s": "Kagi News (Cayman Islands)",
     "d": "kagi.com",
     "t": "knky",
     "u": "/news?q={{{s}}}&r=ky",
@@ -1167,7 +1167,7 @@
     ]
   },
   {
-    "s": "News in Central African Republic (CF)",
+    "s": "Kagi News (Central African Republic)",
     "d": "kagi.com",
     "t": "kncf",
     "u": "/news?q={{{s}}}&r=cf",
@@ -1176,7 +1176,7 @@
     ]
   },
   {
-    "s": "News in Chad (TD)",
+    "s": "Kagi News (Chad)",
     "d": "kagi.com",
     "t": "kntd",
     "u": "/news?q={{{s}}}&r=td",
@@ -1185,7 +1185,7 @@
     ]
   },
   {
-    "s": "News in Chile (CL)",
+    "s": "Kagi News (Chile)",
     "d": "kagi.com",
     "t": "kncl",
     "u": "/news?q={{{s}}}&r=cl",
@@ -1194,7 +1194,7 @@
     ]
   },
   {
-    "s": "News in China (CN)",
+    "s": "Kagi News (China)",
     "d": "kagi.com",
     "t": "kncn",
     "u": "/news?q={{{s}}}&r=cn",
@@ -1203,7 +1203,7 @@
     ]
   },
   {
-    "s": "News in Christmas Island (CX)",
+    "s": "Kagi News (Christmas Island)",
     "d": "kagi.com",
     "t": "kncx",
     "u": "/news?q={{{s}}}&r=cx",
@@ -1212,7 +1212,7 @@
     ]
   },
   {
-    "s": "News in Cocos (Keeling) Islands (CC)",
+    "s": "Kagi News (Cocos Keeling Islands)",
     "d": "kagi.com",
     "t": "kncc",
     "u": "/news?q={{{s}}}&r=cc",
@@ -1221,7 +1221,7 @@
     ]
   },
   {
-    "s": "News in Colombia (CO)",
+    "s": "Kagi News (Colombia)",
     "d": "kagi.com",
     "t": "knco",
     "u": "/news?q={{{s}}}&r=co",
@@ -1230,7 +1230,7 @@
     ]
   },
   {
-    "s": "News in Comoros (KM)",
+    "s": "Kagi News (Comoros)",
     "d": "kagi.com",
     "t": "knkm",
     "u": "/news?q={{{s}}}&r=km",
@@ -1239,7 +1239,7 @@
     ]
   },
   {
-    "s": "News in Congo (CG)",
+    "s": "Kagi News (Congo)",
     "d": "kagi.com",
     "t": "kncg",
     "u": "/news?q={{{s}}}&r=cg",
@@ -1248,7 +1248,7 @@
     ]
   },
   {
-    "s": "News in Congo, Democratic Republic of the (CD)",
+    "s": "Kagi News (Democratic Republic of the Congo)",
     "d": "kagi.com",
     "t": "kncd",
     "u": "/news?q={{{s}}}&r=cd",
@@ -1257,7 +1257,7 @@
     ]
   },
   {
-    "s": "News in Cook Islands (CK)",
+    "s": "Kagi News (Cook Islands)",
     "d": "kagi.com",
     "t": "knck",
     "u": "/news?q={{{s}}}&r=ck",
@@ -1266,7 +1266,7 @@
     ]
   },
   {
-    "s": "News in Costa Rica (CR)",
+    "s": "Kagi News (Costa Rica)",
     "d": "kagi.com",
     "t": "kncr",
     "u": "/news?q={{{s}}}&r=cr",
@@ -1275,7 +1275,7 @@
     ]
   },
   {
-    "s": "News in Croatia (HR)",
+    "s": "Kagi News (Croatia)",
     "d": "kagi.com",
     "t": "knhr",
     "u": "/news?q={{{s}}}&r=hr",
@@ -1284,7 +1284,7 @@
     ]
   },
   {
-    "s": "News in Cuba (CU)",
+    "s": "Kagi News (Cuba)",
     "d": "kagi.com",
     "t": "kncu",
     "u": "/news?q={{{s}}}&r=cu",
@@ -1293,7 +1293,7 @@
     ]
   },
   {
-    "s": "News in Curaçao (CW)",
+    "s": "Kagi News (Curacao)",
     "d": "kagi.com",
     "t": "kncw",
     "u": "/news?q={{{s}}}&r=cw",
@@ -1302,7 +1302,7 @@
     ]
   },
   {
-    "s": "News in Cyprus (CY)",
+    "s": "Kagi News (Cyprus)",
     "d": "kagi.com",
     "t": "kncy",
     "u": "/news?q={{{s}}}&r=cy",
@@ -1311,7 +1311,7 @@
     ]
   },
   {
-    "s": "News in Czechia (CZ)",
+    "s": "Kagi News (Czechia)",
     "d": "kagi.com",
     "t": "kncz",
     "u": "/news?q={{{s}}}&r=cz",
@@ -1320,7 +1320,7 @@
     ]
   },
   {
-    "s": "News in Côte d'Ivoire (CI)",
+    "s": "Kagi News (Cote d'Ivoire)",
     "d": "kagi.com",
     "t": "knci",
     "u": "/news?q={{{s}}}&r=ci",
@@ -1329,7 +1329,7 @@
     ]
   },
   {
-    "s": "News in Denmark (DK)",
+    "s": "Kagi News (Denmark)",
     "d": "kagi.com",
     "t": "kndk",
     "u": "/news?q={{{s}}}&r=dk",
@@ -1338,7 +1338,7 @@
     ]
   },
   {
-    "s": "News in Djibouti (DJ)",
+    "s": "Kagi News (Djibouti)",
     "d": "kagi.com",
     "t": "kndj",
     "u": "/news?q={{{s}}}&r=dj",
@@ -1347,7 +1347,7 @@
     ]
   },
   {
-    "s": "News in Dominica (DM)",
+    "s": "Kagi News (Dominica)",
     "d": "kagi.com",
     "t": "kndm",
     "u": "/news?q={{{s}}}&r=dm",
@@ -1356,7 +1356,7 @@
     ]
   },
   {
-    "s": "News in Dominican Republic (DO)",
+    "s": "Kagi News (Dominican Republic)",
     "d": "kagi.com",
     "t": "kndo",
     "u": "/news?q={{{s}}}&r=do",
@@ -1365,7 +1365,7 @@
     ]
   },
   {
-    "s": "News in Ecuador (EC)",
+    "s": "Kagi News (Ecuador)",
     "d": "kagi.com",
     "t": "knec",
     "u": "/news?q={{{s}}}&r=ec",
@@ -1374,7 +1374,7 @@
     ]
   },
   {
-    "s": "News in Egypt (EG)",
+    "s": "Kagi News (Egypt)",
     "d": "kagi.com",
     "t": "kneg",
     "u": "/news?q={{{s}}}&r=eg",
@@ -1383,7 +1383,7 @@
     ]
   },
   {
-    "s": "News in El Salvador (SV)",
+    "s": "Kagi News (El Salvador)",
     "d": "kagi.com",
     "t": "knsv",
     "u": "/news?q={{{s}}}&r=sv",
@@ -1392,7 +1392,7 @@
     ]
   },
   {
-    "s": "News in Equatorial Guinea (GQ)",
+    "s": "Kagi News (Equatorial Guinea)",
     "d": "kagi.com",
     "t": "kngq",
     "u": "/news?q={{{s}}}&r=gq",
@@ -1401,7 +1401,7 @@
     ]
   },
   {
-    "s": "News in Eritrea (ER)",
+    "s": "Kagi News (Eritrea)",
     "d": "kagi.com",
     "t": "kner",
     "u": "/news?q={{{s}}}&r=er",
@@ -1410,7 +1410,7 @@
     ]
   },
   {
-    "s": "News in Estonia (EE)",
+    "s": "Kagi News (Estonia)",
     "d": "kagi.com",
     "t": "knee",
     "u": "/news?q={{{s}}}&r=ee",
@@ -1419,7 +1419,7 @@
     ]
   },
   {
-    "s": "News in Eswatini (SZ)",
+    "s": "Kagi News (Eswatini)",
     "d": "kagi.com",
     "t": "knsz",
     "u": "/news?q={{{s}}}&r=sz",
@@ -1428,7 +1428,7 @@
     ]
   },
   {
-    "s": "News in Ethiopia (ET)",
+    "s": "Kagi News (Ethiopia)",
     "d": "kagi.com",
     "t": "knet",
     "u": "/news?q={{{s}}}&r=et",
@@ -1437,7 +1437,7 @@
     ]
   },
   {
-    "s": "News in Falkland Islands (FK)",
+    "s": "Kagi News (Falkland Islands)",
     "d": "kagi.com",
     "t": "knfk",
     "u": "/news?q={{{s}}}&r=fk",
@@ -1446,7 +1446,7 @@
     ]
   },
   {
-    "s": "News in Faroe Islands (FO)",
+    "s": "Kagi News (Faroe Islands)",
     "d": "kagi.com",
     "t": "knfo",
     "u": "/news?q={{{s}}}&r=fo",
@@ -1455,7 +1455,7 @@
     ]
   },
   {
-    "s": "News in Fiji (FJ)",
+    "s": "Kagi News (Fiji)",
     "d": "kagi.com",
     "t": "knfj",
     "u": "/news?q={{{s}}}&r=fj",
@@ -1464,7 +1464,7 @@
     ]
   },
   {
-    "s": "News in Finland (FI)",
+    "s": "Kagi News (Finland)",
     "d": "kagi.com",
     "t": "knfi",
     "u": "/news?q={{{s}}}&r=fi",
@@ -1473,7 +1473,7 @@
     ]
   },
   {
-    "s": "News in France (FR)",
+    "s": "Kagi News (France)",
     "d": "kagi.com",
     "t": "knfr",
     "u": "/news?q={{{s}}}&r=fr",
@@ -1482,7 +1482,7 @@
     ]
   },
   {
-    "s": "News in French Guiana (GF)",
+    "s": "Kagi News (French Guiana)",
     "d": "kagi.com",
     "t": "kngf",
     "u": "/news?q={{{s}}}&r=gf",
@@ -1491,7 +1491,7 @@
     ]
   },
   {
-    "s": "News in French Polynesia (PF)",
+    "s": "Kagi News (French Polynesia)",
     "d": "kagi.com",
     "t": "knpf",
     "u": "/news?q={{{s}}}&r=pf",
@@ -1500,7 +1500,7 @@
     ]
   },
   {
-    "s": "News in French Southern Territories (TF)",
+    "s": "Kagi News (French Southern Territories)",
     "d": "kagi.com",
     "t": "kntf",
     "u": "/news?q={{{s}}}&r=tf",
@@ -1509,7 +1509,7 @@
     ]
   },
   {
-    "s": "News in Gabon (GA)",
+    "s": "Kagi News (Gabon)",
     "d": "kagi.com",
     "t": "knga",
     "u": "/news?q={{{s}}}&r=ga",
@@ -1518,7 +1518,7 @@
     ]
   },
   {
-    "s": "News in Gambia (GM)",
+    "s": "Kagi News (Gambia)",
     "d": "kagi.com",
     "t": "kngm",
     "u": "/news?q={{{s}}}&r=gm",
@@ -1527,7 +1527,7 @@
     ]
   },
   {
-    "s": "News in Georgia (GE)",
+    "s": "Kagi News (Georgia)",
     "d": "kagi.com",
     "t": "knge",
     "u": "/news?q={{{s}}}&r=ge",
@@ -1536,7 +1536,7 @@
     ]
   },
   {
-    "s": "News in Germany (DE)",
+    "s": "Kagi News (Germany)",
     "d": "kagi.com",
     "t": "knde",
     "u": "/news?q={{{s}}}&r=de",
@@ -1545,7 +1545,7 @@
     ]
   },
   {
-    "s": "News in Ghana (GH)",
+    "s": "Kagi News (Ghana)",
     "d": "kagi.com",
     "t": "kngh",
     "u": "/news?q={{{s}}}&r=gh",
@@ -1554,7 +1554,7 @@
     ]
   },
   {
-    "s": "News in Gibraltar (GI)",
+    "s": "Kagi News (Gibraltar)",
     "d": "kagi.com",
     "t": "kngi",
     "u": "/news?q={{{s}}}&r=gi",
@@ -1563,7 +1563,7 @@
     ]
   },
   {
-    "s": "News in Greece (GR)",
+    "s": "Kagi News (Greece)",
     "d": "kagi.com",
     "t": "kngr",
     "u": "/news?q={{{s}}}&r=gr",
@@ -1572,7 +1572,7 @@
     ]
   },
   {
-    "s": "News in Greenland (GL)",
+    "s": "Kagi News (Greenland)",
     "d": "kagi.com",
     "t": "kngl",
     "u": "/news?q={{{s}}}&r=gl",
@@ -1581,7 +1581,7 @@
     ]
   },
   {
-    "s": "News in Grenada (GD)",
+    "s": "Kagi News (Grenada)",
     "d": "kagi.com",
     "t": "kngd",
     "u": "/news?q={{{s}}}&r=gd",
@@ -1590,7 +1590,7 @@
     ]
   },
   {
-    "s": "News in Guadeloupe (GP)",
+    "s": "Kagi News (Guadeloupe)",
     "d": "kagi.com",
     "t": "kngp",
     "u": "/news?q={{{s}}}&r=gp",
@@ -1599,7 +1599,7 @@
     ]
   },
   {
-    "s": "News in Guam (GU)",
+    "s": "Kagi News (Guam)",
     "d": "kagi.com",
     "t": "kngu",
     "u": "/news?q={{{s}}}&r=gu",
@@ -1608,7 +1608,7 @@
     ]
   },
   {
-    "s": "News in Guatemala (GT)",
+    "s": "Kagi News (Guatemala)",
     "d": "kagi.com",
     "t": "kngt",
     "u": "/news?q={{{s}}}&r=gt",
@@ -1617,7 +1617,7 @@
     ]
   },
   {
-    "s": "News in Guernsey (GG)",
+    "s": "Kagi News (Guernsey)",
     "d": "kagi.com",
     "t": "kngg",
     "u": "/news?q={{{s}}}&r=gg",
@@ -1626,7 +1626,7 @@
     ]
   },
   {
-    "s": "News in Guinea (GN)",
+    "s": "Kagi News (Guinea)",
     "d": "kagi.com",
     "t": "kngn",
     "u": "/news?q={{{s}}}&r=gn",
@@ -1635,7 +1635,7 @@
     ]
   },
   {
-    "s": "News in Guinea-Bissau (GW)",
+    "s": "Kagi News (Guinea-Bissau)",
     "d": "kagi.com",
     "t": "kngw",
     "u": "/news?q={{{s}}}&r=gw",
@@ -1644,7 +1644,7 @@
     ]
   },
   {
-    "s": "News in Guyana (GY)",
+    "s": "Kagi News (Guyana)",
     "d": "kagi.com",
     "t": "kngy",
     "u": "/news?q={{{s}}}&r=gy",
@@ -1653,7 +1653,7 @@
     ]
   },
   {
-    "s": "News in Haiti (HT)",
+    "s": "Kagi News (Haiti)",
     "d": "kagi.com",
     "t": "knht",
     "u": "/news?q={{{s}}}&r=ht",
@@ -1662,7 +1662,7 @@
     ]
   },
   {
-    "s": "News in Heard Island and McDonald Islands (HM)",
+    "s": "Kagi News (Heard Island and McDonald Islands)",
     "d": "kagi.com",
     "t": "knhm",
     "u": "/news?q={{{s}}}&r=hm",
@@ -1671,7 +1671,7 @@
     ]
   },
   {
-    "s": "News in Honduras (HN)",
+    "s": "Kagi News (Honduras)",
     "d": "kagi.com",
     "t": "knhn",
     "u": "/news?q={{{s}}}&r=hn",
@@ -1680,7 +1680,7 @@
     ]
   },
   {
-    "s": "News in Hong Kong (HK)",
+    "s": "Kagi News (Hong Kong)",
     "d": "kagi.com",
     "t": "knhk",
     "u": "/news?q={{{s}}}&r=hk",
@@ -1689,7 +1689,7 @@
     ]
   },
   {
-    "s": "News in Hungary (HU)",
+    "s": "Kagi News (Hungary)",
     "d": "kagi.com",
     "t": "knhu",
     "u": "/news?q={{{s}}}&r=hu",
@@ -1698,7 +1698,7 @@
     ]
   },
   {
-    "s": "News in Iceland (IS)",
+    "s": "Kagi News (Iceland)",
     "d": "kagi.com",
     "t": "knis",
     "u": "/news?q={{{s}}}&r=is",
@@ -1707,7 +1707,7 @@
     ]
   },
   {
-    "s": "News in India (IN)",
+    "s": "Kagi News (India)",
     "d": "kagi.com",
     "t": "knin",
     "u": "/news?q={{{s}}}&r=in",
@@ -1716,7 +1716,7 @@
     ]
   },
   {
-    "s": "News in Indonesia (ID)",
+    "s": "Kagi News (Indonesia)",
     "d": "kagi.com",
     "t": "knid",
     "u": "/news?q={{{s}}}&r=id",
@@ -1725,7 +1725,7 @@
     ]
   },
   {
-    "s": "News in Iran (IR)",
+    "s": "Kagi News (Iran)",
     "d": "kagi.com",
     "t": "knir",
     "u": "/news?q={{{s}}}&r=ir",
@@ -1734,7 +1734,7 @@
     ]
   },
   {
-    "s": "News in Iraq (IQ)",
+    "s": "Kagi News (Iraq)",
     "d": "kagi.com",
     "t": "kniq",
     "u": "/news?q={{{s}}}&r=iq",
@@ -1743,7 +1743,7 @@
     ]
   },
   {
-    "s": "News in Ireland (IE)",
+    "s": "Kagi News (Ireland)",
     "d": "kagi.com",
     "t": "knie",
     "u": "/news?q={{{s}}}&r=ie",
@@ -1752,7 +1752,7 @@
     ]
   },
   {
-    "s": "News in Isle of Man (IM)",
+    "s": "Kagi News (Isle of Man)",
     "d": "kagi.com",
     "t": "knim",
     "u": "/news?q={{{s}}}&r=im",
@@ -1761,7 +1761,7 @@
     ]
   },
   {
-    "s": "News in Israel (IL)",
+    "s": "Kagi News (Israel)",
     "d": "kagi.com",
     "t": "knil",
     "u": "/news?q={{{s}}}&r=il",
@@ -1770,7 +1770,7 @@
     ]
   },
   {
-    "s": "News in Italy (IT)",
+    "s": "Kagi News (Italy)",
     "d": "kagi.com",
     "t": "knit",
     "u": "/news?q={{{s}}}&r=it",
@@ -1779,7 +1779,7 @@
     ]
   },
   {
-    "s": "News in Jamaica (JM)",
+    "s": "Kagi News (Jamaica)",
     "d": "kagi.com",
     "t": "knjm",
     "u": "/news?q={{{s}}}&r=jm",
@@ -1788,7 +1788,7 @@
     ]
   },
   {
-    "s": "News in Japan (JP)",
+    "s": "Kagi News (Japan)",
     "d": "kagi.com",
     "t": "knjp",
     "u": "/news?q={{{s}}}&r=jp",
@@ -1797,7 +1797,7 @@
     ]
   },
   {
-    "s": "News in Jersey (JE)",
+    "s": "Kagi News (Jersey)",
     "d": "kagi.com",
     "t": "knje",
     "u": "/news?q={{{s}}}&r=je",
@@ -1806,7 +1806,7 @@
     ]
   },
   {
-    "s": "News in Jordan (JO)",
+    "s": "Kagi News (Jordan)",
     "d": "kagi.com",
     "t": "knjo",
     "u": "/news?q={{{s}}}&r=jo",
@@ -1815,7 +1815,7 @@
     ]
   },
   {
-    "s": "News in Kazakhstan (KZ)",
+    "s": "Kagi News (Kazakhstan)",
     "d": "kagi.com",
     "t": "knkz",
     "u": "/news?q={{{s}}}&r=kz",
@@ -1824,7 +1824,7 @@
     ]
   },
   {
-    "s": "News in Kenya (KE)",
+    "s": "Kagi News (Kenya)",
     "d": "kagi.com",
     "t": "knke",
     "u": "/news?q={{{s}}}&r=ke",
@@ -1833,7 +1833,7 @@
     ]
   },
   {
-    "s": "News in Kiribati (KI)",
+    "s": "Kagi News (Kiribati)",
     "d": "kagi.com",
     "t": "knki",
     "u": "/news?q={{{s}}}&r=ki",
@@ -1842,7 +1842,7 @@
     ]
   },
   {
-    "s": "News in Kosovo (XK)",
+    "s": "Kagi News (Kosovo)",
     "d": "kagi.com",
     "t": "knxk",
     "u": "/news?q={{{s}}}&r=xk",
@@ -1851,7 +1851,7 @@
     ]
   },
   {
-    "s": "News in Kuwait (KW)",
+    "s": "Kagi News (Kuwait)",
     "d": "kagi.com",
     "t": "knkw",
     "u": "/news?q={{{s}}}&r=kw",
@@ -1860,7 +1860,7 @@
     ]
   },
   {
-    "s": "News in Kyrgyzstan (KG)",
+    "s": "Kagi News (Kyrgyzstan)",
     "d": "kagi.com",
     "t": "knkg",
     "u": "/news?q={{{s}}}&r=kg",
@@ -1869,7 +1869,7 @@
     ]
   },
   {
-    "s": "News in Laos (LA)",
+    "s": "Kagi News (Laos)",
     "d": "kagi.com",
     "t": "knla",
     "u": "/news?q={{{s}}}&r=la",
@@ -1878,7 +1878,7 @@
     ]
   },
   {
-    "s": "News in Latvia (LV)",
+    "s": "Kagi News (Latvia)",
     "d": "kagi.com",
     "t": "knlv",
     "u": "/news?q={{{s}}}&r=lv",
@@ -1887,7 +1887,7 @@
     ]
   },
   {
-    "s": "News in Lebanon (LB)",
+    "s": "Kagi News (Lebanon)",
     "d": "kagi.com",
     "t": "knlb",
     "u": "/news?q={{{s}}}&r=lb",
@@ -1896,7 +1896,7 @@
     ]
   },
   {
-    "s": "News in Lesotho (LS)",
+    "s": "Kagi News (Lesotho)",
     "d": "kagi.com",
     "t": "knls",
     "u": "/news?q={{{s}}}&r=ls",
@@ -1905,7 +1905,7 @@
     ]
   },
   {
-    "s": "News in Liberia (LR)",
+    "s": "Kagi News (Liberia)",
     "d": "kagi.com",
     "t": "knlr",
     "u": "/news?q={{{s}}}&r=lr",
@@ -1914,7 +1914,7 @@
     ]
   },
   {
-    "s": "News in Libya (LY)",
+    "s": "Kagi News (Libya)",
     "d": "kagi.com",
     "t": "knly",
     "u": "/news?q={{{s}}}&r=ly",
@@ -1923,7 +1923,7 @@
     ]
   },
   {
-    "s": "News in Liechtenstein (LI)",
+    "s": "Kagi News (Liechtenstein)",
     "d": "kagi.com",
     "t": "knli",
     "u": "/news?q={{{s}}}&r=li",
@@ -1932,7 +1932,7 @@
     ]
   },
   {
-    "s": "News in Lithuania (LT)",
+    "s": "Kagi News (Lithuania)",
     "d": "kagi.com",
     "t": "knlt",
     "u": "/news?q={{{s}}}&r=lt",
@@ -1941,7 +1941,7 @@
     ]
   },
   {
-    "s": "News in Luxembourg (LU)",
+    "s": "Kagi News (Luxembourg)",
     "d": "kagi.com",
     "t": "knlu",
     "u": "/news?q={{{s}}}&r=lu",
@@ -1950,7 +1950,7 @@
     ]
   },
   {
-    "s": "News in Macao (MO)",
+    "s": "Kagi News (Macau)",
     "d": "kagi.com",
     "t": "knmo",
     "u": "/news?q={{{s}}}&r=mo",
@@ -1959,7 +1959,7 @@
     ]
   },
   {
-    "s": "News in Madagascar (MG)",
+    "s": "Kagi News (Madagascar)",
     "d": "kagi.com",
     "t": "knmg",
     "u": "/news?q={{{s}}}&r=mg",
@@ -1968,7 +1968,7 @@
     ]
   },
   {
-    "s": "News in Malawi (MW)",
+    "s": "Kagi News (Malawi)",
     "d": "kagi.com",
     "t": "knmw",
     "u": "/news?q={{{s}}}&r=mw",
@@ -1977,7 +1977,7 @@
     ]
   },
   {
-    "s": "News in Malaysia (MY)",
+    "s": "Kagi News (Malaysia)",
     "d": "kagi.com",
     "t": "knmy",
     "u": "/news?q={{{s}}}&r=my",
@@ -1986,7 +1986,7 @@
     ]
   },
   {
-    "s": "News in Maldives (MV)",
+    "s": "Kagi News (Maldives)",
     "d": "kagi.com",
     "t": "knmv",
     "u": "/news?q={{{s}}}&r=mv",
@@ -1995,7 +1995,7 @@
     ]
   },
   {
-    "s": "News in Mali (ML)",
+    "s": "Kagi News (Mali)",
     "d": "kagi.com",
     "t": "knml",
     "u": "/news?q={{{s}}}&r=ml",
@@ -2004,7 +2004,7 @@
     ]
   },
   {
-    "s": "News in Malta (MT)",
+    "s": "Kagi News (Malta)",
     "d": "kagi.com",
     "t": "knmt",
     "u": "/news?q={{{s}}}&r=mt",
@@ -2013,7 +2013,7 @@
     ]
   },
   {
-    "s": "News in Marshall Islands (MH)",
+    "s": "Kagi News (Marshall Islands)",
     "d": "kagi.com",
     "t": "knmh",
     "u": "/news?q={{{s}}}&r=mh",
@@ -2022,7 +2022,7 @@
     ]
   },
   {
-    "s": "News in Martinique (MQ)",
+    "s": "Kagi News (Martinique)",
     "d": "kagi.com",
     "t": "knmq",
     "u": "/news?q={{{s}}}&r=mq",
@@ -2031,7 +2031,7 @@
     ]
   },
   {
-    "s": "News in Mauritania (MR)",
+    "s": "Kagi News (Mauritania)",
     "d": "kagi.com",
     "t": "knmr",
     "u": "/news?q={{{s}}}&r=mr",
@@ -2040,7 +2040,7 @@
     ]
   },
   {
-    "s": "News in Mauritius (MU)",
+    "s": "Kagi News (Mauritius)",
     "d": "kagi.com",
     "t": "knmu",
     "u": "/news?q={{{s}}}&r=mu",
@@ -2049,7 +2049,7 @@
     ]
   },
   {
-    "s": "News in Mayotte (YT)",
+    "s": "Kagi News (Mayotte)",
     "d": "kagi.com",
     "t": "knyt",
     "u": "/news?q={{{s}}}&r=yt",
@@ -2058,7 +2058,7 @@
     ]
   },
   {
-    "s": "News in Mexico (MX)",
+    "s": "Kagi News (Mexico)",
     "d": "kagi.com",
     "t": "knmx",
     "u": "/news?q={{{s}}}&r=mx",
@@ -2067,7 +2067,7 @@
     ]
   },
   {
-    "s": "News in Micronesia (Federated States of) (FM)",
+    "s": "Kagi News (Micronesia)",
     "d": "kagi.com",
     "t": "knfm",
     "u": "/news?q={{{s}}}&r=fm",
@@ -2076,7 +2076,7 @@
     ]
   },
   {
-    "s": "News in Moldova (MD)",
+    "s": "Kagi News (Moldova)",
     "d": "kagi.com",
     "t": "knmd",
     "u": "/news?q={{{s}}}&r=md",
@@ -2085,7 +2085,7 @@
     ]
   },
   {
-    "s": "News in Monaco (MC)",
+    "s": "Kagi News (Monaco)",
     "d": "kagi.com",
     "t": "knmc",
     "u": "/news?q={{{s}}}&r=mc",
@@ -2094,7 +2094,7 @@
     ]
   },
   {
-    "s": "News in Mongolia (MN)",
+    "s": "Kagi News (Mongolia)",
     "d": "kagi.com",
     "t": "knmn",
     "u": "/news?q={{{s}}}&r=mn",
@@ -2103,7 +2103,7 @@
     ]
   },
   {
-    "s": "News in Montenegro (ME)",
+    "s": "Kagi News (Montenegro)",
     "d": "kagi.com",
     "t": "knme",
     "u": "/news?q={{{s}}}&r=me",
@@ -2112,7 +2112,7 @@
     ]
   },
   {
-    "s": "News in Montserrat (MS)",
+    "s": "Kagi News (Montserrat)",
     "d": "kagi.com",
     "t": "knms",
     "u": "/news?q={{{s}}}&r=ms",
@@ -2121,7 +2121,7 @@
     ]
   },
   {
-    "s": "News in Morocco (MA)",
+    "s": "Kagi News (Morocco)",
     "d": "kagi.com",
     "t": "knma",
     "u": "/news?q={{{s}}}&r=ma",
@@ -2130,7 +2130,7 @@
     ]
   },
   {
-    "s": "News in Mozambique (MZ)",
+    "s": "Kagi News (Mozambique)",
     "d": "kagi.com",
     "t": "knmz",
     "u": "/news?q={{{s}}}&r=mz",
@@ -2139,7 +2139,7 @@
     ]
   },
   {
-    "s": "News in Myanmar (MM)",
+    "s": "Kagi News (Myanmar)",
     "d": "kagi.com",
     "t": "knmm",
     "u": "/news?q={{{s}}}&r=mm",
@@ -2148,7 +2148,7 @@
     ]
   },
   {
-    "s": "News in Namibia (NA)",
+    "s": "Kagi News (Namibia)",
     "d": "kagi.com",
     "t": "knna",
     "u": "/news?q={{{s}}}&r=na",
@@ -2157,7 +2157,7 @@
     ]
   },
   {
-    "s": "News in Nauru (NR)",
+    "s": "Kagi News (Nauru)",
     "d": "kagi.com",
     "t": "knnr",
     "u": "/news?q={{{s}}}&r=nr",
@@ -2166,7 +2166,7 @@
     ]
   },
   {
-    "s": "News in Nepal (NP)",
+    "s": "Kagi News (Nepal)",
     "d": "kagi.com",
     "t": "knnp",
     "u": "/news?q={{{s}}}&r=np",
@@ -2175,7 +2175,7 @@
     ]
   },
   {
-    "s": "News in Netherlands (NL)",
+    "s": "Kagi News (Netherlands)",
     "d": "kagi.com",
     "t": "knnl",
     "u": "/news?q={{{s}}}&r=nl",
@@ -2184,7 +2184,7 @@
     ]
   },
   {
-    "s": "News in New Caledonia (NC)",
+    "s": "Kagi News (New Caledonia)",
     "d": "kagi.com",
     "t": "knnc",
     "u": "/news?q={{{s}}}&r=nc",
@@ -2193,7 +2193,7 @@
     ]
   },
   {
-    "s": "News in New Zealand (NZ)",
+    "s": "Kagi News (New Zealand)",
     "d": "kagi.com",
     "t": "knnz",
     "u": "/news?q={{{s}}}&r=nz",
@@ -2202,7 +2202,7 @@
     ]
   },
   {
-    "s": "News in Nicaragua (NI)",
+    "s": "Kagi News (Nicaragua)",
     "d": "kagi.com",
     "t": "knni",
     "u": "/news?q={{{s}}}&r=ni",
@@ -2211,7 +2211,7 @@
     ]
   },
   {
-    "s": "News in Niger (NE)",
+    "s": "Kagi News (Niger)",
     "d": "kagi.com",
     "t": "knne",
     "u": "/news?q={{{s}}}&r=ne",
@@ -2220,7 +2220,7 @@
     ]
   },
   {
-    "s": "News in Nigeria (NG)",
+    "s": "Kagi News (Nigeria)",
     "d": "kagi.com",
     "t": "knng",
     "u": "/news?q={{{s}}}&r=ng",
@@ -2229,7 +2229,7 @@
     ]
   },
   {
-    "s": "News in Niue (NU)",
+    "s": "Kagi News (Niue)",
     "d": "kagi.com",
     "t": "knnu",
     "u": "/news?q={{{s}}}&r=nu",
@@ -2238,7 +2238,7 @@
     ]
   },
   {
-    "s": "News in Norfolk Island (NF)",
+    "s": "Kagi News (Norfolk Island)",
     "d": "kagi.com",
     "t": "knnf",
     "u": "/news?q={{{s}}}&r=nf",
@@ -2247,7 +2247,7 @@
     ]
   },
   {
-    "s": "News in North Korea (KP)",
+    "s": "Kagi News (North Korea)",
     "d": "kagi.com",
     "t": "knkp",
     "u": "/news?q={{{s}}}&r=kp",
@@ -2256,7 +2256,7 @@
     ]
   },
   {
-    "s": "News in North Macedonia (MK)",
+    "s": "Kagi News (North Macedonia)",
     "d": "kagi.com",
     "t": "knmk",
     "u": "/news?q={{{s}}}&r=mk",
@@ -2265,7 +2265,7 @@
     ]
   },
   {
-    "s": "News in Northern Mariana Islands (MP)",
+    "s": "Kagi News (Northern Mariana Islands)",
     "d": "kagi.com",
     "t": "knmp",
     "u": "/news?q={{{s}}}&r=mp",
@@ -2274,7 +2274,7 @@
     ]
   },
   {
-    "s": "News in Norway (NO)",
+    "s": "Kagi News (Norway)",
     "d": "kagi.com",
     "t": "knno",
     "u": "/news?q={{{s}}}&r=no",
@@ -2283,7 +2283,7 @@
     ]
   },
   {
-    "s": "News in Oman (OM)",
+    "s": "Kagi News (Oman)",
     "d": "kagi.com",
     "t": "knom",
     "u": "/news?q={{{s}}}&r=om",
@@ -2292,7 +2292,7 @@
     ]
   },
   {
-    "s": "News in Pakistan (PK)",
+    "s": "Kagi News (Pakistan)",
     "d": "kagi.com",
     "t": "knpk",
     "u": "/news?q={{{s}}}&r=pk",
@@ -2301,7 +2301,7 @@
     ]
   },
   {
-    "s": "News in Palau (PW)",
+    "s": "Kagi News (Palau)",
     "d": "kagi.com",
     "t": "knpw",
     "u": "/news?q={{{s}}}&r=pw",
@@ -2310,7 +2310,7 @@
     ]
   },
   {
-    "s": "News in Palestine (PS)",
+    "s": "Kagi News (Palestine)",
     "d": "kagi.com",
     "t": "knps",
     "u": "/news?q={{{s}}}&r=ps",
@@ -2319,7 +2319,7 @@
     ]
   },
   {
-    "s": "News in Panama (PA)",
+    "s": "Kagi News (Panama)",
     "d": "kagi.com",
     "t": "knpa",
     "u": "/news?q={{{s}}}&r=pa",
@@ -2328,7 +2328,7 @@
     ]
   },
   {
-    "s": "News in Papua New Guinea (PG)",
+    "s": "Kagi News (Papua New Guinea)",
     "d": "kagi.com",
     "t": "knpg",
     "u": "/news?q={{{s}}}&r=pg",
@@ -2337,7 +2337,7 @@
     ]
   },
   {
-    "s": "News in Paraguay (PY)",
+    "s": "Kagi News (Paraguay)",
     "d": "kagi.com",
     "t": "knpy",
     "u": "/news?q={{{s}}}&r=py",
@@ -2346,7 +2346,7 @@
     ]
   },
   {
-    "s": "News in Peru (PE)",
+    "s": "Kagi News (Peru)",
     "d": "kagi.com",
     "t": "knpe",
     "u": "/news?q={{{s}}}&r=pe",
@@ -2355,7 +2355,7 @@
     ]
   },
   {
-    "s": "News in Philippines (PH)",
+    "s": "Kagi News (Philippines)",
     "d": "kagi.com",
     "t": "knph",
     "u": "/news?q={{{s}}}&r=ph",
@@ -2364,7 +2364,7 @@
     ]
   },
   {
-    "s": "News in Pitcairn (PN)",
+    "s": "Kagi News (Pitcairn)",
     "d": "kagi.com",
     "t": "knpn",
     "u": "/news?q={{{s}}}&r=pn",
@@ -2373,7 +2373,7 @@
     ]
   },
   {
-    "s": "News in Poland (PL)",
+    "s": "Kagi News (Poland)",
     "d": "kagi.com",
     "t": "knpl",
     "u": "/news?q={{{s}}}&r=pl",
@@ -2382,7 +2382,7 @@
     ]
   },
   {
-    "s": "News in Portugal (PT)",
+    "s": "Kagi News (Portugal)",
     "d": "kagi.com",
     "t": "knpt",
     "u": "/news?q={{{s}}}&r=pt",
@@ -2391,7 +2391,7 @@
     ]
   },
   {
-    "s": "News in Puerto Rico (PR)",
+    "s": "Kagi News (Puerto Rico)",
     "d": "kagi.com",
     "t": "knpr",
     "u": "/news?q={{{s}}}&r=pr",
@@ -2400,7 +2400,7 @@
     ]
   },
   {
-    "s": "News in Qatar (QA)",
+    "s": "Kagi News (Qatar)",
     "d": "kagi.com",
     "t": "knqa",
     "u": "/news?q={{{s}}}&r=qa",
@@ -2409,7 +2409,7 @@
     ]
   },
   {
-    "s": "News in Romania (RO)",
+    "s": "Kagi News (Romania)",
     "d": "kagi.com",
     "t": "knro",
     "u": "/news?q={{{s}}}&r=ro",
@@ -2418,7 +2418,7 @@
     ]
   },
   {
-    "s": "News in Russia (RU)",
+    "s": "Kagi News (Russia)",
     "d": "kagi.com",
     "t": "knru",
     "u": "/news?q={{{s}}}&r=ru",
@@ -2427,7 +2427,7 @@
     ]
   },
   {
-    "s": "News in Rwanda (RW)",
+    "s": "Kagi News (Rwanda)",
     "d": "kagi.com",
     "t": "knrw",
     "u": "/news?q={{{s}}}&r=rw",
@@ -2436,7 +2436,7 @@
     ]
   },
   {
-    "s": "News in Réunion (RE)",
+    "s": "Kagi News (Réunion)",
     "d": "kagi.com",
     "t": "knre",
     "u": "/news?q={{{s}}}&r=re",
@@ -2445,7 +2445,7 @@
     ]
   },
   {
-    "s": "News in Saint Barthélemy (BL)",
+    "s": "Kagi News (Saint Barthelemy)",
     "d": "kagi.com",
     "t": "knbl",
     "u": "/news?q={{{s}}}&r=bl",
@@ -2454,7 +2454,7 @@
     ]
   },
   {
-    "s": "News in Saint Helena, Ascension and Tristan da Cunha (SH)",
+    "s": "Kagi News (Saint Helena)",
     "d": "kagi.com",
     "t": "knsh",
     "u": "/news?q={{{s}}}&r=sh",
@@ -2463,7 +2463,7 @@
     ]
   },
   {
-    "s": "News in Saint Kitts and Nevis (KN)",
+    "s": "Kagi News (Saint Kitts and Nevis)",
     "d": "kagi.com",
     "t": "knkn",
     "u": "/news?q={{{s}}}&r=kn",
@@ -2472,7 +2472,7 @@
     ]
   },
   {
-    "s": "News in Saint Lucia (LC)",
+    "s": "Kagi News (Saint Lucia)",
     "d": "kagi.com",
     "t": "knlc",
     "u": "/news?q={{{s}}}&r=lc",
@@ -2481,7 +2481,7 @@
     ]
   },
   {
-    "s": "News in Saint Martin (MF)",
+    "s": "Kagi News (Saint Martin)",
     "d": "kagi.com",
     "t": "knmf",
     "u": "/news?q={{{s}}}&r=mf",
@@ -2490,7 +2490,7 @@
     ]
   },
   {
-    "s": "News in Saint Pierre and Miquelon (PM)",
+    "s": "Kagi News (Saint Pierre and Miquelon)",
     "d": "kagi.com",
     "t": "knpm",
     "u": "/news?q={{{s}}}&r=pm",
@@ -2499,7 +2499,7 @@
     ]
   },
   {
-    "s": "News in Saint Vincent and the Grenadines (VC)",
+    "s": "Kagi News (Saint Vincent and the Grenadines)",
     "d": "kagi.com",
     "t": "knvc",
     "u": "/news?q={{{s}}}&r=vc",
@@ -2508,7 +2508,7 @@
     ]
   },
   {
-    "s": "News in Samoa (WS)",
+    "s": "Kagi News (Samoa)",
     "d": "kagi.com",
     "t": "knws",
     "u": "/news?q={{{s}}}&r=ws",
@@ -2517,7 +2517,7 @@
     ]
   },
   {
-    "s": "News in San Marino (SM)",
+    "s": "Kagi News (San Marino)",
     "d": "kagi.com",
     "t": "knsm",
     "u": "/news?q={{{s}}}&r=sm",
@@ -2526,7 +2526,7 @@
     ]
   },
   {
-    "s": "News in Sao Tome and Principe (ST)",
+    "s": "Kagi News (Sao Tome and Principe)",
     "d": "kagi.com",
     "t": "knst",
     "u": "/news?q={{{s}}}&r=st",
@@ -2535,7 +2535,7 @@
     ]
   },
   {
-    "s": "News in Saudi Arabia (SA)",
+    "s": "Kagi News (Saudi Arabia)",
     "d": "kagi.com",
     "t": "knsa",
     "u": "/news?q={{{s}}}&r=sa",
@@ -2544,7 +2544,7 @@
     ]
   },
   {
-    "s": "News in Senegal (SN)",
+    "s": "Kagi News (Senegal)",
     "d": "kagi.com",
     "t": "knsn",
     "u": "/news?q={{{s}}}&r=sn",
@@ -2553,7 +2553,7 @@
     ]
   },
   {
-    "s": "News in Serbia (RS)",
+    "s": "Kagi News (Serbia)",
     "d": "kagi.com",
     "t": "knrs",
     "u": "/news?q={{{s}}}&r=rs",
@@ -2562,7 +2562,7 @@
     ]
   },
   {
-    "s": "News in Seychelles (SC)",
+    "s": "Kagi News (Seychelles)",
     "d": "kagi.com",
     "t": "knsc",
     "u": "/news?q={{{s}}}&r=sc",
@@ -2571,7 +2571,7 @@
     ]
   },
   {
-    "s": "News in Sierra Leone (SL)",
+    "s": "Kagi News (Sierra Leone)",
     "d": "kagi.com",
     "t": "knsl",
     "u": "/news?q={{{s}}}&r=sl",
@@ -2580,7 +2580,7 @@
     ]
   },
   {
-    "s": "News in Singapore (SG)",
+    "s": "Kagi News (Singapore)",
     "d": "kagi.com",
     "t": "knsg",
     "u": "/news?q={{{s}}}&r=sg",
@@ -2589,7 +2589,7 @@
     ]
   },
   {
-    "s": "News in Sint Maarten (SX)",
+    "s": "Kagi News (Sint Maarten)",
     "d": "kagi.com",
     "t": "knsx",
     "u": "/news?q={{{s}}}&r=sx",
@@ -2598,7 +2598,7 @@
     ]
   },
   {
-    "s": "News in Slovakia (SK)",
+    "s": "Kagi News (Slovakia)",
     "d": "kagi.com",
     "t": "knsk",
     "u": "/news?q={{{s}}}&r=sk",
@@ -2607,7 +2607,7 @@
     ]
   },
   {
-    "s": "News in Slovenia (SI)",
+    "s": "Kagi News (Slovenia)",
     "d": "kagi.com",
     "t": "knsi",
     "u": "/news?q={{{s}}}&r=si",
@@ -2616,7 +2616,7 @@
     ]
   },
   {
-    "s": "News in Solomon Islands (SB)",
+    "s": "Kagi News (Solomon Islands)",
     "d": "kagi.com",
     "t": "knsb",
     "u": "/news?q={{{s}}}&r=sb",
@@ -2625,7 +2625,7 @@
     ]
   },
   {
-    "s": "News in Somalia (SO)",
+    "s": "Kagi News (Somalia)",
     "d": "kagi.com",
     "t": "knso",
     "u": "/news?q={{{s}}}&r=so",
@@ -2634,7 +2634,7 @@
     ]
   },
   {
-    "s": "News in South Africa (ZA)",
+    "s": "Kagi News (South Africa)",
     "d": "kagi.com",
     "t": "knza",
     "u": "/news?q={{{s}}}&r=za",
@@ -2643,7 +2643,7 @@
     ]
   },
   {
-    "s": "News in South Georgia and the South Sandwich Islands (GS)",
+    "s": "Kagi News (South Georgia and the South Sandwich Islands)",
     "d": "kagi.com",
     "t": "kngs",
     "u": "/news?q={{{s}}}&r=gs",
@@ -2652,7 +2652,7 @@
     ]
   },
   {
-    "s": "News in South Korea (KR)",
+    "s": "Kagi News (South Korea)",
     "d": "kagi.com",
     "t": "knkr",
     "u": "/news?q={{{s}}}&r=kr",
@@ -2661,7 +2661,7 @@
     ]
   },
   {
-    "s": "News in South Sudan (SS)",
+    "s": "Kagi News (South Sudan)",
     "d": "kagi.com",
     "t": "knss",
     "u": "/news?q={{{s}}}&r=ss",
@@ -2670,7 +2670,7 @@
     ]
   },
   {
-    "s": "News in Spain (ES - ca)",
+    "s": "Kagi News (Spain, Catalan)",
     "d": "kagi.com",
     "t": "knes_ca",
     "u": "/news?q={{{s}}}&r=es_ca",
@@ -2679,7 +2679,7 @@
     ]
   },
   {
-    "s": "News in Spain (ES - es)",
+    "s": "Kagi News (Spain, Spanish)",
     "d": "kagi.com",
     "t": "knes",
     "u": "/news?q={{{s}}}&r=es",
@@ -2688,7 +2688,7 @@
     ]
   },
   {
-    "s": "News in Sri Lanka (LK)",
+    "s": "Kagi News (Sri Lanka)",
     "d": "kagi.com",
     "t": "knlk",
     "u": "/news?q={{{s}}}&r=lk",
@@ -2697,7 +2697,7 @@
     ]
   },
   {
-    "s": "News in Sudan (SD)",
+    "s": "Kagi News (Sudan)",
     "d": "kagi.com",
     "t": "knsd",
     "u": "/news?q={{{s}}}&r=sd",
@@ -2706,7 +2706,7 @@
     ]
   },
   {
-    "s": "News in Suriname (SR)",
+    "s": "Kagi News (Suriname)",
     "d": "kagi.com",
     "t": "knsr",
     "u": "/news?q={{{s}}}&r=sr",
@@ -2715,7 +2715,7 @@
     ]
   },
   {
-    "s": "News in Svalbard and Jan Mayen (SJ)",
+    "s": "Kagi News (Svalbard and Jan Mayen)",
     "d": "kagi.com",
     "t": "knsj",
     "u": "/news?q={{{s}}}&r=sj",
@@ -2724,7 +2724,7 @@
     ]
   },
   {
-    "s": "News in Sweden (SE)",
+    "s": "Kagi News (Sweden)",
     "d": "kagi.com",
     "t": "knse",
     "u": "/news?q={{{s}}}&r=se",
@@ -2733,7 +2733,7 @@
     ]
   },
   {
-    "s": "News in Switzerland (CH - de)",
+    "s": "Kagi News (Switzerland, German)",
     "d": "kagi.com",
     "t": "knch",
     "u": "/news?q={{{s}}}&r=ch",
@@ -2742,7 +2742,7 @@
     ]
   },
   {
-    "s": "News in Switzerland (CH - fr)",
+    "s": "Kagi News (Switzerland, French)",
     "d": "kagi.com",
     "t": "knch_fr",
     "u": "/news?q={{{s}}}&r=ch_fr",
@@ -2751,7 +2751,7 @@
     ]
   },
   {
-    "s": "News in Syria (SY)",
+    "s": "Kagi News (Syria)",
     "d": "kagi.com",
     "t": "knsy",
     "u": "/news?q={{{s}}}&r=sy",
@@ -2760,7 +2760,7 @@
     ]
   },
   {
-    "s": "News in Taiwan (TW)",
+    "s": "Kagi News (Taiwan)",
     "d": "kagi.com",
     "t": "kntw",
     "u": "/news?q={{{s}}}&r=tw",
@@ -2769,7 +2769,7 @@
     ]
   },
   {
-    "s": "News in Tajikistan (TJ)",
+    "s": "Kagi News (Tajikistan)",
     "d": "kagi.com",
     "t": "kntj",
     "u": "/news?q={{{s}}}&r=tj",
@@ -2778,7 +2778,7 @@
     ]
   },
   {
-    "s": "News in Tanzania (TZ)",
+    "s": "Kagi News (Tanzania)",
     "d": "kagi.com",
     "t": "kntz",
     "u": "/news?q={{{s}}}&r=tz",
@@ -2787,7 +2787,7 @@
     ]
   },
   {
-    "s": "News in Thailand (TH)",
+    "s": "Kagi News (Thailand)",
     "d": "kagi.com",
     "t": "knth",
     "u": "/news?q={{{s}}}&r=th",
@@ -2796,7 +2796,7 @@
     ]
   },
   {
-    "s": "News in Timor-Leste (TL)",
+    "s": "Kagi News (Timor-Leste)",
     "d": "kagi.com",
     "t": "kntl",
     "u": "/news?q={{{s}}}&r=tl",
@@ -2805,7 +2805,7 @@
     ]
   },
   {
-    "s": "News in Togo (TG)",
+    "s": "Kagi News (Togo)",
     "d": "kagi.com",
     "t": "kntg",
     "u": "/news?q={{{s}}}&r=tg",
@@ -2814,7 +2814,7 @@
     ]
   },
   {
-    "s": "News in Tokelau (TK)",
+    "s": "Kagi News (Tokelau)",
     "d": "kagi.com",
     "t": "kntk",
     "u": "/news?q={{{s}}}&r=tk",
@@ -2823,7 +2823,7 @@
     ]
   },
   {
-    "s": "News in Tonga (TO)",
+    "s": "Kagi News (Tonga)",
     "d": "kagi.com",
     "t": "knto",
     "u": "/news?q={{{s}}}&r=to",
@@ -2832,7 +2832,7 @@
     ]
   },
   {
-    "s": "News in Trinidad and Tobago (TT)",
+    "s": "Kagi News (Trinidad and Tobago)",
     "d": "kagi.com",
     "t": "kntt",
     "u": "/news?q={{{s}}}&r=tt",
@@ -2841,7 +2841,7 @@
     ]
   },
   {
-    "s": "News in Tristan da Cunha (TA)",
+    "s": "Kagi News (Tristan da Cunha)",
     "d": "kagi.com",
     "t": "knta",
     "u": "/news?q={{{s}}}&r=ta",
@@ -2850,7 +2850,7 @@
     ]
   },
   {
-    "s": "News in Tunisia (TN)",
+    "s": "Kagi News (Tunisia)",
     "d": "kagi.com",
     "t": "kntn",
     "u": "/news?q={{{s}}}&r=tn",
@@ -2859,7 +2859,7 @@
     ]
   },
   {
-    "s": "News in Turkey (TR)",
+    "s": "Kagi News (Turkey)",
     "d": "kagi.com",
     "t": "kntr",
     "u": "/news?q={{{s}}}&r=tr",
@@ -2868,7 +2868,7 @@
     ]
   },
   {
-    "s": "News in Turkmenistan (TM)",
+    "s": "Kagi News (Turkmenistan)",
     "d": "kagi.com",
     "t": "kntm",
     "u": "/news?q={{{s}}}&r=tm",
@@ -2877,7 +2877,7 @@
     ]
   },
   {
-    "s": "News in Turks and Caicos Islands (TC)",
+    "s": "Kagi News (Turks and Caicos Islands)",
     "d": "kagi.com",
     "t": "kntc",
     "u": "/news?q={{{s}}}&r=tc",
@@ -2886,7 +2886,7 @@
     ]
   },
   {
-    "s": "News in Tuvalu (TV)",
+    "s": "Kagi News (Tuvalu)",
     "d": "kagi.com",
     "t": "kntv",
     "u": "/news?q={{{s}}}&r=tv",
@@ -2895,7 +2895,7 @@
     ]
   },
   {
-    "s": "News in Uganda (UG)",
+    "s": "Kagi News (Uganda)",
     "d": "kagi.com",
     "t": "knug",
     "u": "/news?q={{{s}}}&r=ug",
@@ -2904,7 +2904,7 @@
     ]
   },
   {
-    "s": "News in Ukraine (UA)",
+    "s": "Kagi News (Ukraine)",
     "d": "kagi.com",
     "t": "knua",
     "u": "/news?q={{{s}}}&r=ua",
@@ -2913,7 +2913,7 @@
     ]
   },
   {
-    "s": "News in United Arab Emirates (AE)",
+    "s": "Kagi News (United Arab Emirates)",
     "d": "kagi.com",
     "t": "knae",
     "u": "/news?q={{{s}}}&r=ae",
@@ -2922,7 +2922,7 @@
     ]
   },
   {
-    "s": "News in United Kingdom (GB)",
+    "s": "Kagi News (United Kingdom)",
     "d": "kagi.com",
     "t": "kngb",
     "u": "/news?q={{{s}}}&r=gb",
@@ -2931,7 +2931,7 @@
     ]
   },
   {
-    "s": "News in United States (US)",
+    "s": "Kagi News (United States)",
     "d": "kagi.com",
     "t": "knus",
     "u": "/news?q={{{s}}}&r=us",
@@ -2940,7 +2940,7 @@
     ]
   },
   {
-    "s": "News in United States Minor Outlying Islands (UM)",
+    "s": "Kagi News (US Minor Outlying Islands)",
     "d": "kagi.com",
     "t": "knum",
     "u": "/news?q={{{s}}}&r=um",
@@ -2949,7 +2949,7 @@
     ]
   },
   {
-    "s": "News in United States Virgin Islands (VI)",
+    "s": "Kagi News (US Virgin Islands)",
     "d": "kagi.com",
     "t": "knvi",
     "u": "/news?q={{{s}}}&r=vi",
@@ -2958,7 +2958,7 @@
     ]
   },
   {
-    "s": "News in Uruguay (UY)",
+    "s": "Kagi News (Uruguay)",
     "d": "kagi.com",
     "t": "knuy",
     "u": "/news?q={{{s}}}&r=uy",
@@ -2967,7 +2967,7 @@
     ]
   },
   {
-    "s": "News in Uzbekistan (UZ)",
+    "s": "Kagi News (Uzbekistan)",
     "d": "kagi.com",
     "t": "knuz",
     "u": "/news?q={{{s}}}&r=uz",
@@ -2976,7 +2976,7 @@
     ]
   },
   {
-    "s": "News in Vanuatu (VU)",
+    "s": "Kagi News (Vanuatu)",
     "d": "kagi.com",
     "t": "knvu",
     "u": "/news?q={{{s}}}&r=vu",
@@ -2985,7 +2985,7 @@
     ]
   },
   {
-    "s": "News in Vatican City (VA)",
+    "s": "Kagi News (Vatican City)",
     "d": "kagi.com",
     "t": "knva",
     "u": "/news?q={{{s}}}&r=va",
@@ -2994,7 +2994,7 @@
     ]
   },
   {
-    "s": "News in Venezuela (VE)",
+    "s": "Kagi News (Venezuela)",
     "d": "kagi.com",
     "t": "knve",
     "u": "/news?q={{{s}}}&r=ve",
@@ -3003,7 +3003,7 @@
     ]
   },
   {
-    "s": "News in Vietnam (VN)",
+    "s": "Kagi News (Vietnam)",
     "d": "kagi.com",
     "t": "knvn",
     "u": "/news?q={{{s}}}&r=vn",
@@ -3012,7 +3012,7 @@
     ]
   },
   {
-    "s": "News in Wallis and Futuna (WF)",
+    "s": "Kagi News (Wallis and Futuna)",
     "d": "kagi.com",
     "t": "knwf",
     "u": "/news?q={{{s}}}&r=wf",
@@ -3021,7 +3021,7 @@
     ]
   },
   {
-    "s": "News in Western Sahara (EH)",
+    "s": "Kagi News (Western Sahara)",
     "d": "kagi.com",
     "t": "kneh",
     "u": "/news?q={{{s}}}&r=eh",
@@ -3030,7 +3030,7 @@
     ]
   },
   {
-    "s": "News in Yemen (YE)",
+    "s": "Kagi News (Yemen)",
     "d": "kagi.com",
     "t": "knye",
     "u": "/news?q={{{s}}}&r=ye",
@@ -3039,7 +3039,7 @@
     ]
   },
   {
-    "s": "News in Zambia (ZM)",
+    "s": "Kagi News (Zambia)",
     "d": "kagi.com",
     "t": "knzm",
     "u": "/news?q={{{s}}}&r=zm",
@@ -3048,7 +3048,7 @@
     ]
   },
   {
-    "s": "News in Zimbabwe (ZW)",
+    "s": "Kagi News (Zimbabwe)",
     "d": "kagi.com",
     "t": "knzw",
     "u": "/news?q={{{s}}}&r=zw",
@@ -3057,7 +3057,7 @@
     ]
   },
   {
-    "s": "News in Åland Islands (AX)",
+    "s": "Kagi News (Aland Islands)",
     "d": "kagi.com",
     "t": "knax",
     "u": "/news?q={{{s}}}&r=ax",
@@ -3086,7 +3086,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Chat",
+    "s": "Kagi Assistant (Chat)",
     "d": "kagi.com",
     "t": "chat",
     "u": "/assistant?internet=off&q={{{s}}}",
@@ -3096,7 +3096,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Code",
+    "s": "Kagi Assistant (Code)",
     "d": "kagi.com",
     "t": "code",
     "u": "/assistant?profile=code&q={{{s}}}",
@@ -3106,7 +3106,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Study",
+    "s": "Kagi Assistant (Study)",
     "d": "kagi.com",
     "t": "study",
     "u": "/assistant?profile=study&q={{{s}}}",
@@ -3116,7 +3116,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Quick",
+    "s": "Kagi Assistant (Quick)",
     "d": "kagi.com",
     "t": "q",
     "ts": [
@@ -3132,7 +3132,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Research",
+    "s": "Kagi Assistant (Research)",
     "d": "kagi.com",
     "t": "research",
     "ts": [
@@ -3147,7 +3147,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Research (Experimental)",
+    "s": "Kagi Assistant (Research, Experimental)",
     "d": "kagi.com",
     "t": "deep",
     "ts": [
@@ -3161,7 +3161,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - ChatGPT",
+    "s": "Kagi Assistant (ChatGPT)",
     "d": "kagi.com",
     "t": "chatgpt-4o",
     "u": "/assistant?profile=chatgpt-4o&q={{{s}}}",
@@ -3171,7 +3171,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Claude 4.5 Haiku",
+    "s": "Kagi Assistant (Claude 4.5 Haiku)",
     "d": "kagi.com",
     "t": "claude-4-haiku",
     "ts": [
@@ -3184,7 +3184,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Claude 4.5 Haiku (reasoning)",
+    "s": "Kagi Assistant (Claude 4.5 Haiku, Reasoning)",
     "d": "kagi.com",
     "t": "claude-4-haiku-thinking",
     "u": "/assistant?profile=claude-4-haiku-thinking&q={{{s}}}",
@@ -3194,7 +3194,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Claude 4.5 Opus",
+    "s": "Kagi Assistant (Claude 4.5 Opus)",
     "d": "kagi.com",
     "t": "claude-4-opus",
     "ts": [
@@ -3207,7 +3207,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Claude 4.5 Opus (reasoning)",
+    "s": "Kagi Assistant (Claude 4.5 Opus, Reasoning)",
     "d": "kagi.com",
     "t": "claude-4-opus-thinking",
     "ts": [
@@ -3220,7 +3220,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Claude 4.5 Sonnet",
+    "s": "Kagi Assistant (Claude 4.5 Sonnet)",
     "d": "kagi.com",
     "t": "claude-4-sonnet",
     "ts": [
@@ -3233,7 +3233,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Claude 4.5 Sonnet (reasoning)",
+    "s": "Kagi Assistant (Claude 4.5 Sonnet, Reasoning)",
     "d": "kagi.com",
     "t": "claude-4-sonnet-thinking",
     "ts": [
@@ -3246,7 +3246,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Deepseek Chat V3.2",
+    "s": "Kagi Assistant (Deepseek Chat V3.2)",
     "d": "kagi.com",
     "t": "deepseek",
     "u": "/assistant?profile=deepseek&q={{{s}}}",
@@ -3256,7 +3256,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Gemini 2.5 Flash",
+    "s": "Kagi Assistant (Gemini 2.5 Flash)",
     "d": "kagi.com",
     "t": "gemini-2-5-flash",
     "u": "/assistant?profile=gemini-2-5-flash&q={{{s}}}",
@@ -3266,7 +3266,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Gemini 2.5 Flash Lite",
+    "s": "Kagi Assistant (Gemini 2.5 Flash Lite)",
     "d": "kagi.com",
     "t": "gemini-2-5-flash-lite",
     "u": "/assistant?profile=gemini-2-5-flash-lite&q={{{s}}}",
@@ -3276,7 +3276,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Gemini 2.5 Pro",
+    "s": "Kagi Assistant (Gemini 2.5 Pro)",
     "d": "kagi.com",
     "t": "gemini-2-5-pro",
     "u": "/assistant?profile=gemini-2-5-pro&q={{{s}}}",
@@ -3286,7 +3286,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Gemini 3 Flash",
+    "s": "Kagi Assistant (Gemini 3 Flash)",
     "d": "kagi.com",
     "t": "gemini-3-flash",
     "ts": [
@@ -3299,7 +3299,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Gemini 3 Flash (reasoning)",
+    "s": "Kagi Assistant (Gemini 3 Flash, Reasoning)",
     "d": "kagi.com",
     "t": "gemini-3-flash-thinking",
     "u": "/assistant?profile=gemini-3-flash-thinking&q={{{s}}}",
@@ -3309,7 +3309,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Gemini 3 Pro",
+    "s": "Kagi Assistant (Gemini 3 Pro)",
     "d": "kagi.com",
     "t": "gemini-3-pro",
     "ts": [
@@ -3322,7 +3322,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - GLM-4.6",
+    "s": "Kagi Assistant (GLM-4.6)",
     "d": "kagi.com",
     "t": "glm-4-6",
     "u": "/assistant?profile=glm-4-6&q={{{s}}}",
@@ -3332,7 +3332,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - GLM-4.6 (reasoning)",
+    "s": "Kagi Assistant (GLM-4.6, Reasoning)",
     "d": "kagi.com",
     "t": "glm-4-6-thinking",
     "u": "/assistant?profile=glm-4-6-thinking&q={{{s}}}",
@@ -3342,7 +3342,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - GPT 5.1 Codex",
+    "s": "Kagi Assistant (GPT 5.1 Codex)",
     "d": "kagi.com",
     "t": "gpt-5-1-codex",
     "u": "/assistant?profile=gpt-5-1-codex&q={{{s}}}",
@@ -3352,7 +3352,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - GPT 5.2",
+    "s": "Kagi Assistant (GPT 5.2)",
     "d": "kagi.com",
     "t": "gpt-5-2",
     "u": "/assistant?profile=gpt-5-2&q={{{s}}}",
@@ -3362,7 +3362,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - GPT 5 Mini",
+    "s": "Kagi Assistant (GPT 5 Mini)",
     "d": "kagi.com",
     "t": "gpt-5-mini",
     "ts": [
@@ -3375,7 +3375,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - GPT 5 Nano",
+    "s": "Kagi Assistant (GPT 5 Nano)",
     "d": "kagi.com",
     "t": "gpt-5-nano",
     "ts": [
@@ -3388,7 +3388,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - GPT OSS 120B",
+    "s": "Kagi Assistant (GPT OSS 120B)",
     "d": "kagi.com",
     "t": "gpt-oss-120b",
     "u": "/assistant?profile=gpt-oss-120b&q={{{s}}}",
@@ -3398,7 +3398,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Grok 4",
+    "s": "Kagi Assistant (Grok 4)",
     "d": "kagi.com",
     "t": "grok-4",
     "u": "/assistant?profile=grok-4&q={{{s}}}",
@@ -3408,7 +3408,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Grok 4.1 Fast",
+    "s": "Kagi Assistant (Grok 4.1 Fast)",
     "d": "kagi.com",
     "t": "grok-4-fast",
     "u": "/assistant?profile=grok-4-fast&q={{{s}}}",
@@ -3418,7 +3418,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Grok 4.1 Fast (reasoning)",
+    "s": "Kagi Assistant (Grok 4.1 Fast, Reasoning)",
     "d": "kagi.com",
     "t": "grok-4-fast-thinking",
     "u": "/assistant?profile=grok-4-fast-thinking&q={{{s}}}",
@@ -3428,7 +3428,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Hermes-4-405B (reasoning)",
+    "s": "Kagi Assistant (Hermes-4-405B, Reasoning)",
     "d": "kagi.com",
     "t": "hermes-4-405b-thinking",
     "u": "/assistant?profile=hermes-4-405b-thinking&q={{{s}}}",
@@ -3438,7 +3438,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Kimi K2",
+    "s": "Kagi Assistant (Kimi K2)",
     "d": "kagi.com",
     "t": "kimi-k2",
     "u": "/assistant?profile=kimi-k2&q={{{s}}}",
@@ -3448,7 +3448,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Kimi K2 (reasoning)",
+    "s": "Kagi Assistant (Kimi K2, Reasoning)",
     "d": "kagi.com",
     "t": "kimi-k2-thinking",
     "u": "/assistant?profile=kimi-k2-thinking&q={{{s}}}",
@@ -3458,7 +3458,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Llama 4 Maverick",
+    "s": "Kagi Assistant (Llama 4 Maverick)",
     "d": "kagi.com",
     "t": "llama-4-maverick",
     "ts": [
@@ -3471,7 +3471,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Mistral Large 3",
+    "s": "Kagi Assistant (Mistral Large 3)",
     "d": "kagi.com",
     "t": "mistral-large",
     "u": "/assistant?profile=mistral-large&q={{{s}}}",
@@ -3481,7 +3481,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Mistral Small",
+    "s": "Kagi Assistant (Mistral Small)",
     "d": "kagi.com",
     "t": "mistral-small",
     "u": "/assistant?profile=mistral-small&q={{{s}}}",
@@ -3491,7 +3491,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - o3 pro",
+    "s": "Kagi Assistant (o3 Pro)",
     "d": "kagi.com",
     "t": "o3-pro",
     "u": "/assistant?profile=o3-pro&q={{{s}}}",
@@ -3501,7 +3501,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Qwen 3-235B",
+    "s": "Kagi Assistant (Qwen 3-235B)",
     "d": "kagi.com",
     "t": "qwen-3-235b-a22b",
     "ts": [
@@ -3514,7 +3514,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Qwen 3-235B (reasoning)",
+    "s": "Kagi Assistant (Qwen 3-235B, Reasoning)",
     "d": "kagi.com",
     "t": "qwen-3-235b-a22b-thinking",
     "ts": [
@@ -3527,7 +3527,7 @@
     ]
   },
   {
-    "s": "Kagi Assistant - Qwen 3-Coder",
+    "s": "Kagi Assistant (Qwen 3-Coder)",
     "d": "kagi.com",
     "t": "qwen-3-coder",
     "u": "/assistant?profile=qwen-3-coder&q={{{s}}}",

--- a/scripts/health_check.rb
+++ b/scripts/health_check.rb
@@ -3,19 +3,38 @@ require "net/http"
 require "uri"
 require "whirly"
 
+DEFAULT_CONCURRENCY = Integer(ENV.fetch("HEALTH_CHECK_CONCURRENCY", 25))
+OPEN_TIMEOUT = Integer(ENV.fetch("HEALTH_CHECK_OPEN_TIMEOUT", 5))
+READ_TIMEOUT = Integer(ENV.fetch("HEALTH_CHECK_READ_TIMEOUT", 10))
+HEAD_FALLBACK_CODES = [405, 501].freeze
+OUTPUT_FILE = ARGV[0]
+
+abort("Usage: ruby scripts/health_check.rb OUTPUT_FILE") if OUTPUT_FILE.nil? || OUTPUT_FILE.empty?
+
 bangs_json = JSON.parse(File.read("data/bangs.json"))
 kagi_bangs_json = JSON.parse(File.read("data/kagi_bangs.json"))
 
 errored = []
 mutex = Mutex.new
+progress_mutex = Mutex.new
+
+def request(url)
+  Net::HTTP.start(url.host, url.port, use_ssl: url.scheme == "https") do |http|
+    http.open_timeout = OPEN_TIMEOUT
+    http.read_timeout = READ_TIMEOUT
+
+    response = http.request(Net::HTTP::Head.new(url.request_uri))
+    return response unless HEAD_FALLBACK_CODES.include?(response.code.to_i)
+
+    http.request(Net::HTTP::Get.new(url.request_uri))
+  end
+end
 
 def check_url(bang, errored, mutex)
-  return if bang["u"].start_with?("/")
-
   bang_url = bang["u"].gsub("{{{s}}}", "example").strip
   url = URI.parse(bang_url)
 
-  Net::HTTP.get_response(url)
+  request(url)
 rescue Net::ReadTimeout
   # Do nothing
 rescue => e
@@ -26,30 +45,36 @@ end
 Whirly.configure spinner: "dots"
 Whirly.start
 
-all_bangs = bangs_json + kagi_bangs_json
-threads = []
+all_bangs = (bangs_json + kagi_bangs_json).reject { |bang| bang["u"].start_with?("/") }
+queue = Queue.new
+all_bangs.each { |bang| queue << bang }
+processed = 0
 
-all_bangs.each_with_index do |bang, idx|
-  Whirly.status = "Bang #{bang["s"]} (#{idx + 1}/#{all_bangs.size})"
+threads = Array.new(DEFAULT_CONCURRENCY) do
+  Thread.new do
+    loop do
+      bang = queue.pop(true)
+      check_url(bang, errored, mutex)
 
-  threads << Thread.new { check_url(bang, errored, mutex) }
-
-  # Limit the number of concurrent threads to avoid overwhelming the system
-  if threads.size >= 10
-    threads.each(&:join)
-    threads.clear
+      progress_mutex.synchronize do
+        processed += 1
+        Whirly.status = "Bang #{bang["s"]} (#{processed}/#{all_bangs.size})"
+      end
+    rescue ThreadError
+      break
+    end
   end
 end
 
-# Ensure all remaining threads are completed
 threads.each(&:join)
 
 Whirly.stop
 
-errored.each do |error|
-  bang, e = error
-
-  puts "#{bang["u"]} is offline. Error: \n  #{e}"
+File.open(OUTPUT_FILE, "w") do |file|
+  errored.each do |error|
+    bang, e = error
+    file.puts("#{bang["u"]} is offline. Error: #{e}")
+  end
 end
 
 exit 1 if errored.size > 0


### PR DESCRIPTION
Currently, many bang names do not follow a specific pattern, and their names often fail to describe their actual behavior. This makes discovering the correct bang difficult when searching by name. Since I run a search on the names, this lead to a lot of false positives and confusion.

For example, the following bang applies a Spanish language tag, but you wouldn't know it just from looking at the name:

```json
{
    "s": "duckduckgo",
    "d": "duckduckgo.com",
    "t": "ddg-es",
    "u": "https://duckduckgo.com/?q={{{s}}}&kl=xl-es&kad=es_ES&ia=about",
    "c": "Online Services",
    "sc": "Search (non-US)"
  }
```

To fix this, I created a naming specification to ensure bang names accurately reflect their function (such as including language or region tags): https://github.com/FaFre/bangs/blob/main/WEBSITE_NAMING_SPEC.md

I used an LLM to apply this spec across the repository in small batches. Therefore all of the renames are done by LLM and are **not manually reviewed**.

I am not sure if a PR of this size and impact is something that is welcomed to merge, so please let me know if there is interest. I could do this since I had a lot of tokens to burn. Another run (after maybe changes to the spec) will be not possible from my side.

Edit: I forgot to mention the PR also includes some removals of duplicate or nearly identical bangs...