### PR TITLE
change ytc bang to be a search

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -89677,7 +89677,7 @@
     "s": "YouTube Channel",
     "d": "www.youtube.com",
     "t": "ytc",
-    "u": "https://www.youtube.com/user/{{{s}}}",
+    "u": "https://www.youtube.com/results?search_query={{{s}}}&sp=EgIQAg%253D%253D",
     "c": "Entertainment",
     "sc": "Misc"
   },


### PR DESCRIPTION
@nobodywasishere noticed that the ytc bang just goes straight to the url while I was actually expecting it to do a search. thoughts?