### PR TITLE
Add the Software Heritage Archive (swh) bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -91873,6 +91873,14 @@
     "sc": "Reference"
   },
   {
+    "s": "The Software Heritage Archive",
+    "d": "archive.softwareheritage.org",
+    "t": "swh",
+    "u": "https://archive.softwareheritage.org/browse/search/?q={{{s}}}",
+    "c": "Tech",
+    "sc": "Programming"
+  },
+  {
     "s": "Haitian Creole Wikipedia",
     "d": "ht.wikipedia.org",
     "t": "htwiki",


### PR DESCRIPTION
[Software Heritage](https://www.softwareheritage.org) collects all publicly available software in source code form together with its development history, replicates it massively to ensure its preservation, and share it with everyone who needs it.

This bang triggers a search on the archive, for example `kagisearch/bangs !swh` leads to https://archive.softwareheritage.org/browse/search/?q=kagisearch/bangs