### PR TITLE
Replace Fandom wiki bangs with independent alternatives

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -9569,9 +9569,9 @@
   },
   {
     "s": "Bloons Wiki",
-    "d": "bloons.wikia.com",
+    "d": "www.bloonswiki.com",
     "t": "bloonswiki",
-    "u": "https://bloons.wikia.com/search?query={{{s}}}",
+    "u": "https://www.bloonswiki.com/index.php?search={{{s}}}&title=Special%3ASearch",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },
@@ -16304,10 +16304,10 @@
     "sc": "Music"
   },
   {
-    "s": "Critical Role Wikia",
-    "d": "criticalrole.wikia.com",
+    "s": "Critical Role Wiki",
+    "d": "criticalrole.miraheze.org",
     "t": "critrole",
-    "u": "https://criticalrole.wikia.com/wiki/Special:Search?query={{{s}}}",
+    "u": "https://criticalrole.miraheze.org/w/index.php?search={{{s}}}&title=Special:Search",
     "c": "Entertainment",
     "sc": "Misc"
   },
@@ -17261,14 +17261,6 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Dota2 Gamepedia",
-    "d": "dota2.gamepedia.com",
-    "t": "d2gp",
-    "u": "https://dota2.gamepedia.com/Special:Search/{{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (specific)"
-  },
-  {
     "s": "Light.gg",
     "d": "www.light.gg",
     "t": "d2",
@@ -18110,9 +18102,9 @@
   },
   {
     "s": "DEATH BATTLE Wiki",
-    "d": "deathbattle.wikia.com",
+    "d": "deathbattle.miraheze.org",
     "t": "dbwiki",
-    "u": "https://deathbattle.wikia.com/wiki/Special:Search?fulltext=Search&search={{{s}}}",
+    "u": "https://deathbattle.miraheze.org/w/index.php?title=Special:Search&search={{{s}}}",
     "c": "Entertainment",
     "sc": "Misc"
   },
@@ -19600,9 +19592,10 @@
     "t": "dfw",
     "ts": [
       "dfwiki",
-      "dorf"
+      "dorf",
+      "dwarf"
     ],
-    "u": "https://dwarffortresswiki.org/index.php?title=Special:Search&search={{{s}}}&go=Go",
+    "u": "https://dwarffortresswiki.org/index.php?title=Special:Search&search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (offline)"
   },
@@ -20350,10 +20343,13 @@
     "sc": "Programming"
   },
   {
-    "s": "discworld",
-    "d": "discworld.wikia.com",
+    "s": "Terry Pratchett Wiki",
+    "d": "wiki.lspace.org",
     "t": "discworld",
-    "u": "https://discworld.wikia.com/wiki/Special:Search?query={{{s}}}",
+    "ts": [
+      "pratchett"
+    ],
+    "u": "https://wiki.lspace.org/index.php?search={{{s}}}&title=Special%3ASearch",
     "c": "Entertainment",
     "sc": "Forum"
   },
@@ -22426,14 +22422,6 @@
     "sc": "Games (general)"
   },
   {
-    "s": "dwarf fortress wiki",
-    "d": "dwarffortresswiki.org",
-    "t": "dwarf",
-    "u": "https://dwarffortresswiki.org/index.php?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (specific)"
-  },
-  {
     "s": "Deutsches Wörterbuch von Jacob Grimm und Wilhelm Grimm",
     "d": "woerterbuchnetz.de",
     "t": "dwb",
@@ -22632,9 +22620,9 @@
   },
   {
     "s": "Earthbound Wiki",
-    "d": "earthbound.wikia.com",
+    "d": "wikibound.info",
     "t": "earthbound",
-    "u": "https://earthbound.wikia.com/wiki/Special:Search?search={{{s}}}",
+    "u": "https://wikibound.info/w/index.php?title=Special%3ASearch&search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },
@@ -23920,14 +23908,6 @@
     "u": "https://www.elconjugador.com/conjugaison/verbe/espagnol/{{{s}}}.html",
     "c": "Research",
     "sc": "Academic"
-  },
-  {
-    "s": "Elder Scrolls Wiki (Page)",
-    "d": "elderscrolls.wikia.com",
-    "t": "elderwiki",
-    "u": "https://elderscrolls.wikia.com/wiki/index.php?search={{{s}}}&fulltext=Search",
-    "c": "Entertainment",
-    "sc": "Games (general)"
   },
   {
     "s": "electron.atom.io",
@@ -35037,9 +35017,9 @@
   },
   {
     "s": "GTA Wiki",
-    "d": "gta.fandom.com",
+    "d": "gta.wiki",
     "t": "gtawiki",
-    "u": "https://gta.fandom.com/search?query={{{s}}}",
+    "u": "https://gta.wiki/?search={{{s}}}&title=Special%3ASearch",
     "c": "Entertainment",
     "sc": "Games (general)"
   },
@@ -39312,9 +39292,9 @@
   },
   {
     "s": "Hypixel Skyblock Wiki",
-    "d": "hypixel-skyblock.fandom.com",
+    "d": "hypixelskyblock.minecraft.wiki",
     "t": "hysb",
-    "u": "https://hypixel-skyblock.fandom.com/wiki/Special:Search?query={{{s}}}",
+    "u": "https://hypixelskyblock.minecraft.wiki/?search={{{s}}}&title=Special:Search",
     "c": "Entertainment",
     "sc": "Games (Minecraft)"
   },
@@ -39884,14 +39864,6 @@
     "u": "https://www.nv5geospatialsoftware.com/docs/SearchResults.aspx?q={{{s}}}",
     "c": "Tech",
     "sc": "Languages (other)"
-  },
-  {
-    "s": "THE IDOLM@STER Wiki",
-    "d": "idolmaster.wikia.com",
-    "t": "idolmawiki",
-    "u": "https://idolmaster.wikia.com/wiki/Special:Search?search={{{s}}}&fulltext=Search",
-    "c": "Entertainment",
-    "sc": "Games (specific)"
   },
   {
     "s": "Idos",
@@ -40501,19 +40473,15 @@
   },
   {
     "s": "Project iM@S Wiki",
-    "d": "www.project-imas.com",
+    "d": "project-imas.wiki",
     "t": "imas",
-    "u": "https://www.project-imas.com/w/index.php?search={{{s}}}&title=Special:Search&go=Go",
+    "ts": [
+      "idolmawiki",
+      "imaswiki"
+    ],
+    "u": "https://project-imas.wiki/index.php?search={{{s}}}&title=Special%3ASearch",
     "c": "Entertainment",
     "sc": "Games (specific)"
-  },
-  {
-    "s": "project-imas.com wiki",
-    "d": "www.project-imas.com",
-    "t": "imaswiki",
-    "u": "https://www.project-imas.com/w/index.php?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (general)"
   },
   {
     "s": "Images des mathématiques",
@@ -48210,14 +48178,6 @@
     "sc": "TV"
   },
   {
-    "s": "One Wiki to Rule Them All:  The Lord of the Rings Wiki",
-    "d": "lotr.wikia.com",
-    "t": "lotr",
-    "u": "https://lotr.wikia.com/wiki/Special:Search?query={{{s}}}",
-    "c": "Research",
-    "sc": "Topical"
-  },
-  {
     "s": "LOTRO-Wiki",
     "d": "lotro-wiki.com",
     "t": "lotrow",
@@ -50731,14 +50691,6 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Minecraft Pocket Edition Wiki",
-    "d": "minecraftpocketedition.wikia.com",
-    "t": "mcpew",
-    "u": "https://minecraftpocketedition.wikia.com/wiki/Special:Search?search={{{s}}}&fulltext=Search",
-    "c": "Entertainment",
-    "sc": "Games (Minecraft)"
-  },
-  {
     "s": "Montgomery County Public Libraries (Maryland)",
     "d": "mcpl.aspendiscovery.org",
     "t": "mcplmd",
@@ -51229,20 +51181,15 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Megami Tensei Wikia",
-    "d": "megamitensei.wikia.com",
+    "s": "Megami Tensei Wiki",
+    "d": "megatenwiki.com",
     "t": "megamitensei",
-    "u": "https://megamitensei.wikia.com/wiki/Special:Search?search={{{s}}}&fulltext=Search",
+    "ts": [
+      "megatenw"
+    ],
+    "u": "https://megatenwiki.com/index.php?search={{{s}}}&title=Special%3ASearch",
     "c": "Entertainment",
     "sc": "Games (specific)"
-  },
-  {
-    "s": "Megami Tensei Wiki",
-    "d": "megamitensei.wikia.com",
-    "t": "megatenw",
-    "u": "https://megamitensei.wikia.com/wiki/Special:Search?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (general)"
   },
   {
     "s": "Meijer",
@@ -52106,14 +52053,6 @@
     "sc": "Games (Minecraft)"
   },
   {
-    "s": "Minecraft Wiki",
-    "d": "minecraft.gamepedia.com",
-    "t": "minecratwiki",
-    "u": "https://minecraft.gamepedia.com/index.php?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (Minecraft)"
-  },
-  {
     "s": "Ming Pao",
     "d": "news.mingpao.com",
     "t": "mingpao",
@@ -52497,10 +52436,10 @@
     "sc": "Games (general)"
   },
   {
-    "s": "My Little Pony: Friendship is Magic Wiki",
-    "d": "mlp.wikia.com",
+    "s": "Equestripedia",
+    "d": "equestripedia.org",
     "t": "mlp",
-    "u": "https://mlp.wikia.com/wiki/Special:Search?search={{{s}}}",
+    "u": "https://equestripedia.org/w/index.php?search={{{s}}}&title=Special%3ASearch",
     "c": "Entertainment",
     "sc": "TV"
   },
@@ -64833,9 +64772,9 @@
   },
   {
     "s": "Plants vs. Zombies Wiki",
-    "d": "plantsvszombies.wikia.com",
+    "d": "plantsvszombies.wiki.gg",
     "t": "pvz",
-    "u": "https://plantsvszombies.wikia.com/wiki/Special:Search?query={{{s}}}",
+    "u": "https://plantsvszombies.wiki.gg/wiki/Special:Search?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (general)"
   },
@@ -73878,17 +73817,12 @@
     "sc": "Search (non-US)"
   },
   {
-    "s": "SpongeBob Wikia",
-    "d": "spongebob.wikia.com",
-    "t": "spongebob",
-    "u": "https://spongebob.wikia.com/wiki/Special:Search?search={{{s}}}&fulltext=Search",
-    "c": "Entertainment",
-    "sc": "TV"
-  },
-  {
     "s": "Encyclopedia SpongeBobia",
     "d": "spongebob.fandom.com",
     "t": "sponge",
+    "ts": [
+      "spongebob"
+    ],
     "u": "https://spongebob.fandom.com/wiki/Special:Search?search={{{s}}}",
     "c": "Research",
     "sc": "Reference (fun)"
@@ -75083,10 +75017,10 @@
     "sc": "Business"
   },
   {
-    "s": "Slay the spire Wiki | Fandom powered by Wikia",
-    "d": "slay-the-spire.fandom.com",
+    "s": "Slay the Spire Wiki",
+    "d": "slaythespire.wiki.gg",
     "t": "stsw",
-    "u": "https://slay-the-spire.fandom.com/wiki/Special:Search?query={{{s}}}",
+    "u": "https://slaythespire.wiki.gg/wiki/Special:Search?search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },
@@ -75259,9 +75193,9 @@
   },
   {
     "s": "Subnautica Wiki",
-    "d": "subnautica.wikia.com",
+    "d": "wiki.subnautica.com",
     "t": "subnautica",
-    "u": "https://subnautica.wikia.com/wiki/Special:Search?search={{{s}}}",
+    "u": "https://wiki.subnautica.com/sn/?search={{{s}}}&title=Special%3ASearch",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },
@@ -77459,14 +77393,6 @@
     "sc": "Blogs (intl)"
   },
   {
-    "s": "The Elder Scrolls WIki",
-    "d": "elderscrolls.wikia.com",
-    "t": "teswiki",
-    "u": "https://elderscrolls.wikia.com/wiki/Special:Search?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (specific)"
-  },
-  {
     "s": "TEU",
     "d": "eur-lex.europa.eu",
     "t": "teu",
@@ -77646,7 +77572,8 @@
     "t": "tgate",
     "ts": [
       "tolkiengateway",
-      "tolkien"
+      "tolkien",
+      "lotr"
     ],
     "u": "https://tolkiengateway.net/wiki/Special:Search?search={{{s}}}&go=Go",
     "c": "Entertainment",
@@ -81191,7 +81118,11 @@
     "s": "The Unofficial Elder Scrolls Pages",
     "d": "en.uesp.net",
     "t": "uesp",
-    "u": "https://en.uesp.net/w/index.php?title=Special:Search&profile=default&search={{{s}}}&fulltext=Search",
+    "ts": [
+      "teswiki",
+      "elderwiki"
+    ],
+    "u": "https://en.uesp.net/w/index.php?title=Special%3ASearch&search={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },
@@ -81619,10 +81550,10 @@
     "sc": "Academic"
   },
   {
-    "s": "Undertale wiki",
-    "d": "undertale.wikia.com",
+    "s": "Undertale Wiki",
+    "d": "undertale.wiki",
     "t": "undertale",
-    "u": "https://undertale.wikia.com/wiki/Special:Search?search={{{s}}}&fulltext=Search",
+    "u": "https://undertale.wiki/index.php?search={{{s}}}&title=Special:Search",
     "c": "Entertainment",
     "sc": "Games (offline)"
   },
@@ -88698,9 +88629,9 @@
   },
   {
     "s": "Xenoblade Wiki",
-    "d": "xenoblade.wikia.com",
+    "d": "www.xenoserieswiki.org",
     "t": "xenoblade",
-    "u": "https://xenoblade.wikia.com/wiki/Special:Search?search={{{s}}}",
+    "u": "https://www.xenoserieswiki.org/w/index.php?search={{{s}}}&title=Special%3ASearch",
     "c": "Entertainment",
     "sc": "Games (specific)"
   },


### PR DESCRIPTION
Independent wikis were gathered from [Indie Wiki Buddy](https://getindie.wiki/), a project dedicated to boosting active indie wikis in search results through use of a browser extension

Additionally cleaned up some redundant wiki bangs

Properly, this time