### PR TITLE
Add direct Modrinth project slug

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -50597,6 +50597,20 @@
     "sc": "Games (Minecraft)"
   },
   {
+    "s": "Modrinth (Project by slug)",
+    "d": "modrinth.com",
+    "t": "mdproject",
+    "ts": [
+      "mrproject"
+    ],
+    "u": "https://modrinth.com/project/{{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (Minecraft)",
+    "fmt": [
+      "open_base_path"
+    ]
+  },
+  {
     "s": "Modrinth (Mods)",
     "d": "modrinth.com",
     "t": "mdmods",


### PR DESCRIPTION
This follows the same kind of thing that !ghrepo does, but for Modrinth projects (and allows both `mr` and `md` versions like the other Modrinth bangs)

Modrinth handles the lookup of what kind of project, so with a search of `mellow`, you'd end up at the [Mellow](https://modrinth.com/project/mellow) shader pack, but `iris` will bring you to the [Iris](https://modrinth.com/project/iris) mod. It works both with developer-decided slugs as well as individual project IDs (in fact, that's the way its permalinks work, probably because of things like [Simple Voice Chat](https://modrinth.com/project/simple-voice-chat), which is both mod and plugin)