### PR TITLE
change roblox experiences to roblox games

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -67906,7 +67906,7 @@
     "sc": "Music"
   },
   {
-    "s": "Roblox Experiences",
+    "s": "Roblox Games",
     "d": "www.roblox.com",
     "t": "robloxg",
     "ts": [


### PR DESCRIPTION
roblox recently renamed experiences back to games. the bang does not reflect this.