### PR TITLE
Add bang for NixOS home-manager options search

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -90688,6 +90688,18 @@
     "sc": "Languages (nix)"
   },
   {
+    "s": "NixOS Home Manager Options Search",
+    "d": "search.nixos.org",
+    "t": "nixhopt",
+    "ts": [
+      "nixhmopt",
+      "nixhmo"
+    ],
+    "u": "https://search.nixos.org/options?query={{{s}}}&source=home_manager",
+    "c": "Tech",
+    "sc": "Languages (nix)"
+  },
+  {
     "s": "Noogle Nix Function Search",
     "d": "noogle.dev",
     "t": "noogle",


### PR DESCRIPTION
Added a bang to search for home-manager options on the [search.nixos.org](https://search.nixos.org/packages) website.

This may be a controversial decision as there is active discussion on NixOS/nixos-search#1281 about removing this search parameter from the official search website. There is another website which provides similar functionality hosted by [extranix.com](https://home-manager-options.extranix.com/). I added this bang back in December #338 and at the time the official option either didn't exist or I had no knowledge of it. If I had known about the search.nixos.org search option, I wold have not created the extranix.com bang and instead only added the former.

It appears that the discussion from nixos-search favors keeping the home-manager search option but marking it as part of the nixos-community and not an official part of NixOS. I would also be open to the idea of removing the extranix.com home-manager search bang and only having the official nixos.org search option.

I apologize for any disruption I may have caused bringing this up, but I hope that this can lead to the improved usability of Kagi Search bangs for NixOS development.