### PR TITLE
Add RetroAchievements (!ra), replacing dead Resident Advisor bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -65919,17 +65919,6 @@
     "sc": "Online"
   },
   {
-    "s": "Resident Advisor",
-    "d": "www.residentadvisor.net",
-    "t": "ra",
-    "ts": [
-      "residentadvisor"
-    ],
-    "u": "https://www.residentadvisor.net/search.aspx?searchstr={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Misc"
-  },
-  {
     "s": "Raspberry Pi",
     "d": "www.raspberrypi.org",
     "t": "rpi",
@@ -67271,6 +67260,17 @@
     "u": "https://www.reta-vortaro.de/cgi-bin/sercxu.pl?sercxata={{{s}}}&kadroj=1",
     "c": "Research",
     "sc": "Reference"
+  },
+  {
+    "s": "RetroAchievements",
+    "d": "retroachievements.org",
+    "t": "ra",
+    "ts": [
+      "retroachievements"
+    ],
+    "u": "https://retroachievements.org/search?query={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (general)"
   },
   {
     "s": "RetroPie",


### PR DESCRIPTION
- **Adds** a bang for RetroAchievements (`!ra`, `!retroachievements`)
  - RetroAchievements is a service that adds achievements to retro gaming titles. Widely used: 1.7m registered users, 600k achievements across almost 11k titles.
  - `!ra` proposed as shorthand since it is a common initialism that significantly reduces length of the bang. 
- **Removes** a bang for Resident Advisor magazine (`!ra`, `!residentadvisor`)
  - This bang no longer works as `residentadvisor.net` now redirects to `ra.co` without preserving URL state.
  - As far as I am aware, `ra.co` offers no dedicated search page; the site now uses inline search so bang support seemingly cannot be re-implemented.

Please let me know if this is okay. Can open a separate PR for the Resident Advisor change, if desired.