### PR TITLE
Add the Wavedash bangs (wavedash, wvd, wvdsh)

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -84813,6 +84813,18 @@
     "sc": "Tools (URLs)"
   },
   {
+    "s": "Wavedash",
+    "d": "wavedash.com",
+    "t": "wavedash",
+    "ts": [
+      "wvd",
+      "wvdsh"
+    ],
+    "u": "https://wavedash.com/browse?q={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (general)"
+  },
+  {
     "s": "Wolfram Alpha",
     "d": "wolframalpha.com",
     "t": "wa",


### PR DESCRIPTION
Adds a bang for wavedash.com (browser-based gaming platform). Trigger !wavedash (aliases !wvd, !wvdsh) searches the games catalog via ?q=.