### PR TITLE
Add CHZZK and SOOP bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -11434,6 +11434,14 @@
     "sc": "Online (intl)"
   },
   {
+    "s": "CHZZK",
+    "d": "chzzk.naver.com",
+    "t": "chzzk",
+    "u": "https://chzzk.naver.com/search?query={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (general)"
+  },
+  {
     "s": "Camptocamp",
     "d": "www.camptocamp.org",
     "t": "c2c",
@@ -73016,6 +73024,14 @@
     "u": "https://www.socksandmore.dk/catalogsearch/result/?q={{{s}}}",
     "c": "Shopping",
     "sc": "Online"
+  },
+  {
+    "s": "SOOP",
+    "d": "sooplive.com",
+    "t": "soop",
+    "u": "https://www.sooplive.com/search?szKeyword={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (general)"
   },
   {
     "s": "StackOverflow Companies",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -73027,7 +73027,7 @@
   },
   {
     "s": "SOOP",
-    "d": "sooplive.com",
+    "d": "www.sooplive.com",
     "t": "soop",
     "u": "https://www.sooplive.com/search?szKeyword={{{s}}}",
     "c": "Entertainment",


### PR DESCRIPTION
[CHZZK](https://chzzk.naver.com) (치지직) and [SOOP](https://sooplive.com) are popular alternatives to Twitch in South Korea, widely used for stream gaming and Just Chatting content.