### PR TITLE
Updated broken TPL bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -79327,7 +79327,7 @@
     "s": "Toronto Public Library",
     "d": "www.torontopubliclibrary.ca",
     "t": "tpl",
-    "u": "https://www.torontopubliclibrary.ca/search.jsp?Ntt={{{s}}}",
+    "u": "https://tpl.bibliocommons.com/v2/search?query={{{s}}}&searchType=smart",
     "c": "Research",
     "sc": "Local"
   },


### PR DESCRIPTION
Current bang is outdated due to a change in TPL's infrastructure.
This update makes the bang work with the current backend.
