### PR TITLE
Fix !dalla with the official website of the asturian dictionary

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -17485,11 +17485,11 @@
   },
   {
     "s": "Diccionariu de l'Academia de la Llingua Asturiana",
-    "d": "asturianu.elahorcado.net",
+    "d": "www.diccionariu.alladixital.org",
     "t": "dalla",
-    "u": "https://asturianu.elahorcado.net/search.php?search={{{s}}}",
+    "u": "https://www.diccionariu.alladixital.org/index.php?pallabra={{{s}}}",
     "c": "Research",
-    "sc": "Academic"
+    "sc": "Reference (words intl)"
   },
   {
     "s": "The Dallas Morning News",


### PR DESCRIPTION
Existing URL pointed to a unofficial version of the dictionary that no longer works.

- Previous URL (not working): https://asturianu.elahorcado.net/
- Official DALLA website: https://diccionariu.alladixital.org/
- Context on the dictionary publisher: https://en.wikipedia.org/wiki/Academy_of_the_Asturian_Language 