### PR TITLE
Add bang for Podcast Index

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -64389,6 +64389,18 @@
     "sc": "Blogs"
   },
   {
+    "s": "Podcast Index",
+    "d": "podcastindex.org",
+    "t": "podindex",
+    "ts": [
+      "poddex",
+      "podcastindex"
+    ],
+    "u": "https://podcastindex.org/search?{{{s}}}&type=all",
+    "c": "Online Services",
+    "sc": "Search"
+  },
+  {
     "s": "PSDDude Photoshop Tutorials",
     "d": "www.psd-dude.com",
     "t": "psddude",


### PR DESCRIPTION
[Podcast Index](https://podcastindex.org/) search allows the user to search for a podcast and get the url to the rss feed.