### PR TITLE
Add Oxlint bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -57463,6 +57463,28 @@
     "sc": "Learning (intl)"
   },
   {
+    "s": "Oxlint (Rule)",
+    "d": "oxc.rs",
+    "t": "oxlint",
+    "u": "https://oxc.rs/docs/guide/usage/linter/rules/{{{s}}}",
+    "c": "Tech",
+    "sc": "Languages (javascript)",
+    "fmt": []
+  },
+  {
+    "s": "Oxlint (ESLint Rule)",
+    "d": "oxc.rs",
+    "t": "oxlinte",
+    "ts": [
+      "oxlintes",
+      "oxlinteslint"
+    ],
+    "u": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/{{{s}}}",
+    "c": "Tech",
+    "sc": "Languages (javascript)",
+    "fmt": []
+  },
+  {
     "s": "OverAPI Cheatsheet",
     "d": "overapi.com",
     "t": "oapi",


### PR DESCRIPTION
Adds bangs for Oxlint, similar to the existing ESLint bang.

Includes "Oxlint (ESLint Rule)" bang for adding the `eslint/` prefix as the core rules have an implicit eslint prefix that could otherwise trip people up or just be inconvenient to type.