### PR TITLE
Updated Barnes & Noble

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -7172,7 +7172,7 @@
       "b&n",
       "bn"
     ],
-    "u": "https://www.barnesandnoble.com/s/{{{s}}}",
+    "u": "https://www.barnesandnoble.com/search?q={{{s}}}",
     "c": "Shopping",
     "sc": "Big box/department"
   },


### PR DESCRIPTION
The current search URL leads to HTTP 404:
- `https://www.barnesandnoble.com/s/{{{s}}}` 

New URL is:
- `https://www.barnesandnoble.com/search?q={{{s}}}`