### PR TITLE
some wikimedia-related cleanup

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -90752,7 +90752,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Wikipedia (English)",
+    "s": "English Wikipedia",
     "d": "en.wikipedia.org",
     "t": "wen",
     "ts": [
@@ -91656,7 +91656,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Norwegian (Nynorsk) Wikipedia",
+    "s": "Norwegian Nynorsk Wikipedia",
     "d": "nn.wikipedia.org",
     "t": "wnn",
     "ts": [
@@ -92603,7 +92603,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Wikipedia - Zitierhilfe",
+    "s": "German Wikipedia CiteThisPage",
     "d": "de.wikipedia.org",
     "t": "cwde",
     "u": "https://de.wikipedia.org/w/index.php?title=Spezial:Zitierhilfe&page={{{s}}}",
@@ -92637,7 +92637,7 @@
     "sc": "Games (Pokemon)"
   },
   {
-    "s": "Wikipedia – Friddje diehtosátnegirji",
+    "s": "Northern Sami Wikipedia",
     "d": "se.wikipedia.org",
     "t": "wse",
     "u": "https://se.wikipedia.org/w/index.php?search={{{s}}}",
@@ -92645,7 +92645,7 @@
     "sc": "Reference"
   },
   {
-    "s": "Wikipedia (VO)",
+    "s": "Volapük Wikipedia",
     "d": "vo.wikipedia.org",
     "t": "wvo",
     "u": "https://vo.wikipedia.org/w/index.php?search={{{s}}}",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -90754,7 +90754,7 @@
   {
     "s": "English Wikipedia",
     "d": "en.wikipedia.org",
-    "t": "wen",
+    "t": "enwikipedia",
     "ts": [
       "enwiki",
       "wikien",
@@ -90800,7 +90800,7 @@
   {
     "s": "German Wikipedia",
     "d": "de.wikipedia.org",
-    "t": "wde",
+    "t": "dewikipedia",
     "ts": [
       "dewiki",
       "wikide",
@@ -90816,7 +90816,7 @@
   {
     "s": "French Wikipedia",
     "d": "fr.wikipedia.org",
-    "t": "wfr",
+    "t": "frwikipedia",
     "ts": [
       "wikifr"
     ],
@@ -90827,7 +90827,7 @@
   {
     "s": "Spanish Wikipedia",
     "d": "es.wikipedia.org",
-    "t": "wes",
+    "t": "eswikipedia",
     "ts": [
       "eswiki",
       "wikies"
@@ -90839,7 +90839,7 @@
   {
     "s": "Japanese Wikipedia",
     "d": "ja.wikipedia.org",
-    "t": "wja",
+    "t": "jawikipedia",
     "ts": [
       "jawiki",
       "wikija",
@@ -90852,7 +90852,7 @@
   {
     "s": "Russian Wikipedia",
     "d": "ru.wikipedia.org",
-    "t": "wru",
+    "t": "ruwikipedia",
     "ts": [
       "ruwiki",
       "wikiru",
@@ -90868,7 +90868,7 @@
   {
     "s": "Portuguese Wikipedia",
     "d": "pt.wikipedia.org",
-    "t": "wpt",
+    "t": "ptwikipedia",
     "ts": [
       "ptwiki",
       "wikipt"
@@ -90880,7 +90880,7 @@
   {
     "s": "Italian Wikipedia",
     "d": "it.wikipedia.org",
-    "t": "wit",
+    "t": "itwikipedia",
     "ts": [
       "itwiki",
       "wikiit",
@@ -90893,7 +90893,7 @@
   {
     "s": "Chinese Wikipedia",
     "d": "zh.wikipedia.org",
-    "t": "wzh",
+    "t": "zhwikipedia",
     "ts": [
       "zhwiki",
       "wikizh",
@@ -90906,7 +90906,7 @@
   {
     "s": "Persian Wikipedia",
     "d": "fa.wikipedia.org",
-    "t": "wfa",
+    "t": "fawikipedia",
     "ts": [
       "fawiki",
       "wikifa",
@@ -90919,7 +90919,7 @@
   {
     "s": "Polish Wikipedia",
     "d": "pl.wikipedia.org",
-    "t": "wpl",
+    "t": "plwikipedia",
     "ts": [
       "plwiki",
       "wikipl",
@@ -90932,7 +90932,7 @@
   {
     "s": "Arabic Wikipedia",
     "d": "ar.wikipedia.org",
-    "t": "war",
+    "t": "arwikipedia",
     "ts": [
       "arwiki",
       "wikiar"
@@ -90944,7 +90944,7 @@
   {
     "s": "Dutch Wikipedia",
     "d": "nl.wikipedia.org",
-    "t": "wnl",
+    "t": "nlwikipedia",
     "ts": [
       "nlwiki",
       "wikinl",
@@ -90957,7 +90957,7 @@
   {
     "s": "Hebrew Wikipedia",
     "d": "he.wikipedia.org",
-    "t": "whe",
+    "t": "hewikipedia",
     "ts": [
       "hewiki",
       "wikihe",
@@ -90971,7 +90971,7 @@
   {
     "s": "Ukrainian Wikipedia",
     "d": "uk.wikipedia.org",
-    "t": "wuk",
+    "t": "ukwikipedia",
     "ts": [
       "ukwiki",
       "wikiuk"
@@ -90983,7 +90983,7 @@
   {
     "s": "Turkish Wikipedia",
     "d": "tr.wikipedia.org",
-    "t": "wtr",
+    "t": "trwikipedia",
     "ts": [
       "trwiki",
       "wikitr"
@@ -90995,7 +90995,7 @@
   {
     "s": "Czech Wikipedia",
     "d": "cs.wikipedia.org",
-    "t": "wcs",
+    "t": "cswikipedia",
     "ts": [
       "cswiki",
       "wikics",
@@ -91008,7 +91008,7 @@
   {
     "s": "Indonesian Wikipedia",
     "d": "id.wikipedia.org",
-    "t": "wid",
+    "t": "idwikipedia",
     "ts": [
       "idwiki",
       "wikiid"
@@ -91020,7 +91020,7 @@
   {
     "s": "Korean Wikipedia",
     "d": "ko.wikipedia.org",
-    "t": "wko",
+    "t": "kowikipedia",
     "ts": [
       "kowiki",
       "wikiko"
@@ -91032,7 +91032,7 @@
   {
     "s": "Swedish Wikipedia",
     "d": "sv.wikipedia.org",
-    "t": "wsv",
+    "t": "svwikipedia",
     "ts": [
       "svwiki",
       "wikisv"
@@ -91044,7 +91044,7 @@
   {
     "s": "Finnish Wikipedia",
     "d": "fi.wikipedia.org",
-    "t": "wfi",
+    "t": "fiwikipedia",
     "ts": [
       "fiwiki",
       "wikifi",
@@ -91057,7 +91057,7 @@
   {
     "s": "Simple English Wikipedia",
     "d": "simple.wikipedia.org",
-    "t": "wsimple",
+    "t": "simplewikipedia",
     "ts": [
       "simplewiki",
       "wikisimple",
@@ -91070,7 +91070,7 @@
   {
     "s": "Vietnamese Wikipedia",
     "d": "vi.wikipedia.org",
-    "t": "wvi",
+    "t": "viwikipedia",
     "ts": [
       "viwiki",
       "wikivi",
@@ -91084,7 +91084,7 @@
   {
     "s": "Hungarian Wikipedia",
     "d": "hu.wikipedia.org",
-    "t": "whu",
+    "t": "huwikipedia",
     "ts": [
       "huwiki",
       "wikihu"
@@ -91096,7 +91096,7 @@
   {
     "s": "Catalan Wikipedia",
     "d": "ca.wikipedia.org",
-    "t": "wca",
+    "t": "cawikipedia",
     "ts": [
       "cawiki",
       "wikica",
@@ -91110,7 +91110,7 @@
   {
     "s": "Thai Wikipedia",
     "d": "th.wikipedia.org",
-    "t": "wikith",
+    "t": "thwikipedia",
     "u": "https://th.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Reference"
@@ -91118,7 +91118,7 @@
   {
     "s": "Norwegian Wikipedia",
     "d": "no.wikipedia.org",
-    "t": "wno",
+    "t": "nowikipedia",
     "ts": [
       "nowiki",
       "wikino"
@@ -91130,7 +91130,7 @@
   {
     "s": "Serbian Wikipedia",
     "d": "sr.wikipedia.org",
-    "t": "wsr",
+    "t": "srwikipedia",
     "ts": [
       "srwiki",
       "wikisr"
@@ -91142,7 +91142,7 @@
   {
     "s": "Greek Wikipedia",
     "d": "el.wikipedia.org",
-    "t": "wel",
+    "t": "elwikipedia",
     "ts": [
       "elwiki",
       "wikiel",
@@ -91155,7 +91155,7 @@
   {
     "s": "Hindi Wikipedia",
     "d": "hi.wikipedia.org",
-    "t": "whi",
+    "t": "hiwikipedia",
     "ts": [
       "hiwiki",
       "wikihi",
@@ -91168,7 +91168,7 @@
   {
     "s": "Bengali Wikipedia",
     "d": "bn.wikipedia.org",
-    "t": "wbn",
+    "t": "bnwikipedia",
     "ts": [
       "bnwiki",
       "wikibn"
@@ -91180,7 +91180,7 @@
   {
     "s": "Romanian Wikipedia",
     "d": "ro.wikipedia.org",
-    "t": "wro",
+    "t": "rowikipedia",
     "ts": [
       "wikiro"
     ],
@@ -91191,7 +91191,7 @@
   {
     "s": "Estonian Wikipedia",
     "d": "et.wikipedia.org",
-    "t": "wet",
+    "t": "etwikipedia",
     "ts": [
       "etwiki",
       "wikiet",
@@ -91204,7 +91204,7 @@
   {
     "s": "Danish Wikipedia",
     "d": "da.wikipedia.org",
-    "t": "wda",
+    "t": "dawikipedia",
     "ts": [
       "wikida",
       "wdk"
@@ -91216,7 +91216,7 @@
   {
     "s": "Uzbek Wikipedia",
     "d": "uz.wikipedia.org",
-    "t": "wuz",
+    "t": "uzwikipedia",
     "ts": [
       "uzwiki",
       "wikiuz"
@@ -91228,7 +91228,7 @@
   {
     "s": "Bulgarian Wikipedia",
     "d": "bg.wikipedia.org",
-    "t": "wbg",
+    "t": "bgwikipedia",
     "ts": [
       "bgwiki",
       "wikibg"
@@ -91240,7 +91240,7 @@
   {
     "s": "Azerbaijani Wikipedia",
     "d": "az.wikipedia.org",
-    "t": "waz",
+    "t": "azwikipedia",
     "ts": [
       "azwiki",
       "wikiaz"
@@ -91252,7 +91252,7 @@
   {
     "s": "Malay Wikipedia",
     "d": "ms.wikipedia.org",
-    "t": "wms",
+    "t": "mswikipedia",
     "ts": [
       "mswiki",
       "wikims"
@@ -91264,7 +91264,7 @@
   {
     "s": "Slovak Wikipedia",
     "d": "sk.wikipedia.org",
-    "t": "wsk",
+    "t": "skwikipedia",
     "ts": [
       "skwiki",
       "wikisk"
@@ -91276,7 +91276,7 @@
   {
     "s": "Basque Wikipedia",
     "d": "eu.wikipedia.org",
-    "t": "weu",
+    "t": "euwikipedia",
     "ts": [
       "euwiki",
       "wikieu"
@@ -91288,7 +91288,7 @@
   {
     "s": "Armenian Wikipedia",
     "d": "hy.wikipedia.org",
-    "t": "why",
+    "t": "hywikipedia",
     "ts": [
       "hywiki",
       "wikihy",
@@ -91301,7 +91301,7 @@
   {
     "s": "Croatian Wikipedia",
     "d": "hr.wikipedia.org",
-    "t": "whr",
+    "t": "hrwikipedia",
     "ts": [
       "wikihr"
     ],
@@ -91312,7 +91312,7 @@
   {
     "s": "Kazakh Wikipedia",
     "d": "kk.wikipedia.org",
-    "t": "wkk",
+    "t": "kkwikipedia",
     "ts": [
       "kkwiki",
       "wikikk"
@@ -91324,7 +91324,7 @@
   {
     "s": "Lithuanian Wikipedia",
     "d": "lt.wikipedia.org",
-    "t": "wlt",
+    "t": "ltwikipedia",
     "ts": [
       "ltwiki",
       "wikilt"
@@ -91336,7 +91336,7 @@
   {
     "s": "Slovene Wikipedia",
     "d": "sl.wikipedia.org",
-    "t": "wsl",
+    "t": "slwikipedia",
     "ts": [
       "wikisl"
     ],
@@ -91347,7 +91347,7 @@
   {
     "s": "Esperanto Wikipedia",
     "d": "eo.wikipedia.org",
-    "t": "weo",
+    "t": "eowikipedia",
     "ts": [
       "eowiki",
       "wikieo",
@@ -91361,7 +91361,7 @@
   {
     "s": "Latvian Wikipedia",
     "d": "lv.wikipedia.org",
-    "t": "wlv",
+    "t": "lvwikipedia",
     "ts": [
       "lvwiki",
       "wikilv"
@@ -91373,7 +91373,7 @@
   {
     "s": "Georgian Wikipedia",
     "d": "ka.wikipedia.org",
-    "t": "wka",
+    "t": "kawikipedia",
     "ts": [
       "kawiki",
       "wikika"
@@ -91385,7 +91385,7 @@
   {
     "s": "Tamil Wikipedia",
     "d": "ta.wikipedia.org",
-    "t": "tawiki",
+    "t": "tawikipedia",
     "ts": [
       "wikita",
       "tawk"
@@ -91397,7 +91397,7 @@
   {
     "s": "Galician Wikipedia",
     "d": "gl.wikipedia.org",
-    "t": "wgl",
+    "t": "glwikipedia",
     "ts": [
       "wikigl",
       "wgal"
@@ -91409,7 +91409,7 @@
   {
     "s": "Albanian Wikipedia",
     "d": "sq.wikipedia.org",
-    "t": "wsq",
+    "t": "sqwikipedia",
     "ts": [
       "sqwiki",
       "wikisq"
@@ -91421,7 +91421,7 @@
   {
     "s": "Urdu Wikipedia",
     "d": "ur.wikipedia.org",
-    "t": "wur",
+    "t": "urwikipedia",
     "ts": [
       "urwiki",
       "wikiur"
@@ -91433,7 +91433,7 @@
   {
     "s": "Belarusian Wikipedia",
     "d": "be.wikipedia.org",
-    "t": "wbe",
+    "t": "bewikipedia",
     "ts": [
       "bewiki",
       "wikibe"
@@ -91445,7 +91445,7 @@
   {
     "s": "Macedonian Wikipedia",
     "d": "mk.wikipedia.org",
-    "t": "wmk",
+    "t": "mkwikipedia",
     "ts": [
       "mkwiki",
       "wikimk"
@@ -91457,7 +91457,7 @@
   {
     "s": "Malayalam Wikipedia",
     "d": "ml.wikipedia.org",
-    "t": "wml",
+    "t": "mlwikipedia",
     "ts": [
       "mlwiki",
       "wikiml"
@@ -91469,7 +91469,7 @@
   {
     "s": "Telugu Wikipedia",
     "d": "te.wikipedia.org",
-    "t": "wte",
+    "t": "tewikipedia",
     "ts": [
       "tewiki",
       "wikite"
@@ -91481,7 +91481,7 @@
   {
     "s": "Hausa Wikipedia",
     "d": "ha.wikipedia.org",
-    "t": "wha",
+    "t": "hawikipedia",
     "ts": [
       "hawiki",
       "wikiha"
@@ -91493,7 +91493,7 @@
   {
     "s": "Afrikaans Wikipedia",
     "d": "af.wikipedia.org",
-    "t": "waf",
+    "t": "afwikipedia",
     "ts": [
       "afwiki",
       "wikiaf"
@@ -91505,7 +91505,7 @@
   {
     "s": "Egyptian Arabic Wikipedia",
     "d": "arz.wikipedia.org",
-    "t": "warz",
+    "t": "arzwikipedia",
     "ts": [
       "arzwiki",
       "wikiarz"
@@ -91517,7 +91517,7 @@
   {
     "s": "Serbo-Croatian Wikipedia",
     "d": "sh.wikipedia.org",
-    "t": "shwiki",
+    "t": "shwikipedia",
     "ts": [
       "wikish"
     ],
@@ -91528,7 +91528,7 @@
   {
     "s": "Kannada Wikipedia",
     "d": "kn.wikipedia.org",
-    "t": "wkn",
+    "t": "knwikipedia",
     "ts": [
       "knwiki",
       "wikikn"
@@ -91540,7 +91540,7 @@
   {
     "s": "Swahili Wikipedia",
     "d": "sw.wikipedia.org",
-    "t": "wsw",
+    "t": "swwikipedia",
     "ts": [
       "wikisw"
     ],
@@ -91551,7 +91551,7 @@
   {
     "s": "Bosnian Wikipedia",
     "d": "bs.wikipedia.org",
-    "t": "bswiki",
+    "t": "bswikipedia",
     "ts": [
       "wikibs"
     ],
@@ -91562,7 +91562,7 @@
   {
     "s": "Icelandic Wikipedia",
     "d": "is.wikipedia.org",
-    "t": "wis",
+    "t": "iswikipedia",
     "ts": [
       "iswiki",
       "wikiis"
@@ -91574,7 +91574,7 @@
   {
     "s": "Central Bikol Wikipedia",
     "d": "bcl.wikipedia.org",
-    "t": "wbcl",
+    "t": "bclwikipedia",
     "ts": [
       "bclwiki",
       "wikibcl"
@@ -91586,7 +91586,7 @@
   {
     "s": "Latin Wikipedia",
     "d": "la.wikipedia.org",
-    "t": "wla",
+    "t": "lawikipedia",
     "ts": [
       "lawiki",
       "wikila",
@@ -91599,7 +91599,7 @@
   {
     "s": "Sorani Kurdish Wikipedia",
     "d": "ckb.wikipedia.org",
-    "t": "wckb",
+    "t": "ckbwikipedia",
     "ts": [
       "ckbwiki",
       "wikickb"
@@ -91611,7 +91611,7 @@
   {
     "s": "Cebuano Wikipedia",
     "d": "ceb.wikipedia.org",
-    "t": "wceb",
+    "t": "cebwikipedia",
     "ts": [
       "cebwiki",
       "wikiceb"
@@ -91623,7 +91623,7 @@
   {
     "s": "Marathi Wikipedia",
     "d": "mr.wikipedia.org",
-    "t": "wmr",
+    "t": "mrwikipedia",
     "ts": [
       "mrwiki",
       "wikimr"
@@ -91635,7 +91635,7 @@
   {
     "s": "Assamese Wikipedia",
     "d": "as.wikipedia.org",
-    "t": "was",
+    "t": "aswikipedia",
     "ts": [
       "aswiki",
       "wikias"
@@ -91647,7 +91647,7 @@
   {
     "s": "Tagalog Wikipedia",
     "d": "tl.wikipedia.org",
-    "t": "tlwiki",
+    "t": "tlwikipedia",
     "ts": [
       "wikitl"
     ],
@@ -91658,7 +91658,7 @@
   {
     "s": "Norwegian Nynorsk Wikipedia",
     "d": "nn.wikipedia.org",
-    "t": "wnn",
+    "t": "nnwikipedia",
     "ts": [
       "nnwiki",
       "wikinn"
@@ -91670,7 +91670,7 @@
   {
     "s": "Igbo Wikipedia",
     "d": "ig.wikipedia.org",
-    "t": "wig",
+    "t": "igwikipedia",
     "ts": [
       "igwiki",
       "wikiig"
@@ -91682,7 +91682,7 @@
   {
     "s": "Welsh Wikipedia",
     "d": "cy.wikipedia.org",
-    "t": "wcy",
+    "t": "cywikipedia",
     "ts": [
       "cywiki",
       "wikicy"
@@ -91694,7 +91694,7 @@
   {
     "s": "Mongolian Wikipedia",
     "d": "mn.wikipedia.org",
-    "t": "wmn",
+    "t": "mnwikipedia",
     "ts": [
       "mnwiki",
       "wikimn"
@@ -91706,7 +91706,7 @@
   {
     "s": "Nepali Wikipedia",
     "d": "ne.wikipedia.org",
-    "t": "wne",
+    "t": "newikipedia",
     "ts": [
       "newiki",
       "wikine"
@@ -91718,7 +91718,7 @@
   {
     "s": "Burmese Wikipedia",
     "d": "my.wikipedia.org",
-    "t": "wmy",
+    "t": "mywikipedia",
     "ts": [
       "mywiki",
       "wikimy"
@@ -91730,7 +91730,7 @@
   {
     "s": "South Azerbaijani Wikipedia",
     "d": "azb.wikipedia.org",
-    "t": "wazb",
+    "t": "azbwikipedia",
     "ts": [
       "azbwiki",
       "wikiazb"
@@ -91742,7 +91742,7 @@
   {
     "s": "Asturian Wikipedia",
     "d": "ast.wikipedia.org",
-    "t": "wast",
+    "t": "astwikipedia",
     "ts": [
       "astwiki",
       "wikiast"
@@ -91754,7 +91754,7 @@
   {
     "s": "Occitan Wikipedia",
     "d": "oc.wikipedia.org",
-    "t": "woc",
+    "t": "ocwikipedia",
     "ts": [
       "ocwiki",
       "wikioc"
@@ -91766,7 +91766,7 @@
   {
     "s": "Punjabi Wikipedia",
     "d": "pa.wikipedia.org",
-    "t": "wpa",
+    "t": "pawikipedia",
     "ts": [
       "pawiki",
       "wikipa"
@@ -91778,7 +91778,7 @@
   {
     "s": "Irish Wikipedia",
     "d": "ga.wikipedia.org",
-    "t": "wga",
+    "t": "gawikipedia",
     "ts": [
       "gawiki",
       "wikiga"
@@ -91790,7 +91790,7 @@
   {
     "s": "Breton Wikipedia",
     "d": "br.wikipedia.org",
-    "t": "wbr",
+    "t": "brwikipedia",
     "ts": [
       "brwiki",
       "wikibr"
@@ -91802,7 +91802,7 @@
   {
     "s": "Kyrgyz Wikipedia",
     "d": "ky.wikipedia.org",
-    "t": "wky",
+    "t": "kywikipedia",
     "ts": [
       "kywiki",
       "wikiky"
@@ -91814,7 +91814,7 @@
   {
     "s": "Kurdish Wikipedia",
     "d": "ku.wikipedia.org",
-    "t": "kuwiki",
+    "t": "kuwikipedia",
     "ts": [
       "wikiku"
     ],
@@ -91825,7 +91825,7 @@
   {
     "s": "Sinhala Wikipedia",
     "d": "si.wikipedia.org",
-    "t": "wsi",
+    "t": "siwikipedia",
     "ts": [
       "siwiki",
       "wikisi"
@@ -91837,7 +91837,7 @@
   {
     "s": "West Frisian Wikipedia",
     "d": "fy.wikipedia.org",
-    "t": "wfy",
+    "t": "fywikipedia",
     "ts": [
       "fywiki",
       "wikify"
@@ -91849,7 +91849,7 @@
   {
     "s": "Alemannic Wikipedia",
     "d": "als.wikipedia.org",
-    "t": "wals",
+    "t": "alswikipedia",
     "ts": [
       "alswiki",
       "wikials"
@@ -91861,7 +91861,7 @@
   {
     "s": "Javanese Wikipedia",
     "d": "jv.wikipedia.org",
-    "t": "wjv",
+    "t": "jvwikipedia",
     "ts": [
       "jvwiki",
       "wikijv"
@@ -91873,7 +91873,7 @@
   {
     "s": "Tajik Wikipedia",
     "d": "tg.wikipedia.org",
-    "t": "tgwiki",
+    "t": "tgwikipedia",
     "ts": [
       "wikitg"
     ],
@@ -91884,7 +91884,7 @@
   {
     "s": "Scots Wikipedia",
     "d": "sco.wikipedia.org",
-    "t": "wsco",
+    "t": "scowikipedia",
     "ts": [
       "scowiki",
       "wikisco"
@@ -91904,7 +91904,7 @@
   {
     "s": "Haitian Creole Wikipedia",
     "d": "ht.wikipedia.org",
-    "t": "htwiki",
+    "t": "htwikipedia",
     "ts": [
       "wikiht"
     ],
@@ -91915,7 +91915,7 @@
   {
     "s": "Tatar Wikipedia",
     "d": "tt.wikipedia.org",
-    "t": "wtt",
+    "t": "ttwikipedia",
     "ts": [
       "ttwiki",
       "wikitt"
@@ -91927,7 +91927,7 @@
   {
     "s": "Bashkir Wikipedia",
     "d": "ba.wikipedia.org",
-    "t": "wba",
+    "t": "bawikipedia",
     "ts": [
       "bawiki",
       "wikiba"
@@ -91939,7 +91939,7 @@
   {
     "s": "Luxembourgish Wikipedia",
     "d": "lb.wikipedia.org",
-    "t": "wlb",
+    "t": "lbwikipedia",
     "ts": [
       "lbwiki",
       "wikilb"
@@ -91951,7 +91951,7 @@
   {
     "s": "Somali Wikipedia",
     "d": "so.wikipedia.org",
-    "t": "sowiki",
+    "t": "sowikipedia",
     "ts": [
       "wikiso"
     ],
@@ -91962,7 +91962,7 @@
   {
     "s": "Yoruba Wikipedia",
     "d": "yo.wikipedia.org",
-    "t": "wyo",
+    "t": "yowikipedia",
     "ts": [
       "yowiki",
       "wikiyo"
@@ -91974,7 +91974,7 @@
   {
     "s": "Gujarati Wikipedia",
     "d": "gu.wikipedia.org",
-    "t": "wgu",
+    "t": "guwikipedia",
     "ts": [
       "guwiki",
       "wikigu"
@@ -91986,7 +91986,7 @@
   {
     "s": "Waray Wikipedia",
     "d": "war.wikipedia.org",
-    "t": "wwar",
+    "t": "warwikipedia",
     "ts": [
       "warwiki",
       "wikiwar"
@@ -91998,7 +91998,7 @@
   {
     "s": "Karakalpak Wikipedia",
     "d": "kaa.wikipedia.org",
-    "t": "wkaa",
+    "t": "kaawikipedia",
     "ts": [
       "kaawiki",
       "wikikaa"
@@ -92010,7 +92010,7 @@
   {
     "s": "Aragonese Wikipedia",
     "d": "an.wikipedia.org",
-    "t": "wan",
+    "t": "anwikipedia",
     "ts": [
       "anwiki",
       "wikian"
@@ -92022,7 +92022,7 @@
   {
     "s": "Zulu Wikipedia",
     "d": "zu.wikipedia.org",
-    "t": "wzu",
+    "t": "zuwikipedia",
     "ts": [
       "zuwiki",
       "wikizu"
@@ -92034,7 +92034,7 @@
   {
     "s": "Khmer Wikipedia",
     "d": "km.wikipedia.org",
-    "t": "wkm",
+    "t": "kmwikipedia",
     "ts": [
       "kmwiki",
       "wikikm"
@@ -92046,7 +92046,7 @@
   {
     "s": "Bavarian Wikipedia",
     "d": "bar.wikipedia.org",
-    "t": "wbar",
+    "t": "barwikipedia",
     "ts": [
       "barwiki",
       "wikibar"
@@ -92058,7 +92058,7 @@
   {
     "s": "Ido Wikipedia",
     "d": "io.wikipedia.org",
-    "t": "wio",
+    "t": "iowikipedia",
     "ts": [
       "iowiki",
       "wikiio"
@@ -92070,7 +92070,7 @@
   {
     "s": "Western Punjabi Wikipedia",
     "d": "pnb.wikipedia.org",
-    "t": "wpnb",
+    "t": "pnbwikipedia",
     "ts": [
       "pnbwiki",
       "wikipnb"
@@ -92082,7 +92082,7 @@
   {
     "s": "Wu Wikipedia",
     "d": "wuu.wikipedia.org",
-    "t": "wwuu",
+    "t": "wuuwikipedia",
     "ts": [
       "wuuwiki",
       "wikiwuu"
@@ -92094,7 +92094,7 @@
   {
     "s": "Chechen Wikipedia",
     "d": "ce.wikipedia.org",
-    "t": "wce",
+    "t": "cewikipedia",
     "ts": [
       "cewiki",
       "wikice"
@@ -92106,7 +92106,7 @@
   {
     "s": "Lombard Wikipedia",
     "d": "lmo.wikipedia.org",
-    "t": "wlmo",
+    "t": "lmowikipedia",
     "ts": [
       "lmowiki",
       "wikilmo"
@@ -92118,7 +92118,7 @@
   {
     "s": "Odia Wikipedia",
     "d": "or.wikipedia.org",
-    "t": "wor",
+    "t": "orwikipedia",
     "ts": [
       "orwiki",
       "wikior"
@@ -92130,7 +92130,7 @@
   {
     "s": "Kinyarwanda Wikipedia",
     "d": "rw.wikipedia.org",
-    "t": "wrw",
+    "t": "rwwikipedia",
     "ts": [
       "rwwiki",
       "wikirw"
@@ -92142,7 +92142,7 @@
   {
     "s": "Low German Wikipedia",
     "d": "nds.wikipedia.org",
-    "t": "wnds",
+    "t": "ndswikipedia",
     "ts": [
       "ndswiki",
       "wikinds"
@@ -92154,7 +92154,7 @@
   {
     "s": "Maltese Wikipedia",
     "d": "mt.wikipedia.org",
-    "t": "wmt",
+    "t": "mtwikipedia",
     "ts": [
       "mtwiki",
       "wikimt"
@@ -92166,7 +92166,7 @@
   {
     "s": "Balinese Wikipedia",
     "d": "ban.wikipedia.org",
-    "t": "wban",
+    "t": "banwikipedia",
     "ts": [
       "banwiki",
       "wikiban"
@@ -92178,7 +92178,7 @@
   {
     "s": "Amharic Wikipedia",
     "d": "am.wikipedia.org",
-    "t": "amwiki",
+    "t": "amwikipedia",
     "ts": [
       "wikiam"
     ],
@@ -92189,7 +92189,7 @@
   {
     "s": "Fiji Hindi Wikipedia",
     "d": "hif.wikipedia.org",
-    "t": "whif",
+    "t": "hifwikipedia",
     "ts": [
       "hifwiki",
       "wikihif"
@@ -92201,7 +92201,7 @@
   {
     "s": "Sundanese Wikipedia",
     "d": "su.wikipedia.org",
-    "t": "suwiki",
+    "t": "suwikipedia",
     "ts": [
       "wikisu"
     ],
@@ -92212,7 +92212,7 @@
   {
     "s": "Yiddish Wikipedia",
     "d": "yi.wikipedia.org",
-    "t": "wyi",
+    "t": "yiwikipedia",
     "ts": [
       "yiwiki",
       "wikiyi"
@@ -92224,7 +92224,7 @@
   {
     "s": "Malagasy Wikipedia",
     "d": "mg.wikipedia.org",
-    "t": "wmg",
+    "t": "mgwikipedia",
     "ts": [
       "mgwiki",
       "wikimg"
@@ -92236,7 +92236,7 @@
   {
     "s": "Minangkabau Wikipedia",
     "d": "min.wikipedia.org",
-    "t": "wmin",
+    "t": "minwikipedia",
     "ts": [
       "minwiki",
       "wikimin"
@@ -92248,7 +92248,7 @@
   {
     "s": "Venetian Wikipedia",
     "d": "vec.wikipedia.org",
-    "t": "wvec",
+    "t": "vecwikipedia",
     "ts": [
       "vecwiki",
       "wikivec"
@@ -92260,7 +92260,7 @@
   {
     "s": "Old English Wikipedia",
     "d": "ang.wikipedia.org",
-    "t": "wang",
+    "t": "angwikipedia",
     "ts": [
       "angwiki",
       "wikiang"
@@ -92272,7 +92272,7 @@
   {
     "s": "Tswana Wikipedia",
     "d": "tn.wikipedia.org",
-    "t": "wtn",
+    "t": "tnwikipedia",
     "ts": [
       "tnwiki",
       "wikitn"
@@ -92284,7 +92284,7 @@
   {
     "s": "Moroccan Arabic Wikipedia",
     "d": "ary.wikipedia.org",
-    "t": "wary",
+    "t": "arywikipedia",
     "ts": [
       "arywiki",
       "wikiary"
@@ -92296,7 +92296,7 @@
   {
     "s": "Bhojpuri Wikipedia",
     "d": "bh.wikipedia.org",
-    "t": "wbh",
+    "t": "bhwikipedia",
     "ts": [
       "bhwiki",
       "wikibh"
@@ -92308,7 +92308,7 @@
   {
     "s": "Corsican Wikipedia",
     "d": "co.wikipedia.org",
-    "t": "wco",
+    "t": "cowikipedia",
     "ts": [
       "cowiki",
       "wikico"
@@ -92320,7 +92320,7 @@
   {
     "s": "Crimean Tatar Wikipedia",
     "d": "crh.wikipedia.org",
-    "t": "wcrh",
+    "t": "crhwikipedia",
     "ts": [
       "crhwiki",
       "wikicrh"
@@ -92332,7 +92332,7 @@
   {
     "s": "Sanskrit Wikipedia",
     "d": "sa.wikipedia.org",
-    "t": "wsa",
+    "t": "sawikipedia",
     "ts": [
       "sawiki",
       "wikisa"
@@ -92344,7 +92344,7 @@
   {
     "s": "Mazanderani Wikipedia",
     "d": "mzn.wikipedia.org",
-    "t": "wmzn",
+    "t": "mznwikipedia",
     "ts": [
       "mznwiki",
       "wikimzn"
@@ -92356,7 +92356,7 @@
   {
     "s": "Quechua Wikipedia",
     "d": "qu.wikipedia.org",
-    "t": "wqu",
+    "t": "quwikipedia",
     "ts": [
       "quwiki",
       "wikiqu"
@@ -92368,7 +92368,7 @@
   {
     "s": "Interlingue Wikipedia",
     "d": "ie.wikipedia.org",
-    "t": "iewiki",
+    "t": "iewikipedia",
     "ts": [
       "wikiie"
     ],
@@ -92379,7 +92379,7 @@
   {
     "s": "Pashto Wikipedia",
     "d": "ps.wikipedia.org",
-    "t": "wps",
+    "t": "pswikipedia",
     "ts": [
       "pswiki",
       "wikips"
@@ -92391,7 +92391,7 @@
   {
     "s": "Chuvash Wikipedia",
     "d": "cv.wikipedia.org",
-    "t": "wcv",
+    "t": "cvwikipedia",
     "ts": [
       "cvwiki",
       "wikicv"
@@ -92403,7 +92403,7 @@
   {
     "s": "Faroese Wikipedia",
     "d": "fo.wikipedia.org",
-    "t": "wfo",
+    "t": "fowikipedia",
     "ts": [
       "wikifo"
     ],
@@ -92414,7 +92414,7 @@
   {
     "s": "Interlingua Wikipedia",
     "d": "ia.wikipedia.org",
-    "t": "iawiki",
+    "t": "iawikipedia",
     "ts": [
       "wikiia"
     ],
@@ -92425,7 +92425,7 @@
   {
     "s": "Moroccan Amazigh Wikipedia",
     "d": "zgh.wikipedia.org",
-    "t": "wzgh",
+    "t": "zghwikipedia",
     "ts": [
       "zghwiki",
       "wikizgh"
@@ -92437,7 +92437,7 @@
   {
     "s": "Rusyn Wikipedia",
     "d": "rue.wikipedia.org",
-    "t": "wrue",
+    "t": "ruewikipedia",
     "ts": [
       "ruewiki",
       "wikirue"
@@ -92449,7 +92449,7 @@
   {
     "s": "Dagbani Wikipedia",
     "d": "dag.wikipedia.org",
-    "t": "wdag",
+    "t": "dagwikipedia",
     "ts": [
       "dagwiki",
       "wikidag"
@@ -92461,7 +92461,7 @@
   {
     "s": "Guarani Wikipedia",
     "d": "gn.wikipedia.org",
-    "t": "wgn",
+    "t": "gnwikipedia",
     "ts": [
       "gnwiki",
       "wikign"
@@ -92473,7 +92473,7 @@
   {
     "s": "Silesian Wikipedia",
     "d": "szl.wikipedia.org",
-    "t": "wszl",
+    "t": "szlwikipedia",
     "ts": [
       "szlwiki",
       "wikiszl"
@@ -92485,7 +92485,7 @@
   {
     "s": "Piedmontese Wikipedia",
     "d": "pms.wikipedia.org",
-    "t": "wpms",
+    "t": "pmswikipedia",
     "ts": [
       "pmswiki",
       "wikipms"
@@ -92497,7 +92497,7 @@
   {
     "s": "Lao Wikipedia",
     "d": "lo.wikipedia.org",
-    "t": "wlo",
+    "t": "lowikipedia",
     "ts": [
       "lowiki",
       "wikilo"
@@ -92509,7 +92509,7 @@
   {
     "s": "Turkmen Wikipedia",
     "d": "tk.wikipedia.org",
-    "t": "wtk",
+    "t": "tkwikipedia",
     "ts": [
       "tkwiki",
       "wikitk"
@@ -92521,7 +92521,7 @@
   {
     "s": "Mirandese Wikipedia",
     "d": "mwl.wikipedia.org",
-    "t": "wmwl",
+    "t": "mwlwikipedia",
     "ts": [
       "mwlwiki",
       "wikimwl"
@@ -92533,7 +92533,7 @@
   {
     "s": "Sardinian Wikipedia",
     "d": "sc.wikipedia.org",
-    "t": "wsc",
+    "t": "scwikipedia",
     "ts": [
       "scwiki",
       "wikisc"
@@ -92545,7 +92545,7 @@
   {
     "s": "Wayuu Wikipedia",
     "d": "guc.wikipedia.org",
-    "t": "wguc",
+    "t": "gucwikipedia",
     "ts": [
       "gucwiki",
       "wikiguc"
@@ -92557,7 +92557,7 @@
   {
     "s": "Sicilian Wikipedia",
     "d": "scn.wikipedia.org",
-    "t": "wscn",
+    "t": "scnwikipedia",
     "ts": [
       "scnwiki",
       "wikiscn"
@@ -92569,7 +92569,7 @@
   {
     "s": "Yakut Wikipedia",
     "d": "sah.wikipedia.org",
-    "t": "wsah",
+    "t": "sahwikipedia",
     "ts": [
       "sahwiki",
       "wikisah"
@@ -92581,7 +92581,7 @@
   {
     "s": "Maithili Wikipedia",
     "d": "mai.wikipedia.org",
-    "t": "wmai",
+    "t": "maiwikipedia",
     "ts": [
       "maiwiki",
       "wikimai"
@@ -92593,7 +92593,7 @@
   {
     "s": "Santali Wikipedia",
     "d": "sat.wikipedia.org",
-    "t": "wsat",
+    "t": "satwikipedia",
     "ts": [
       "satwiki",
       "wikisat"
@@ -92623,7 +92623,7 @@
     "s": "Google Wikipedia",
     "d": "www.google.com",
     "ad": "wikipedia.org",
-    "t": "gwp",
+    "t": "wwwgoogle",
     "u": "https://www.google.com/search?q={{{s}}} site:wikipedia.org",
     "c": "Online Services",
     "sc": "Google"
@@ -92639,7 +92639,7 @@
   {
     "s": "Northern Sami Wikipedia",
     "d": "se.wikipedia.org",
-    "t": "wse",
+    "t": "sewikipedia",
     "u": "https://se.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Reference"
@@ -92647,7 +92647,7 @@
   {
     "s": "Volapük Wikipedia",
     "d": "vo.wikipedia.org",
-    "t": "wvo",
+    "t": "vowikipedia",
     "u": "https://vo.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -90757,9 +90757,11 @@
     "t": "enwikipedia",
     "ts": [
       "enwiki",
+      "enwp",
+      "enw",
       "wikien",
-      "w.en",
-      "we"
+      "wpen",
+      "wen"
     ],
     "u": "https://en.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90803,11 +90805,11 @@
     "t": "dewikipedia",
     "ts": [
       "dewiki",
+      "dewp",
+      "dew",
       "wikide",
-      "w.de",
-      "wge",
-      "wiki.de",
-      "wikipediade"
+      "wpde",
+      "wde"
     ],
     "u": "https://de.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90818,7 +90820,12 @@
     "d": "fr.wikipedia.org",
     "t": "frwikipedia",
     "ts": [
-      "wikifr"
+      "frwiki",
+      "frwp",
+      "frw",
+      "wikifr",
+      "wpfr",
+      "wfr"
     ],
     "u": "https://fr.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90830,7 +90837,11 @@
     "t": "eswikipedia",
     "ts": [
       "eswiki",
-      "wikies"
+      "eswp",
+      "esw",
+      "wikies",
+      "wpes",
+      "wes"
     ],
     "u": "https://es.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90842,8 +90853,11 @@
     "t": "jawikipedia",
     "ts": [
       "jawiki",
+      "jawp",
+      "jaw",
       "wikija",
-      "jawp"
+      "wpja",
+      "wja"
     ],
     "u": "https://ja.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90855,11 +90869,11 @@
     "t": "ruwikipedia",
     "ts": [
       "ruwiki",
+      "ruwp",
+      "ruw",
       "wikiru",
-      "ruwk",
-      "w.ru",
-      "ш",
-      "шру"
+      "wpru",
+      "wru"
     ],
     "u": "https://ru.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90871,7 +90885,11 @@
     "t": "ptwikipedia",
     "ts": [
       "ptwiki",
-      "wikipt"
+      "ptwp",
+      "ptw",
+      "wikipt",
+      "wppt",
+      "wpt"
     ],
     "u": "https://pt.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90883,8 +90901,11 @@
     "t": "itwikipedia",
     "ts": [
       "itwiki",
+      "itwp",
+      "itw",
       "wikiit",
-      "wikipediait"
+      "wpit",
+      "wit"
     ],
     "u": "https://it.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90896,8 +90917,11 @@
     "t": "zhwikipedia",
     "ts": [
       "zhwiki",
+      "zhwp",
+      "zhw",
       "wikizh",
-      "wizh"
+      "wpzh",
+      "wzh"
     ],
     "u": "https://zh.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90909,8 +90933,11 @@
     "t": "fawikipedia",
     "ts": [
       "fawiki",
+      "fawp",
+      "faw",
       "wikifa",
-      "pwp"
+      "wpfa",
+      "wfa"
     ],
     "u": "https://fa.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90922,8 +90949,11 @@
     "t": "plwikipedia",
     "ts": [
       "plwiki",
+      "plwp",
+      "plw",
       "wikipl",
-      "plw"
+      "wppl",
+      "wpl"
     ],
     "u": "https://pl.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90935,7 +90965,11 @@
     "t": "arwikipedia",
     "ts": [
       "arwiki",
-      "wikiar"
+      "arwp",
+      "arw",
+      "wikiar",
+      "wpar",
+      "war"
     ],
     "u": "https://ar.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90947,8 +90981,11 @@
     "t": "nlwikipedia",
     "ts": [
       "nlwiki",
+      "nlwp",
+      "nlw",
       "wikinl",
-      "nlwi"
+      "wpnl",
+      "wnl"
     ],
     "u": "https://nl.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90960,9 +90997,11 @@
     "t": "hewikipedia",
     "ts": [
       "hewiki",
+      "hewp",
+      "hew",
       "wikihe",
-      "hebwiki",
-      "ויקי"
+      "wphe",
+      "whe"
     ],
     "u": "https://he.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90974,7 +91013,11 @@
     "t": "ukwikipedia",
     "ts": [
       "ukwiki",
-      "wikiuk"
+      "ukwp",
+      "ukw",
+      "wikiuk",
+      "wpuk",
+      "wuk"
     ],
     "u": "https://uk.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90986,7 +91029,11 @@
     "t": "trwikipedia",
     "ts": [
       "trwiki",
-      "wikitr"
+      "trwp",
+      "trw",
+      "wikitr",
+      "wptr",
+      "wtr"
     ],
     "u": "https://tr.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -90998,8 +91045,11 @@
     "t": "cswikipedia",
     "ts": [
       "cswiki",
+      "cswp",
+      "csw",
       "wikics",
-      "wcz"
+      "wpcs",
+      "wcs"
     ],
     "u": "https://cs.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91011,7 +91061,11 @@
     "t": "idwikipedia",
     "ts": [
       "idwiki",
-      "wikiid"
+      "idwp",
+      "idw",
+      "wikiid",
+      "wpid",
+      "wid"
     ],
     "u": "https://id.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91023,7 +91077,11 @@
     "t": "kowikipedia",
     "ts": [
       "kowiki",
-      "wikiko"
+      "kowp",
+      "kow",
+      "wikiko",
+      "wpko",
+      "wko"
     ],
     "u": "https://ko.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91035,7 +91093,11 @@
     "t": "svwikipedia",
     "ts": [
       "svwiki",
-      "wikisv"
+      "svwp",
+      "svw",
+      "wikisv",
+      "wpsv",
+      "wsv"
     ],
     "u": "https://sv.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91047,8 +91109,11 @@
     "t": "fiwikipedia",
     "ts": [
       "fiwiki",
+      "fiwp",
+      "fiw",
       "wikifi",
-      "wi-fi"
+      "wpfi",
+      "wfi"
     ],
     "u": "https://fi.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91060,8 +91125,11 @@
     "t": "simplewikipedia",
     "ts": [
       "simplewiki",
+      "simplewp",
+      "simplew",
       "wikisimple",
-      "sw"
+      "wpsimple",
+      "wsimple"
     ],
     "u": "https://simple.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91073,9 +91141,11 @@
     "t": "viwikipedia",
     "ts": [
       "viwiki",
+      "viwp",
+      "viw",
       "wikivi",
-      "vnwiki",
-      "wiki-vn"
+      "wpvi",
+      "wvi"
     ],
     "u": "https://vi.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91087,7 +91157,11 @@
     "t": "huwikipedia",
     "ts": [
       "huwiki",
-      "wikihu"
+      "huwp",
+      "huw",
+      "wikihu",
+      "wphu",
+      "whu"
     ],
     "u": "https://hu.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91099,9 +91173,11 @@
     "t": "cawikipedia",
     "ts": [
       "cawiki",
+      "cawp",
+      "caw",
       "wikica",
-      "viquipedia",
-      "wcat"
+      "wpca",
+      "wca"
     ],
     "u": "https://ca.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91111,6 +91187,14 @@
     "s": "Thai Wikipedia",
     "d": "th.wikipedia.org",
     "t": "thwikipedia",
+    "ts": [
+      "thwiki",
+      "thwp",
+      "thw",
+      "wikith",
+      "wpth",
+      "wth"
+    ],
     "u": "https://th.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Reference"
@@ -91121,7 +91205,11 @@
     "t": "nowikipedia",
     "ts": [
       "nowiki",
-      "wikino"
+      "nowp",
+      "now",
+      "wikino",
+      "wpno",
+      "wno"
     ],
     "u": "https://no.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91133,7 +91221,11 @@
     "t": "srwikipedia",
     "ts": [
       "srwiki",
-      "wikisr"
+      "srwp",
+      "srw",
+      "wikisr",
+      "wpsr",
+      "wsr"
     ],
     "u": "https://sr.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91145,8 +91237,11 @@
     "t": "elwikipedia",
     "ts": [
       "elwiki",
+      "elwp",
+      "elw",
       "wikiel",
-      "elw"
+      "wpel",
+      "wel"
     ],
     "u": "https://el.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91158,8 +91253,11 @@
     "t": "hiwikipedia",
     "ts": [
       "hiwiki",
+      "hiwp",
+      "hiw",
       "wikihi",
-      "hwiki"
+      "wphi",
+      "whi"
     ],
     "u": "https://hi.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91171,7 +91269,11 @@
     "t": "bnwikipedia",
     "ts": [
       "bnwiki",
-      "wikibn"
+      "bnwp",
+      "bnw",
+      "wikibn",
+      "wpbn",
+      "wbn"
     ],
     "u": "https://bn.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91182,7 +91284,12 @@
     "d": "ro.wikipedia.org",
     "t": "rowikipedia",
     "ts": [
-      "wikiro"
+      "rowiki",
+      "rowp",
+      "row",
+      "wikiro",
+      "wpro",
+      "wro"
     ],
     "u": "https://ro.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91194,8 +91301,11 @@
     "t": "etwikipedia",
     "ts": [
       "etwiki",
+      "etwp",
+      "etw",
       "wikiet",
-      "viki"
+      "wpet",
+      "wet"
     ],
     "u": "https://et.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91206,8 +91316,12 @@
     "d": "da.wikipedia.org",
     "t": "dawikipedia",
     "ts": [
+      "dawiki",
+      "dawp",
+      "daw",
       "wikida",
-      "wdk"
+      "wpda",
+      "wda"
     ],
     "u": "https://da.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91219,7 +91333,11 @@
     "t": "uzwikipedia",
     "ts": [
       "uzwiki",
-      "wikiuz"
+      "uzwp",
+      "uzw",
+      "wikiuz",
+      "wpuz",
+      "wuz"
     ],
     "u": "https://uz.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91231,7 +91349,11 @@
     "t": "bgwikipedia",
     "ts": [
       "bgwiki",
-      "wikibg"
+      "bgwp",
+      "bgw",
+      "wikibg",
+      "wpbg",
+      "wbg"
     ],
     "u": "https://bg.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91243,7 +91365,11 @@
     "t": "azwikipedia",
     "ts": [
       "azwiki",
-      "wikiaz"
+      "azwp",
+      "azw",
+      "wikiaz",
+      "wpaz",
+      "waz"
     ],
     "u": "https://az.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91255,7 +91381,11 @@
     "t": "mswikipedia",
     "ts": [
       "mswiki",
-      "wikims"
+      "mswp",
+      "msw",
+      "wikims",
+      "wpms",
+      "wms"
     ],
     "u": "https://ms.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91267,7 +91397,11 @@
     "t": "skwikipedia",
     "ts": [
       "skwiki",
-      "wikisk"
+      "skwp",
+      "skw",
+      "wikisk",
+      "wpsk",
+      "wsk"
     ],
     "u": "https://sk.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91279,7 +91413,11 @@
     "t": "euwikipedia",
     "ts": [
       "euwiki",
-      "wikieu"
+      "euwp",
+      "euw",
+      "wikieu",
+      "wpeu",
+      "weu"
     ],
     "u": "https://eu.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91291,8 +91429,11 @@
     "t": "hywikipedia",
     "ts": [
       "hywiki",
+      "hywp",
+      "hyw",
       "wikihy",
-      "w-hy"
+      "wphy",
+      "why"
     ],
     "u": "https://hy.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91303,7 +91444,12 @@
     "d": "hr.wikipedia.org",
     "t": "hrwikipedia",
     "ts": [
-      "wikihr"
+      "hrwiki",
+      "hrwp",
+      "hrw",
+      "wikihr",
+      "wphr",
+      "whr"
     ],
     "u": "https://hr.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91315,7 +91461,11 @@
     "t": "kkwikipedia",
     "ts": [
       "kkwiki",
-      "wikikk"
+      "kkwp",
+      "kkw",
+      "wikikk",
+      "wpkk",
+      "wkk"
     ],
     "u": "https://kk.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91327,7 +91477,11 @@
     "t": "ltwikipedia",
     "ts": [
       "ltwiki",
-      "wikilt"
+      "ltwp",
+      "ltw",
+      "wikilt",
+      "wplt",
+      "wlt"
     ],
     "u": "https://lt.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91338,7 +91492,12 @@
     "d": "sl.wikipedia.org",
     "t": "slwikipedia",
     "ts": [
-      "wikisl"
+      "slwiki",
+      "slwp",
+      "slw",
+      "wikisl",
+      "wpsl",
+      "wsl"
     ],
     "u": "https://sl.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91350,9 +91509,11 @@
     "t": "eowikipedia",
     "ts": [
       "eowiki",
+      "eowp",
+      "eow",
       "wikieo",
-      "vikipedio",
-      "vo"
+      "wpeo",
+      "weo"
     ],
     "u": "https://eo.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91364,7 +91525,11 @@
     "t": "lvwikipedia",
     "ts": [
       "lvwiki",
-      "wikilv"
+      "lvwp",
+      "lvw",
+      "wikilv",
+      "wplv",
+      "wlv"
     ],
     "u": "https://lv.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91376,7 +91541,11 @@
     "t": "kawikipedia",
     "ts": [
       "kawiki",
-      "wikika"
+      "kawp",
+      "kaw",
+      "wikika",
+      "wpka",
+      "wka"
     ],
     "u": "https://ka.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91387,8 +91556,12 @@
     "d": "ta.wikipedia.org",
     "t": "tawikipedia",
     "ts": [
+      "tawiki",
+      "tawp",
+      "taw",
       "wikita",
-      "tawk"
+      "wpta",
+      "wta"
     ],
     "u": "https://ta.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91399,8 +91572,12 @@
     "d": "gl.wikipedia.org",
     "t": "glwikipedia",
     "ts": [
+      "glwiki",
+      "glwp",
+      "glw",
       "wikigl",
-      "wgal"
+      "wpgl",
+      "wgl"
     ],
     "u": "https://gl.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91412,7 +91589,11 @@
     "t": "sqwikipedia",
     "ts": [
       "sqwiki",
-      "wikisq"
+      "sqwp",
+      "sqw",
+      "wikisq",
+      "wpsq",
+      "wsq"
     ],
     "u": "https://sq.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91424,7 +91605,11 @@
     "t": "urwikipedia",
     "ts": [
       "urwiki",
-      "wikiur"
+      "urwp",
+      "urw",
+      "wikiur",
+      "wpur",
+      "wur"
     ],
     "u": "https://ur.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91436,7 +91621,11 @@
     "t": "bewikipedia",
     "ts": [
       "bewiki",
-      "wikibe"
+      "bewp",
+      "bew",
+      "wikibe",
+      "wpbe",
+      "wbe"
     ],
     "u": "https://be.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91448,7 +91637,11 @@
     "t": "mkwikipedia",
     "ts": [
       "mkwiki",
-      "wikimk"
+      "mkwp",
+      "mkw",
+      "wikimk",
+      "wpmk",
+      "wmk"
     ],
     "u": "https://mk.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91460,7 +91653,11 @@
     "t": "mlwikipedia",
     "ts": [
       "mlwiki",
-      "wikiml"
+      "mlwp",
+      "mlw",
+      "wikiml",
+      "wpml",
+      "wml"
     ],
     "u": "https://ml.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91472,7 +91669,11 @@
     "t": "tewikipedia",
     "ts": [
       "tewiki",
-      "wikite"
+      "tewp",
+      "tew",
+      "wikite",
+      "wpte",
+      "wte"
     ],
     "u": "https://te.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91484,7 +91685,11 @@
     "t": "hawikipedia",
     "ts": [
       "hawiki",
-      "wikiha"
+      "hawp",
+      "haw",
+      "wikiha",
+      "wpha",
+      "wha"
     ],
     "u": "https://ha.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91496,7 +91701,11 @@
     "t": "afwikipedia",
     "ts": [
       "afwiki",
-      "wikiaf"
+      "afwp",
+      "afw",
+      "wikiaf",
+      "wpaf",
+      "waf"
     ],
     "u": "https://af.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91508,7 +91717,11 @@
     "t": "arzwikipedia",
     "ts": [
       "arzwiki",
-      "wikiarz"
+      "arzwp",
+      "arzw",
+      "wikiarz",
+      "wparz",
+      "warz"
     ],
     "u": "https://arz.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91519,7 +91732,12 @@
     "d": "sh.wikipedia.org",
     "t": "shwikipedia",
     "ts": [
-      "wikish"
+      "shwiki",
+      "shwp",
+      "shw",
+      "wikish",
+      "wpsh",
+      "wsh"
     ],
     "u": "https://sh.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91531,7 +91749,11 @@
     "t": "knwikipedia",
     "ts": [
       "knwiki",
-      "wikikn"
+      "knwp",
+      "knw",
+      "wikikn",
+      "wpkn",
+      "wkn"
     ],
     "u": "https://kn.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91542,7 +91764,12 @@
     "d": "sw.wikipedia.org",
     "t": "swwikipedia",
     "ts": [
-      "wikisw"
+      "swwiki",
+      "swwp",
+      "sww",
+      "wikisw",
+      "wpsw",
+      "wsw"
     ],
     "u": "https://sw.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91553,7 +91780,12 @@
     "d": "bs.wikipedia.org",
     "t": "bswikipedia",
     "ts": [
-      "wikibs"
+      "bswiki",
+      "bswp",
+      "bsw",
+      "wikibs",
+      "wpbs",
+      "wbs"
     ],
     "u": "https://bs.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91565,7 +91797,11 @@
     "t": "iswikipedia",
     "ts": [
       "iswiki",
-      "wikiis"
+      "iswp",
+      "isw",
+      "wikiis",
+      "wpis",
+      "wis"
     ],
     "u": "https://is.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91577,7 +91813,11 @@
     "t": "bclwikipedia",
     "ts": [
       "bclwiki",
-      "wikibcl"
+      "bclwp",
+      "bclw",
+      "wikibcl",
+      "wpbcl",
+      "wbcl"
     ],
     "u": "https://bcl.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91589,8 +91829,11 @@
     "t": "lawikipedia",
     "ts": [
       "lawiki",
+      "lawp",
+      "law",
       "wikila",
-      "vici"
+      "wpla",
+      "wla"
     ],
     "u": "https://la.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91602,7 +91845,11 @@
     "t": "ckbwikipedia",
     "ts": [
       "ckbwiki",
-      "wikickb"
+      "ckbwp",
+      "ckbw",
+      "wikickb",
+      "wpckb",
+      "wckb"
     ],
     "u": "https://ckb.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91614,7 +91861,11 @@
     "t": "cebwikipedia",
     "ts": [
       "cebwiki",
-      "wikiceb"
+      "cebwp",
+      "cebw",
+      "wikiceb",
+      "wpceb",
+      "wceb"
     ],
     "u": "https://ceb.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91626,7 +91877,11 @@
     "t": "mrwikipedia",
     "ts": [
       "mrwiki",
-      "wikimr"
+      "mrwp",
+      "mrw",
+      "wikimr",
+      "wpmr",
+      "wmr"
     ],
     "u": "https://mr.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91638,7 +91893,11 @@
     "t": "aswikipedia",
     "ts": [
       "aswiki",
-      "wikias"
+      "aswp",
+      "asw",
+      "wikias",
+      "wpas",
+      "was"
     ],
     "u": "https://as.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91649,7 +91908,12 @@
     "d": "tl.wikipedia.org",
     "t": "tlwikipedia",
     "ts": [
-      "wikitl"
+      "tlwiki",
+      "tlwp",
+      "tlw",
+      "wikitl",
+      "wptl",
+      "wtl"
     ],
     "u": "https://tl.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91661,7 +91925,11 @@
     "t": "nnwikipedia",
     "ts": [
       "nnwiki",
-      "wikinn"
+      "nnwp",
+      "nnw",
+      "wikinn",
+      "wpnn",
+      "wnn"
     ],
     "u": "https://nn.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91673,7 +91941,11 @@
     "t": "igwikipedia",
     "ts": [
       "igwiki",
-      "wikiig"
+      "igwp",
+      "igw",
+      "wikiig",
+      "wpig",
+      "wig"
     ],
     "u": "https://ig.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91685,7 +91957,11 @@
     "t": "cywikipedia",
     "ts": [
       "cywiki",
-      "wikicy"
+      "cywp",
+      "cyw",
+      "wikicy",
+      "wpcy",
+      "wcy"
     ],
     "u": "https://cy.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91697,7 +91973,11 @@
     "t": "mnwikipedia",
     "ts": [
       "mnwiki",
-      "wikimn"
+      "mnwp",
+      "mnw",
+      "wikimn",
+      "wpmn",
+      "wmn"
     ],
     "u": "https://mn.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91709,7 +91989,11 @@
     "t": "newikipedia",
     "ts": [
       "newiki",
-      "wikine"
+      "newp",
+      "new",
+      "wikine",
+      "wpne",
+      "wne"
     ],
     "u": "https://ne.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91721,7 +92005,11 @@
     "t": "mywikipedia",
     "ts": [
       "mywiki",
-      "wikimy"
+      "mywp",
+      "myw",
+      "wikimy",
+      "wpmy",
+      "wmy"
     ],
     "u": "https://my.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91733,7 +92021,11 @@
     "t": "azbwikipedia",
     "ts": [
       "azbwiki",
-      "wikiazb"
+      "azbwp",
+      "azbw",
+      "wikiazb",
+      "wpazb",
+      "wazb"
     ],
     "u": "https://azb.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91745,7 +92037,11 @@
     "t": "astwikipedia",
     "ts": [
       "astwiki",
-      "wikiast"
+      "astwp",
+      "astw",
+      "wikiast",
+      "wpast",
+      "wast"
     ],
     "u": "https://ast.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91757,7 +92053,11 @@
     "t": "ocwikipedia",
     "ts": [
       "ocwiki",
-      "wikioc"
+      "ocwp",
+      "ocw",
+      "wikioc",
+      "wpoc",
+      "woc"
     ],
     "u": "https://oc.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91769,7 +92069,11 @@
     "t": "pawikipedia",
     "ts": [
       "pawiki",
-      "wikipa"
+      "pawp",
+      "paw",
+      "wikipa",
+      "wppa",
+      "wpa"
     ],
     "u": "https://pa.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91781,7 +92085,11 @@
     "t": "gawikipedia",
     "ts": [
       "gawiki",
-      "wikiga"
+      "gawp",
+      "gaw",
+      "wikiga",
+      "wpga",
+      "wga"
     ],
     "u": "https://ga.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91793,7 +92101,11 @@
     "t": "brwikipedia",
     "ts": [
       "brwiki",
-      "wikibr"
+      "brwp",
+      "brw",
+      "wikibr",
+      "wpbr",
+      "wbr"
     ],
     "u": "https://br.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91805,7 +92117,11 @@
     "t": "kywikipedia",
     "ts": [
       "kywiki",
-      "wikiky"
+      "kywp",
+      "kyw",
+      "wikiky",
+      "wpky",
+      "wky"
     ],
     "u": "https://ky.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91816,7 +92132,12 @@
     "d": "ku.wikipedia.org",
     "t": "kuwikipedia",
     "ts": [
-      "wikiku"
+      "kuwiki",
+      "kuwp",
+      "kuw",
+      "wikiku",
+      "wpku",
+      "wku"
     ],
     "u": "https://ku.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91828,7 +92149,11 @@
     "t": "siwikipedia",
     "ts": [
       "siwiki",
-      "wikisi"
+      "siwp",
+      "siw",
+      "wikisi",
+      "wpsi",
+      "wsi"
     ],
     "u": "https://si.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91840,7 +92165,11 @@
     "t": "fywikipedia",
     "ts": [
       "fywiki",
-      "wikify"
+      "fywp",
+      "fyw",
+      "wikify",
+      "wpfy",
+      "wfy"
     ],
     "u": "https://fy.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91852,7 +92181,11 @@
     "t": "alswikipedia",
     "ts": [
       "alswiki",
-      "wikials"
+      "alswp",
+      "alsw",
+      "wikials",
+      "wpals",
+      "wals"
     ],
     "u": "https://als.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91864,7 +92197,11 @@
     "t": "jvwikipedia",
     "ts": [
       "jvwiki",
-      "wikijv"
+      "jvwp",
+      "jvw",
+      "wikijv",
+      "wpjv",
+      "wjv"
     ],
     "u": "https://jv.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91875,7 +92212,12 @@
     "d": "tg.wikipedia.org",
     "t": "tgwikipedia",
     "ts": [
-      "wikitg"
+      "tgwiki",
+      "tgwp",
+      "tgw",
+      "wikitg",
+      "wptg",
+      "wtg"
     ],
     "u": "https://tg.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91887,7 +92229,11 @@
     "t": "scowikipedia",
     "ts": [
       "scowiki",
-      "wikisco"
+      "scowp",
+      "scow",
+      "wikisco",
+      "wpsco",
+      "wsco"
     ],
     "u": "https://sco.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91906,7 +92252,12 @@
     "d": "ht.wikipedia.org",
     "t": "htwikipedia",
     "ts": [
-      "wikiht"
+      "htwiki",
+      "htwp",
+      "htw",
+      "wikiht",
+      "wpht",
+      "wht"
     ],
     "u": "https://ht.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91918,7 +92269,11 @@
     "t": "ttwikipedia",
     "ts": [
       "ttwiki",
-      "wikitt"
+      "ttwp",
+      "ttw",
+      "wikitt",
+      "wptt",
+      "wtt"
     ],
     "u": "https://tt.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91930,7 +92285,11 @@
     "t": "bawikipedia",
     "ts": [
       "bawiki",
-      "wikiba"
+      "bawp",
+      "baw",
+      "wikiba",
+      "wpba",
+      "wba"
     ],
     "u": "https://ba.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91942,7 +92301,11 @@
     "t": "lbwikipedia",
     "ts": [
       "lbwiki",
-      "wikilb"
+      "lbwp",
+      "lbw",
+      "wikilb",
+      "wplb",
+      "wlb"
     ],
     "u": "https://lb.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91953,7 +92316,12 @@
     "d": "so.wikipedia.org",
     "t": "sowikipedia",
     "ts": [
-      "wikiso"
+      "sowiki",
+      "sowp",
+      "sow",
+      "wikiso",
+      "wpso",
+      "wso"
     ],
     "u": "https://so.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91965,7 +92333,11 @@
     "t": "yowikipedia",
     "ts": [
       "yowiki",
-      "wikiyo"
+      "yowp",
+      "yow",
+      "wikiyo",
+      "wpyo",
+      "wyo"
     ],
     "u": "https://yo.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91977,7 +92349,11 @@
     "t": "guwikipedia",
     "ts": [
       "guwiki",
-      "wikigu"
+      "guwp",
+      "guw",
+      "wikigu",
+      "wpgu",
+      "wgu"
     ],
     "u": "https://gu.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91989,7 +92365,11 @@
     "t": "warwikipedia",
     "ts": [
       "warwiki",
-      "wikiwar"
+      "warwp",
+      "warw",
+      "wikiwar",
+      "wpwar",
+      "wwar"
     ],
     "u": "https://war.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92001,7 +92381,11 @@
     "t": "kaawikipedia",
     "ts": [
       "kaawiki",
-      "wikikaa"
+      "kaawp",
+      "kaaw",
+      "wikikaa",
+      "wpkaa",
+      "wkaa"
     ],
     "u": "https://kaa.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92013,7 +92397,11 @@
     "t": "anwikipedia",
     "ts": [
       "anwiki",
-      "wikian"
+      "anwp",
+      "anw",
+      "wikian",
+      "wpan",
+      "wan"
     ],
     "u": "https://an.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92025,7 +92413,11 @@
     "t": "zuwikipedia",
     "ts": [
       "zuwiki",
-      "wikizu"
+      "zuwp",
+      "zuw",
+      "wikizu",
+      "wpzu",
+      "wzu"
     ],
     "u": "https://zu.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92037,7 +92429,11 @@
     "t": "kmwikipedia",
     "ts": [
       "kmwiki",
-      "wikikm"
+      "kmwp",
+      "kmw",
+      "wikikm",
+      "wpkm",
+      "wkm"
     ],
     "u": "https://km.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92049,7 +92445,11 @@
     "t": "barwikipedia",
     "ts": [
       "barwiki",
-      "wikibar"
+      "barwp",
+      "barw",
+      "wikibar",
+      "wpbar",
+      "wbar"
     ],
     "u": "https://bar.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92061,7 +92461,11 @@
     "t": "iowikipedia",
     "ts": [
       "iowiki",
-      "wikiio"
+      "iowp",
+      "iow",
+      "wikiio",
+      "wpio",
+      "wio"
     ],
     "u": "https://io.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92073,7 +92477,11 @@
     "t": "pnbwikipedia",
     "ts": [
       "pnbwiki",
-      "wikipnb"
+      "pnbwp",
+      "pnbw",
+      "wikipnb",
+      "wppnb",
+      "wpnb"
     ],
     "u": "https://pnb.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92085,7 +92493,11 @@
     "t": "wuuwikipedia",
     "ts": [
       "wuuwiki",
-      "wikiwuu"
+      "wuuwp",
+      "wuuw",
+      "wikiwuu",
+      "wpwuu",
+      "wwuu"
     ],
     "u": "https://wuu.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92097,7 +92509,11 @@
     "t": "cewikipedia",
     "ts": [
       "cewiki",
-      "wikice"
+      "cewp",
+      "cew",
+      "wikice",
+      "wpce",
+      "wce"
     ],
     "u": "https://ce.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92109,7 +92525,11 @@
     "t": "lmowikipedia",
     "ts": [
       "lmowiki",
-      "wikilmo"
+      "lmowp",
+      "lmow",
+      "wikilmo",
+      "wplmo",
+      "wlmo"
     ],
     "u": "https://lmo.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92121,7 +92541,11 @@
     "t": "orwikipedia",
     "ts": [
       "orwiki",
-      "wikior"
+      "orwp",
+      "orw",
+      "wikior",
+      "wpor",
+      "wor"
     ],
     "u": "https://or.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92133,7 +92557,11 @@
     "t": "rwwikipedia",
     "ts": [
       "rwwiki",
-      "wikirw"
+      "rwwp",
+      "rww",
+      "wikirw",
+      "wprw",
+      "wrw"
     ],
     "u": "https://rw.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92145,7 +92573,11 @@
     "t": "ndswikipedia",
     "ts": [
       "ndswiki",
-      "wikinds"
+      "ndswp",
+      "ndsw",
+      "wikinds",
+      "wpnds",
+      "wnds"
     ],
     "u": "https://nds.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92157,7 +92589,11 @@
     "t": "mtwikipedia",
     "ts": [
       "mtwiki",
-      "wikimt"
+      "mtwp",
+      "mtw",
+      "wikimt",
+      "wpmt",
+      "wmt"
     ],
     "u": "https://mt.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92169,7 +92605,11 @@
     "t": "banwikipedia",
     "ts": [
       "banwiki",
-      "wikiban"
+      "banwp",
+      "banw",
+      "wikiban",
+      "wpban",
+      "wban"
     ],
     "u": "https://ban.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92180,7 +92620,12 @@
     "d": "am.wikipedia.org",
     "t": "amwikipedia",
     "ts": [
-      "wikiam"
+      "amwiki",
+      "amwp",
+      "amw",
+      "wikiam",
+      "wpam",
+      "wam"
     ],
     "u": "https://am.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92192,7 +92637,11 @@
     "t": "hifwikipedia",
     "ts": [
       "hifwiki",
-      "wikihif"
+      "hifwp",
+      "hifw",
+      "wikihif",
+      "wphif",
+      "whif"
     ],
     "u": "https://hif.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92203,7 +92652,12 @@
     "d": "su.wikipedia.org",
     "t": "suwikipedia",
     "ts": [
-      "wikisu"
+      "suwiki",
+      "suwp",
+      "suw",
+      "wikisu",
+      "wpsu",
+      "wsu"
     ],
     "u": "https://su.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92215,7 +92669,11 @@
     "t": "yiwikipedia",
     "ts": [
       "yiwiki",
-      "wikiyi"
+      "yiwp",
+      "yiw",
+      "wikiyi",
+      "wpyi",
+      "wyi"
     ],
     "u": "https://yi.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92227,7 +92685,11 @@
     "t": "mgwikipedia",
     "ts": [
       "mgwiki",
-      "wikimg"
+      "mgwp",
+      "mgw",
+      "wikimg",
+      "wpmg",
+      "wmg"
     ],
     "u": "https://mg.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92239,7 +92701,11 @@
     "t": "minwikipedia",
     "ts": [
       "minwiki",
-      "wikimin"
+      "minwp",
+      "minw",
+      "wikimin",
+      "wpmin",
+      "wmin"
     ],
     "u": "https://min.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92251,7 +92717,11 @@
     "t": "vecwikipedia",
     "ts": [
       "vecwiki",
-      "wikivec"
+      "vecwp",
+      "vecw",
+      "wikivec",
+      "wpvec",
+      "wvec"
     ],
     "u": "https://vec.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92263,7 +92733,11 @@
     "t": "angwikipedia",
     "ts": [
       "angwiki",
-      "wikiang"
+      "angwp",
+      "angw",
+      "wikiang",
+      "wpang",
+      "wang"
     ],
     "u": "https://ang.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92275,7 +92749,11 @@
     "t": "tnwikipedia",
     "ts": [
       "tnwiki",
-      "wikitn"
+      "tnwp",
+      "tnw",
+      "wikitn",
+      "wptn",
+      "wtn"
     ],
     "u": "https://tn.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92287,7 +92765,11 @@
     "t": "arywikipedia",
     "ts": [
       "arywiki",
-      "wikiary"
+      "arywp",
+      "aryw",
+      "wikiary",
+      "wpary",
+      "wary"
     ],
     "u": "https://ary.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92299,7 +92781,11 @@
     "t": "bhwikipedia",
     "ts": [
       "bhwiki",
-      "wikibh"
+      "bhwp",
+      "bhw",
+      "wikibh",
+      "wpbh",
+      "wbh"
     ],
     "u": "https://bh.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92311,7 +92797,11 @@
     "t": "cowikipedia",
     "ts": [
       "cowiki",
-      "wikico"
+      "cowp",
+      "cow",
+      "wikico",
+      "wpco",
+      "wco"
     ],
     "u": "https://co.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92323,7 +92813,11 @@
     "t": "crhwikipedia",
     "ts": [
       "crhwiki",
-      "wikicrh"
+      "crhwp",
+      "crhw",
+      "wikicrh",
+      "wpcrh",
+      "wcrh"
     ],
     "u": "https://crh.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92335,7 +92829,11 @@
     "t": "sawikipedia",
     "ts": [
       "sawiki",
-      "wikisa"
+      "sawp",
+      "saw",
+      "wikisa",
+      "wpsa",
+      "wsa"
     ],
     "u": "https://sa.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92347,7 +92845,11 @@
     "t": "mznwikipedia",
     "ts": [
       "mznwiki",
-      "wikimzn"
+      "mznwp",
+      "mznw",
+      "wikimzn",
+      "wpmzn",
+      "wmzn"
     ],
     "u": "https://mzn.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92359,7 +92861,11 @@
     "t": "quwikipedia",
     "ts": [
       "quwiki",
-      "wikiqu"
+      "quwp",
+      "quw",
+      "wikiqu",
+      "wpqu",
+      "wqu"
     ],
     "u": "https://qu.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92370,7 +92876,12 @@
     "d": "ie.wikipedia.org",
     "t": "iewikipedia",
     "ts": [
-      "wikiie"
+      "iewiki",
+      "iewp",
+      "iew",
+      "wikiie",
+      "wpie",
+      "wie"
     ],
     "u": "https://ie.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92382,7 +92893,11 @@
     "t": "pswikipedia",
     "ts": [
       "pswiki",
-      "wikips"
+      "pswp",
+      "psw",
+      "wikips",
+      "wpps",
+      "wps"
     ],
     "u": "https://ps.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92394,7 +92909,11 @@
     "t": "cvwikipedia",
     "ts": [
       "cvwiki",
-      "wikicv"
+      "cvwp",
+      "cvw",
+      "wikicv",
+      "wpcv",
+      "wcv"
     ],
     "u": "https://cv.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92405,7 +92924,12 @@
     "d": "fo.wikipedia.org",
     "t": "fowikipedia",
     "ts": [
-      "wikifo"
+      "fowiki",
+      "fowp",
+      "fow",
+      "wikifo",
+      "wpfo",
+      "wfo"
     ],
     "u": "https://fo.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92416,7 +92940,12 @@
     "d": "ia.wikipedia.org",
     "t": "iawikipedia",
     "ts": [
-      "wikiia"
+      "iawiki",
+      "iawp",
+      "iaw",
+      "wikiia",
+      "wpia",
+      "wia"
     ],
     "u": "https://ia.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92428,7 +92957,11 @@
     "t": "zghwikipedia",
     "ts": [
       "zghwiki",
-      "wikizgh"
+      "zghwp",
+      "zghw",
+      "wikizgh",
+      "wpzgh",
+      "wzgh"
     ],
     "u": "https://zgh.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92440,7 +92973,11 @@
     "t": "ruewikipedia",
     "ts": [
       "ruewiki",
-      "wikirue"
+      "ruewp",
+      "ruew",
+      "wikirue",
+      "wprue",
+      "wrue"
     ],
     "u": "https://rue.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92452,7 +92989,11 @@
     "t": "dagwikipedia",
     "ts": [
       "dagwiki",
-      "wikidag"
+      "dagwp",
+      "dagw",
+      "wikidag",
+      "wpdag",
+      "wdag"
     ],
     "u": "https://dag.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92464,7 +93005,11 @@
     "t": "gnwikipedia",
     "ts": [
       "gnwiki",
-      "wikign"
+      "gnwp",
+      "gnw",
+      "wikign",
+      "wpgn",
+      "wgn"
     ],
     "u": "https://gn.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92476,7 +93021,11 @@
     "t": "szlwikipedia",
     "ts": [
       "szlwiki",
-      "wikiszl"
+      "szlwp",
+      "szlw",
+      "wikiszl",
+      "wpszl",
+      "wszl"
     ],
     "u": "https://szl.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92488,7 +93037,11 @@
     "t": "pmswikipedia",
     "ts": [
       "pmswiki",
-      "wikipms"
+      "pmswp",
+      "pmsw",
+      "wikipms",
+      "wppms",
+      "wpms"
     ],
     "u": "https://pms.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92500,7 +93053,11 @@
     "t": "lowikipedia",
     "ts": [
       "lowiki",
-      "wikilo"
+      "lowp",
+      "low",
+      "wikilo",
+      "wplo",
+      "wlo"
     ],
     "u": "https://lo.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92512,7 +93069,11 @@
     "t": "tkwikipedia",
     "ts": [
       "tkwiki",
-      "wikitk"
+      "tkwp",
+      "tkw",
+      "wikitk",
+      "wptk",
+      "wtk"
     ],
     "u": "https://tk.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92524,7 +93085,11 @@
     "t": "mwlwikipedia",
     "ts": [
       "mwlwiki",
-      "wikimwl"
+      "mwlwp",
+      "mwlw",
+      "wikimwl",
+      "wpmwl",
+      "wmwl"
     ],
     "u": "https://mwl.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92536,7 +93101,11 @@
     "t": "scwikipedia",
     "ts": [
       "scwiki",
-      "wikisc"
+      "scwp",
+      "scw",
+      "wikisc",
+      "wpsc",
+      "wsc"
     ],
     "u": "https://sc.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92548,7 +93117,11 @@
     "t": "gucwikipedia",
     "ts": [
       "gucwiki",
-      "wikiguc"
+      "gucwp",
+      "gucw",
+      "wikiguc",
+      "wpguc",
+      "wguc"
     ],
     "u": "https://guc.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92560,7 +93133,11 @@
     "t": "scnwikipedia",
     "ts": [
       "scnwiki",
-      "wikiscn"
+      "scnwp",
+      "scnw",
+      "wikiscn",
+      "wpscn",
+      "wscn"
     ],
     "u": "https://scn.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92572,7 +93149,11 @@
     "t": "sahwikipedia",
     "ts": [
       "sahwiki",
-      "wikisah"
+      "sahwp",
+      "sahw",
+      "wikisah",
+      "wpsah",
+      "wsah"
     ],
     "u": "https://sah.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92584,7 +93165,11 @@
     "t": "maiwikipedia",
     "ts": [
       "maiwiki",
-      "wikimai"
+      "maiwp",
+      "maiw",
+      "wikimai",
+      "wpmai",
+      "wmai"
     ],
     "u": "https://mai.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92596,7 +93181,11 @@
     "t": "satwikipedia",
     "ts": [
       "satwiki",
-      "wikisat"
+      "satwp",
+      "satw",
+      "wikisat",
+      "wpsat",
+      "wsat"
     ],
     "u": "https://sat.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92640,6 +93229,14 @@
     "s": "Northern Sami Wikipedia",
     "d": "se.wikipedia.org",
     "t": "sewikipedia",
+    "ts": [
+      "sewiki",
+      "sewp",
+      "sew",
+      "wikise",
+      "wpse",
+      "wse"
+    ],
     "u": "https://se.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Reference"
@@ -92648,6 +93245,14 @@
     "s": "Volapük Wikipedia",
     "d": "vo.wikipedia.org",
     "t": "vowikipedia",
+    "ts": [
+      "vowiki",
+      "vowp",
+      "vow",
+      "wikivo",
+      "wpvo",
+      "wvo"
+    ],
     "u": "https://vo.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -86274,7 +86274,6 @@
     "d": "en.wikiversity.org",
     "t": "wikiversity",
     "ts": [
-      "wku",
       "wvers"
     ],
     "u": "https://en.wikiversity.org/w/index.php?search={{{s}}}",
@@ -88187,7 +88186,7 @@
   {
     "s": "Wiktionary (Hindi)",
     "d": "hi.wiktionary.org",
-    "t": "wth",
+    "t": "hiwiktionary",
     "u": "https://hi.wiktionary.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Reference (words)"
@@ -90820,9 +90819,7 @@
     "d": "fr.wikipedia.org",
     "t": "frwikipedia",
     "ts": [
-      "frwiki",
       "frwp",
-      "frw",
       "wikifr",
       "wpfr",
       "wfr"
@@ -90934,7 +90931,6 @@
     "ts": [
       "fawiki",
       "fawp",
-      "faw",
       "wikifa",
       "wpfa",
       "wfa"
@@ -90952,7 +90948,6 @@
       "plwp",
       "plw",
       "wikipl",
-      "wppl",
       "wpl"
     ],
     "u": "https://pl.wikipedia.org/w/index.php?search={{{s}}}",
@@ -90982,7 +90977,6 @@
     "ts": [
       "nlwiki",
       "nlwp",
-      "nlw",
       "wikinl",
       "wpnl",
       "wnl"
@@ -91030,7 +91024,6 @@
     "ts": [
       "trwiki",
       "trwp",
-      "trw",
       "wikitr",
       "wptr",
       "wtr"
@@ -91046,7 +91039,6 @@
     "ts": [
       "cswiki",
       "cswp",
-      "csw",
       "wikics",
       "wpcs",
       "wcs"
@@ -91094,7 +91086,6 @@
     "ts": [
       "svwiki",
       "svwp",
-      "svw",
       "wikisv",
       "wpsv",
       "wsv"
@@ -91188,9 +91179,7 @@
     "d": "th.wikipedia.org",
     "t": "thwikipedia",
     "ts": [
-      "thwiki",
       "thwp",
-      "thw",
       "wikith",
       "wpth",
       "wth"
@@ -91302,7 +91291,6 @@
     "ts": [
       "etwiki",
       "etwp",
-      "etw",
       "wikiet",
       "wpet",
       "wet"
@@ -91316,7 +91304,6 @@
     "d": "da.wikipedia.org",
     "t": "dawikipedia",
     "ts": [
-      "dawiki",
       "dawp",
       "daw",
       "wikida",
@@ -91350,7 +91337,6 @@
     "ts": [
       "bgwiki",
       "bgwp",
-      "bgw",
       "wikibg",
       "wpbg",
       "wbg"
@@ -91444,7 +91430,6 @@
     "d": "hr.wikipedia.org",
     "t": "hrwikipedia",
     "ts": [
-      "hrwiki",
       "hrwp",
       "hrw",
       "wikihr",
@@ -91492,7 +91477,6 @@
     "d": "sl.wikipedia.org",
     "t": "slwikipedia",
     "ts": [
-      "slwiki",
       "slwp",
       "slw",
       "wikisl",
@@ -91510,7 +91494,6 @@
     "ts": [
       "eowiki",
       "eowp",
-      "eow",
       "wikieo",
       "wpeo",
       "weo"
@@ -91558,10 +91541,8 @@
     "ts": [
       "tawiki",
       "tawp",
-      "taw",
       "wikita",
-      "wpta",
-      "wta"
+      "wpta"
     ],
     "u": "https://ta.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91572,7 +91553,6 @@
     "d": "gl.wikipedia.org",
     "t": "glwikipedia",
     "ts": [
-      "glwiki",
       "glwp",
       "glw",
       "wikigl",
@@ -91638,7 +91618,6 @@
     "ts": [
       "mkwiki",
       "mkwp",
-      "mkw",
       "wikimk",
       "wpmk",
       "wmk"
@@ -91736,8 +91715,7 @@
       "shwp",
       "shw",
       "wikish",
-      "wpsh",
-      "wsh"
+      "wpsh"
     ],
     "u": "https://sh.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91764,7 +91742,6 @@
     "d": "sw.wikipedia.org",
     "t": "swwikipedia",
     "ts": [
-      "swwiki",
       "swwp",
       "sww",
       "wikisw",
@@ -91782,10 +91759,8 @@
     "ts": [
       "bswiki",
       "bswp",
-      "bsw",
       "wikibs",
-      "wpbs",
-      "wbs"
+      "wpbs"
     ],
     "u": "https://bs.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -91798,7 +91773,6 @@
     "ts": [
       "iswiki",
       "iswp",
-      "isw",
       "wikiis",
       "wpis",
       "wis"
@@ -91830,7 +91804,6 @@
     "ts": [
       "lawiki",
       "lawp",
-      "law",
       "wikila",
       "wpla",
       "wla"
@@ -91878,7 +91851,6 @@
     "ts": [
       "mrwiki",
       "mrwp",
-      "mrw",
       "wikimr",
       "wpmr",
       "wmr"
@@ -91910,10 +91882,8 @@
     "ts": [
       "tlwiki",
       "tlwp",
-      "tlw",
       "wikitl",
-      "wptl",
-      "wtl"
+      "wptl"
     ],
     "u": "https://tl.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92054,7 +92024,6 @@
     "ts": [
       "ocwiki",
       "ocwp",
-      "ocw",
       "wikioc",
       "wpoc",
       "woc"
@@ -92150,7 +92119,6 @@
     "ts": [
       "siwiki",
       "siwp",
-      "siw",
       "wikisi",
       "wpsi",
       "wsi"
@@ -92254,10 +92222,8 @@
     "ts": [
       "htwiki",
       "htwp",
-      "htw",
       "wikiht",
-      "wpht",
-      "wht"
+      "wpht"
     ],
     "u": "https://ht.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92320,8 +92286,7 @@
       "sowp",
       "sow",
       "wikiso",
-      "wpso",
-      "wso"
+      "wpso"
     ],
     "u": "https://so.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92398,7 +92363,6 @@
     "ts": [
       "anwiki",
       "anwp",
-      "anw",
       "wikian",
       "wpan",
       "wan"
@@ -92590,7 +92554,6 @@
     "ts": [
       "mtwiki",
       "mtwp",
-      "mtw",
       "wikimt",
       "wpmt",
       "wmt"
@@ -92624,8 +92587,7 @@
       "amwp",
       "amw",
       "wikiam",
-      "wpam",
-      "wam"
+      "wpam"
     ],
     "u": "https://am.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92656,8 +92618,7 @@
       "suwp",
       "suw",
       "wikisu",
-      "wpsu",
-      "wsu"
+      "wpsu"
     ],
     "u": "https://su.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92686,7 +92647,6 @@
     "ts": [
       "mgwiki",
       "mgwp",
-      "mgw",
       "wikimg",
       "wpmg",
       "wmg"
@@ -92750,7 +92710,6 @@
     "ts": [
       "tnwiki",
       "tnwp",
-      "tnw",
       "wikitn",
       "wptn",
       "wtn"
@@ -92798,7 +92757,6 @@
     "ts": [
       "cowiki",
       "cowp",
-      "cow",
       "wikico",
       "wpco",
       "wco"
@@ -92880,8 +92838,7 @@
       "iewp",
       "iew",
       "wikiie",
-      "wpie",
-      "wie"
+      "wpie"
     ],
     "u": "https://ie.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -92924,9 +92881,7 @@
     "d": "fo.wikipedia.org",
     "t": "fowikipedia",
     "ts": [
-      "fowiki",
       "fowp",
-      "fow",
       "wikifo",
       "wpfo",
       "wfo"
@@ -92942,10 +92897,8 @@
     "ts": [
       "iawiki",
       "iawp",
-      "iaw",
       "wikiia",
-      "wpia",
-      "wia"
+      "wpia"
     ],
     "u": "https://ia.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -93040,8 +92993,7 @@
       "pmswp",
       "pmsw",
       "wikipms",
-      "wppms",
-      "wpms"
+      "wppms"
     ],
     "u": "https://pms.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -93070,7 +93022,6 @@
     "ts": [
       "tkwiki",
       "tkwp",
-      "tkw",
       "wikitk",
       "wptk",
       "wtk"
@@ -93234,7 +93185,6 @@
       "sewp",
       "sew",
       "wikise",
-      "wpse",
       "wse"
     ],
     "u": "https://se.wikipedia.org/w/index.php?search={{{s}}}",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -90766,33 +90766,33 @@
     "sc": "Reference"
   },
   {
-    "s": "Wikipedia Random in Category",
+    "s": "English Wikipedia Random in Category",
     "d": "en.wikipedia.org",
-    "t": "wrand",
+    "t": "enwikirand",
     "u": "https://en.wikipedia.org/wiki/Special:RandomInCategory/{{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
   {
-    "s": "Wikipedia Band Discography",
+    "s": "English Wikipedia Discography",
     "d": "en.wikipedia.org",
-    "t": "wdg",
+    "t": "enwikidg",
     "u": "https://en.wikipedia.org/w/index.php?title=Special:Search&search={{{s}}}+discography",
     "c": "Research",
     "sc": "Reference"
   },
   {
-    "s": "Wikipedia Modules",
+    "s": "English Wikipedia Modules",
     "d": "en.wikipedia.org",
-    "t": "wikimodule",
+    "t": "enwikimod",
     "u": "https://en.wikipedia.org/wiki/Module:{{{s}}}",
     "c": "Research",
     "sc": "Academic"
   },
   {
-    "s": "Wikipedia Templates",
+    "s": "English Wikipedia Templates",
     "d": "en.wikipedia.org",
-    "t": "wikitemplate",
+    "t": "enwikitm",
     "u": "https://en.wikipedia.org/wiki/Template:{{{s}}}",
     "c": "Research",
     "sc": "Academic"

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -92611,14 +92611,6 @@
     "sc": "Reference"
   },
   {
-    "s": "de.wikipedia.org",
-    "d": "de.wikipedia.org",
-    "t": "dew",
-    "u": "https://de.wikipedia.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Academic"
-  },
-  {
     "s": "Google de.Wikipedia",
     "d": "www.google.de",
     "ad": "de.wikipedia.org",
@@ -92637,84 +92629,12 @@
     "sc": "Google"
   },
   {
-    "s": "Simple English Wikipedia (short bang)",
-    "d": "simple.wikipedia.org",
-    "t": "se.w",
-    "u": "https://simple.wikipedia.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
-    "s": "Vikipedi (Turkish Wikipedia)",
-    "d": "tr.wikipedia.org",
-    "t": "vikipedi",
-    "u": "https://tr.wikipedia.org/wiki/Special:Search?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
-    "s": "Wikipedia (BR)",
-    "d": "pt.wikipedia.org",
-    "t": "w.br",
-    "u": "https://pt.wikipedia.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Learning"
-  },
-  {
     "s": "Pokemon Wiki",
     "d": "es.pokemon.wikia.com",
     "t": "wdex",
     "u": "https://es.pokemon.wikia.com/wiki/Especial:Buscar?query={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (Pokemon)"
-  },
-  {
-    "s": "Wikipedia Euskaraz (in Basque)",
-    "d": "eu.wikipedia.org",
-    "t": "weus",
-    "u": "https://eu.wikipedia.org/wiki/Special:Search?search={{{s}}}",
-    "c": "Research",
-    "sc": "Academic"
-  },
-  {
-    "s": "fr.wikipedia.org",
-    "d": "fr.wikipedia.org",
-    "t": "wf",
-    "u": "https://fr.wikipedia.org/wiki/Special:Search?search={{{s}}}",
-    "c": "Online Services",
-    "sc": "Search (non-US)"
-  },
-  {
-    "s": "Wikipedia (GR)",
-    "d": "el.wikipedia.org",
-    "t": "wgr",
-    "u": "https://el.wikipedia.org/wiki/Special:Search?search={{{s}}}",
-    "c": "Research",
-    "sc": "Learning"
-  },
-  {
-    "s": "Wikipedia Polska",
-    "d": "pl.wikipedia.org",
-    "t": "wiki.pl",
-    "u": "https://pl.wikipedia.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Learning"
-  },
-  {
-    "s": "Wikipedia in Japanese",
-    "d": "ja.wikipedia.org",
-    "t": "wj",
-    "u": "https://ja.wikipedia.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
-    "s": "Wikipedia (FR)",
-    "d": "fr.wikipedia.org",
-    "t": "wpfr",
-    "u": "https://fr.wikipedia.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Learning (intl)"
   },
   {
     "s": "Wikipedia – Friddje diehtosátnegirji",
@@ -92731,41 +92651,6 @@
     "u": "https://vo.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
-  },
-  {
-    "s": "ويكيبيديا العربية",
-    "d": "ar.wikipedia.org",
-    "t": "و",
-    "u": "https://ar.wikipedia.org/wiki/Special:Search?search={{{s}}}",
-    "c": "Research",
-    "sc": "Learning"
-  },
-  {
-    "s": "greek wikipedia",
-    "d": "el.wikipedia.org",
-    "t": "ςγρ",
-    "u": "https://el.wikipedia.org/wiki/?search={{{s}}}",
-    "c": "Online Services",
-    "sc": "Search"
-  },
-  {
-    "s": "Википедия",
-    "d": "ru.wikipedia.org",
-    "t": "вики",
-    "ts": [
-      "ц"
-    ],
-    "u": "https://ru.wikipedia.org/w/index.php?search={{{s}}}&",
-    "c": "Multimedia",
-    "sc": "Docs"
-  },
-  {
-    "s": "Wikipedia (BG)",
-    "d": "bg.wikipedia.org",
-    "t": "уики",
-    "u": "https://bg.wikipedia.org/wiki/{{{s}}}",
-    "c": "Translation",
-    "sc": "Google"
   },
   {
     "s": "Predecessor Official Wiki",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -86532,14 +86532,6 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Wikrionary(GR)",
-    "d": "el.m.wiktionary.org",
-    "t": "wiktgr",
-    "u": "https://el.m.wiktionary.org/wiki{{{s}}}",
-    "c": "Research",
-    "sc": "Academic"
-  },
-  {
     "s": "Wiktionary (hu)",
     "d": "hu.wiktionary.org",
     "t": "wikthu",
@@ -86832,17 +86824,6 @@
     "d": "www.wissen.de",
     "t": "wissen",
     "u": "https://www.wissen.de/wissensserver/search?keyword={{{s}}}",
-    "c": "Research",
-    "sc": "Academic"
-  },
-  {
-    "s": "Wiktionary(GR)",
-    "d": "el.m.wiktionary.org",
-    "t": "witgr",
-    "ts": [
-      "λεξικό"
-    ],
-    "u": "https://el.m.wiktionary.org/wiki/{{{s}}}",
     "c": "Research",
     "sc": "Academic"
   },
@@ -88232,14 +88213,6 @@
     "u": "https://whatthefuckshouldilistentorightnow.com/artist.php?artist={{{s}}}",
     "c": "Entertainment",
     "sc": "Audio"
-  },
-  {
-    "s": "Wiktionary Mobile",
-    "d": "en.m.wiktionary.org",
-    "t": "wtm",
-    "u": "https://en.m.wiktionary.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words)"
   },
   {
     "s": "WikiWoordenboek",
@@ -92736,38 +92709,6 @@
     "sc": "Reference"
   },
   {
-    "s": "Wikipedia Deutsch Mobile",
-    "d": "de.m.wikipedia.org",
-    "t": "wmde",
-    "u": "https://de.m.wikipedia.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Learning"
-  },
-  {
-    "s": "Wikipedia French mobile",
-    "d": "fr.m.wikipedia.org",
-    "t": "wmfr",
-    "u": "https://fr.m.wikipedia.org/w/index.php?search={{{s}}}",
-    "c": "Online Services",
-    "sc": "Search"
-  },
-  {
-    "s": "Wikipedia Mobile (Serbia)",
-    "d": "sr.m.wikipedia.org",
-    "t": "wmsr",
-    "u": "https://sr.m.wikipedia.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Learning"
-  },
-  {
-    "s": "Wikipedia mobile",
-    "d": "en.m.wikipedia.org",
-    "t": "wm",
-    "u": "https://en.m.wikipedia.org/wiki?search={{{s}}}",
-    "c": "Research",
-    "sc": "Academic"
-  },
-  {
     "s": "Wikipedia (FR)",
     "d": "fr.wikipedia.org",
     "t": "wpfr",
@@ -92808,14 +92749,6 @@
     "sc": "Search"
   },
   {
-    "s": "Wikipedia (Ukraine)",
-    "d": "uk.m.wikipedia.org",
-    "t": "в",
-    "u": "https://uk.m.wikipedia.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Learning"
-  },
-  {
     "s": "Википедия",
     "d": "ru.wikipedia.org",
     "t": "вики",
@@ -92825,14 +92758,6 @@
     "u": "https://ru.wikipedia.org/w/index.php?search={{{s}}}&",
     "c": "Multimedia",
     "sc": "Docs"
-  },
-  {
-    "s": "Βικιπαίδεια",
-    "d": "el.m.wikipedia.org",
-    "t": "βικι",
-    "u": "https://el.m.wikipedia.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Academic"
   },
   {
     "s": "Wikipedia (BG)",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -86454,149 +86454,328 @@
     "sc": "Learning"
   },
   {
-    "s": "Wikivoyage (Deutsch)",
-    "d": "de.wikivoyage.org",
-    "t": "wikivoyagede",
-    "u": "https://de.wikivoyage.org/w/index.php?search={{{s}}}&title=Special:Search&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (Ελληνικά)",
-    "d": "el.wikivoyage.org",
-    "t": "wikivoyageel",
-    "u": "https://el.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (English)",
+    "s": "English Wikivoyage",
     "d": "en.wikivoyage.org",
-    "t": "wikivoyageen",
+    "t": "enwikivoyage",
     "ts": [
-      "wven"
-    ],
-    "u": "https://en.wikivoyage.org/w/index.php?search={{{s}}}&title=Special:Search&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (Español)",
-    "d": "es.wikivoyage.org",
-    "t": "wikivoyagees",
-    "u": "https://es.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (français)",
-    "d": "fr.wikivoyage.org",
-    "t": "wikivoyagefr",
-    "u": "https://fr.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (עברית)",
-    "d": "he.wikivoyage.org",
-    "t": "wikivoyagehe",
-    "u": "https://he.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (Italiano)",
-    "d": "it.wikivoyage.org",
-    "t": "wikivoyageit",
-    "u": "https://it.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (Netherlands)",
-    "d": "nl.wikivoyage.org",
-    "t": "wikivoyagenl",
-    "u": "https://nl.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (Polski)",
-    "d": "pl.wikivoyage.org",
-    "t": "wikivoyagepl",
-    "u": "https://pl.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (português)",
-    "d": "pt.wikivoyage.org",
-    "t": "wikivoyagept",
-    "u": "https://pt.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (Română)",
-    "d": "ro.wikivoyage.org",
-    "t": "wikivoyagero",
-    "u": "https://ro.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (Русский)",
-    "d": "ru.wikivoyage.org",
-    "t": "wikivoyageru",
-    "ts": [
-      "викивояж"
-    ],
-    "u": "https://ru.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (Svenska)",
-    "d": "sv.wikivoyage.org",
-    "t": "wikivoyagesv",
-    "u": "https://sv.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (Українська)",
-    "d": "uk.wikivoyage.org",
-    "t": "wikivoyageuk",
-    "u": "https://uk.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage (Tiếng Việt)",
-    "d": "vi.wikivoyage.org",
-    "t": "wikivoyagevi",
-    "u": "https://vi.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage",
-    "d": "en.wikivoyage.org",
-    "t": "wikivoyage",
-    "ts": [
-      "wv"
+      "enwvoy",
+      "wvoyen"
     ],
     "u": "https://en.wikivoyage.org/w/index.php?search={{{s}}}",
     "c": "Research",
-    "sc": "Travel"
+    "sc": "Learning"
   },
   {
-    "s": "Wikivoyage (中文)",
-    "d": "zh.wikivoyage.org",
-    "t": "wikivoyagezh",
-    "u": "https://zh.wikivoyage.org/wiki/Special:Search?search={{{s}}}&go=Go",
+    "s": "German Wikivoyage",
+    "d": "de.wikivoyage.org",
+    "t": "dewikivoyage",
+    "ts": [
+      "dewvoy",
+      "wvoyde"
+    ],
+    "u": "https://de.wikivoyage.org/w/index.php?search={{{s}}}",
     "c": "Research",
-    "sc": "Travel"
+    "sc": "Learning"
+  },
+  {
+    "s": "Polish Wikivoyage",
+    "d": "pl.wikivoyage.org",
+    "t": "plwikivoyage",
+    "ts": [
+      "plwvoy",
+      "wvoypl"
+    ],
+    "u": "https://pl.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Italian Wikivoyage",
+    "d": "it.wikivoyage.org",
+    "t": "itwikivoyage",
+    "ts": [
+      "itwvoy",
+      "wvoyit"
+    ],
+    "u": "https://it.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "French Wikivoyage",
+    "d": "fr.wikivoyage.org",
+    "t": "frwikivoyage",
+    "ts": [
+      "frwvoy",
+      "wvoyfr"
+    ],
+    "u": "https://fr.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Persian Wikivoyage",
+    "d": "fa.wikivoyage.org",
+    "t": "fawikivoyage",
+    "ts": [
+      "fawvoy",
+      "wvoyfa"
+    ],
+    "u": "https://fa.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Russian Wikivoyage",
+    "d": "ru.wikivoyage.org",
+    "t": "ruwikivoyage",
+    "ts": [
+      "ruwvoy",
+      "wvoyru"
+    ],
+    "u": "https://ru.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Chinese Wikivoyage",
+    "d": "zh.wikivoyage.org",
+    "t": "zhwikivoyage",
+    "ts": [
+      "zhwvoy",
+      "wvoyzh"
+    ],
+    "u": "https://zh.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Dutch Wikivoyage",
+    "d": "nl.wikivoyage.org",
+    "t": "nlwikivoyage",
+    "ts": [
+      "nlwvoy",
+      "wvoynl"
+    ],
+    "u": "https://nl.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Portuguese Wikivoyage",
+    "d": "pt.wikivoyage.org",
+    "t": "ptwikivoyage",
+    "ts": [
+      "ptwvoy",
+      "wvoypt"
+    ],
+    "u": "https://pt.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Spanish Wikivoyage",
+    "d": "es.wikivoyage.org",
+    "t": "eswikivoyage",
+    "ts": [
+      "eswvoy",
+      "wvoyes"
+    ],
+    "u": "https://es.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Hebrew Wikivoyage",
+    "d": "he.wikivoyage.org",
+    "t": "hewikivoyage",
+    "ts": [
+      "hewvoy",
+      "wvoyhe"
+    ],
+    "u": "https://he.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Bangla Wikivoyage",
+    "d": "bn.wikivoyage.org",
+    "t": "bnwikivoyage",
+    "ts": [
+      "bnwvoy",
+      "wvoybn"
+    ],
+    "u": "https://bn.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Finnish Wikivoyage",
+    "d": "fi.wikivoyage.org",
+    "t": "fiwikivoyage",
+    "ts": [
+      "fiwvoy",
+      "wvoyfi"
+    ],
+    "u": "https://fi.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Japanese Wikivoyage",
+    "d": "ja.wikivoyage.org",
+    "t": "jawikivoyage",
+    "ts": [
+      "jawvoy",
+      "wvoyja"
+    ],
+    "u": "https://ja.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Indonesian Wikivoyage",
+    "d": "id.wikivoyage.org",
+    "t": "idwikivoyage",
+    "ts": [
+      "idwvoy",
+      "wvoyid"
+    ],
+    "u": "https://id.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Swedish Wikivoyage",
+    "d": "sv.wikivoyage.org",
+    "t": "svwikivoyage",
+    "ts": [
+      "svwvoy",
+      "wvoysv"
+    ],
+    "u": "https://sv.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Vietnamese Wikivoyage",
+    "d": "vi.wikivoyage.org",
+    "t": "viwikivoyage",
+    "ts": [
+      "viwvoy",
+      "wvoyvi"
+    ],
+    "u": "https://vi.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Esperanto Wikivoyage",
+    "d": "eo.wikivoyage.org",
+    "t": "eowikivoyage",
+    "ts": [
+      "eowvoy",
+      "wvoyeo"
+    ],
+    "u": "https://eo.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Greek Wikivoyage",
+    "d": "el.wikivoyage.org",
+    "t": "elwikivoyage",
+    "ts": [
+      "elwvoy",
+      "wvoyel"
+    ],
+    "u": "https://el.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Ukrainian Wikivoyage",
+    "d": "uk.wikivoyage.org",
+    "t": "ukwikivoyage",
+    "ts": [
+      "ukwvoy",
+      "wvoyuk"
+    ],
+    "u": "https://uk.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Romanian Wikivoyage",
+    "d": "ro.wikivoyage.org",
+    "t": "rowikivoyage",
+    "ts": [
+      "rowvoy",
+      "wvoyro"
+    ],
+    "u": "https://ro.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Czech Wikivoyage",
+    "d": "cs.wikivoyage.org",
+    "t": "cswikivoyage",
+    "ts": [
+      "cswvoy",
+      "wvoycs"
+    ],
+    "u": "https://cs.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Turkish Wikivoyage",
+    "d": "tr.wikivoyage.org",
+    "t": "trwikivoyage",
+    "ts": [
+      "trwvoy",
+      "wvoytr"
+    ],
+    "u": "https://tr.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Pashto Wikivoyage",
+    "d": "ps.wikivoyage.org",
+    "t": "pswikivoyage",
+    "ts": [
+      "pswvoy",
+      "wvoyps"
+    ],
+    "u": "https://ps.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Shan Wikivoyage",
+    "d": "shn.wikivoyage.org",
+    "t": "shnwikivoyage",
+    "ts": [
+      "shnwvoy",
+      "wvoyshn"
+    ],
+    "u": "https://shn.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Hindi Wikivoyage",
+    "d": "hi.wikivoyage.org",
+    "t": "hiwikivoyage",
+    "ts": [
+      "hiwvoy",
+      "wvoyhi"
+    ],
+    "u": "https://hi.wikivoyage.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
   },
   {
     "s": "WikiWand",
@@ -89438,76 +89617,12 @@
     "sc": "Search"
   },
   {
-    "s": "Wikivoyage Deutsch",
-    "d": "de.wikivoyage.org",
-    "t": "wvde",
-    "u": "https://de.wikivoyage.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage español",
-    "d": "es.wikivoyage.org",
-    "t": "wves",
-    "u": "https://es.wikivoyage.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage Français",
-    "d": "fr.wikivoyage.org",
-    "t": "wvfr",
-    "u": "https://fr.wikivoyage.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage Italiano",
-    "d": "it.wikivoyage.org",
-    "t": "wvit",
-    "u": "https://it.wikivoyage.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
     "s": "WorldVectorLogo",
     "d": "worldvectorlogo.com",
     "t": "wvl",
     "u": "https://worldvectorlogo.com/search/{{{s}}}",
     "c": "Tech",
     "sc": "Design"
-  },
-  {
-    "s": "Wikivoyage Nederlands",
-    "d": "nl.wikivoyage.org",
-    "t": "wvnl",
-    "u": "https://nl.wikivoyage.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage Português",
-    "d": "pt.wikivoyage.org",
-    "t": "wvpt",
-    "u": "https://pt.wikivoyage.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage Russian",
-    "d": "ru.wikivoyage.org",
-    "t": "wvru",
-    "u": "https://ru.wikivoyage.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Travel"
-  },
-  {
-    "s": "Wikivoyage Svenska",
-    "d": "sv.wikivoyage.org",
-    "t": "wvsv",
-    "u": "https://sv.wikivoyage.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Travel"
   },
   {
     "s": "WoodwindsBrasswinds",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -42376,14 +42376,6 @@
     "sc": "Reference"
   },
   {
-    "s": "Japanese Wikiquote",
-    "d": "ja.wikiquote.org",
-    "t": "jawq",
-    "u": "https://ja.wikiquote.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
     "s": "Japanese Wikisource",
     "d": "ja.wikisource.org",
     "t": "jaws",
@@ -65492,17 +65484,6 @@
     "sc": "Reference"
   },
   {
-    "s": "WikiQuote",
-    "d": "en.wikiquote.org",
-    "t": "quotes",
-    "ts": [
-      "wq"
-    ],
-    "u": "https://en.wikiquote.org/wiki/Special:Search?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Misc"
-  },
-  {
     "s": "Quotev",
     "d": "www.quotev.com",
     "t": "quotev",
@@ -86176,14 +86157,6 @@
     "sc": "Tools"
   },
   {
-    "s": "Wikiquote",
-    "d": "en.wikiquote.org",
-    "t": "wikiquote",
-    "u": "https://en.wikiquote.org/w/index.php?search={{{s}}}",
-    "c": "Multimedia",
-    "sc": "Docs"
-  },
-  {
     "s": "Wikirby",
     "d": "wikirby.com",
     "t": "wikirby",
@@ -87881,34 +87854,926 @@
     "sc": "Blogs (intl)"
   },
   {
-    "s": "Wikiquote German",
-    "d": "de.wikiquote.org",
-    "t": "wqde",
-    "u": "https://de.wikiquote.org/w/index.php?search={{{s}}}&title=Spezial:Suche",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
-    "s": "Wikiquote Español",
-    "d": "es.wikiquote.org",
-    "t": "wqes",
-    "u": "https://es.wikiquote.org/w/?search={{{s}}}",
+    "s": "English Wikiquote",
+    "d": "en.wikiquote.org",
+    "t": "enwikiquote",
+    "ts": [
+      "enwq",
+      "wqen"
+    ],
+    "u": "https://en.wikiquote.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Reference"
   },
   {
-    "s": "WikiQuote Italian",
+    "s": "Italian Wikiquote",
     "d": "it.wikiquote.org",
-    "t": "wqit",
-    "u": "https://it.wikiquote.org/?q={{{s}}}:",
-    "c": "Online Services",
-    "sc": "Tools"
+    "t": "itwikiquote",
+    "ts": [
+      "itwq",
+      "wqit"
+    ],
+    "u": "https://it.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
   },
   {
-    "s": "Wikiquote Polish",
+    "s": "Polish Wikiquote",
     "d": "pl.wikiquote.org",
-    "t": "wqpl",
-    "u": "https://pl.wikiquote.org/w/index.php?search={{{s}}}&title=Specjalna:Szukaj&go=Przejdź",
+    "t": "plwikiquote",
+    "ts": [
+      "plwq",
+      "wqpl"
+    ],
+    "u": "https://pl.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Russian Wikiquote",
+    "d": "ru.wikiquote.org",
+    "t": "ruwikiquote",
+    "ts": [
+      "ruwq",
+      "wqru"
+    ],
+    "u": "https://ru.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Czech Wikiquote",
+    "d": "cs.wikiquote.org",
+    "t": "cswikiquote",
+    "ts": [
+      "cswq",
+      "wqcs"
+    ],
+    "u": "https://cs.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Estonian Wikiquote",
+    "d": "et.wikiquote.org",
+    "t": "etwikiquote",
+    "ts": [
+      "etwq",
+      "wqet"
+    ],
+    "u": "https://et.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Ukrainian Wikiquote",
+    "d": "uk.wikiquote.org",
+    "t": "ukwikiquote",
+    "ts": [
+      "ukwq",
+      "wquk"
+    ],
+    "u": "https://uk.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Portuguese Wikiquote",
+    "d": "pt.wikiquote.org",
+    "t": "ptwikiquote",
+    "ts": [
+      "ptwq",
+      "wqpt"
+    ],
+    "u": "https://pt.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Hebrew Wikiquote",
+    "d": "he.wikiquote.org",
+    "t": "hewikiquote",
+    "ts": [
+      "hewq",
+      "wqhe"
+    ],
+    "u": "https://he.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "French Wikiquote",
+    "d": "fr.wikiquote.org",
+    "t": "frwikiquote",
+    "ts": [
+      "frwq",
+      "wqfr"
+    ],
+    "u": "https://fr.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Persian Wikiquote",
+    "d": "fa.wikiquote.org",
+    "t": "fawikiquote",
+    "ts": [
+      "fawq",
+      "wqfa"
+    ],
+    "u": "https://fa.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Spanish Wikiquote",
+    "d": "es.wikiquote.org",
+    "t": "eswikiquote",
+    "ts": [
+      "eswq",
+      "wqes"
+    ],
+    "u": "https://es.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "German Wikiquote",
+    "d": "de.wikiquote.org",
+    "t": "dewikiquote",
+    "ts": [
+      "dewq",
+      "wqde"
+    ],
+    "u": "https://de.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Serbian Wikiquote",
+    "d": "sr.wikiquote.org",
+    "t": "srwikiquote",
+    "ts": [
+      "srwq",
+      "wqsr"
+    ],
+    "u": "https://sr.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Turkish Wikiquote",
+    "d": "tr.wikiquote.org",
+    "t": "trwikiquote",
+    "ts": [
+      "trwq",
+      "wqtr"
+    ],
+    "u": "https://tr.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Esperanto Wikiquote",
+    "d": "eo.wikiquote.org",
+    "t": "eowikiquote",
+    "ts": [
+      "eowq",
+      "wqeo"
+    ],
+    "u": "https://eo.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Azerbaijani Wikiquote",
+    "d": "az.wikiquote.org",
+    "t": "azwikiquote",
+    "ts": [
+      "azwq",
+      "wqaz"
+    ],
+    "u": "https://az.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Slovak Wikiquote",
+    "d": "sk.wikiquote.org",
+    "t": "skwikiquote",
+    "ts": [
+      "skwq",
+      "wqsk"
+    ],
+    "u": "https://sk.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Catalan Wikiquote",
+    "d": "ca.wikiquote.org",
+    "t": "cawikiquote",
+    "ts": [
+      "cawq",
+      "wqca"
+    ],
+    "u": "https://ca.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Bosnian Wikiquote",
+    "d": "bs.wikiquote.org",
+    "t": "bswikiquote",
+    "ts": [
+      "bswq",
+      "wqbs"
+    ],
+    "u": "https://bs.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Chinese Wikiquote",
+    "d": "zh.wikiquote.org",
+    "t": "zhwikiquote",
+    "ts": [
+      "zhwq",
+      "wqzh"
+    ],
+    "u": "https://zh.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Arabic Wikiquote",
+    "d": "ar.wikiquote.org",
+    "t": "arwikiquote",
+    "ts": [
+      "arwq",
+      "wqar"
+    ],
+    "u": "https://ar.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Indonesian Wikiquote",
+    "d": "id.wikiquote.org",
+    "t": "idwikiquote",
+    "ts": [
+      "idwq",
+      "wqid"
+    ],
+    "u": "https://id.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Finnish Wikiquote",
+    "d": "fi.wikiquote.org",
+    "t": "fiwikiquote",
+    "ts": [
+      "fiwq",
+      "wqfi"
+    ],
+    "u": "https://fi.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Lithuanian Wikiquote",
+    "d": "lt.wikiquote.org",
+    "t": "ltwikiquote",
+    "ts": [
+      "ltwq",
+      "wqlt"
+    ],
+    "u": "https://lt.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Slovenian Wikiquote",
+    "d": "sl.wikiquote.org",
+    "t": "slwikiquote",
+    "ts": [
+      "slwq",
+      "wqsl"
+    ],
+    "u": "https://sl.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Bangla Wikiquote",
+    "d": "bn.wikiquote.org",
+    "t": "bnwikiquote",
+    "ts": [
+      "bnwq",
+      "wqbn"
+    ],
+    "u": "https://bn.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Sundanese Wikiquote",
+    "d": "su.wikiquote.org",
+    "t": "suwikiquote",
+    "ts": [
+      "suwq",
+      "wqsu"
+    ],
+    "u": "https://su.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Armenian Wikiquote",
+    "d": "hy.wikiquote.org",
+    "t": "hywikiquote",
+    "ts": [
+      "hywq",
+      "wqhy"
+    ],
+    "u": "https://hy.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Bulgarian Wikiquote",
+    "d": "bg.wikiquote.org",
+    "t": "bgwikiquote",
+    "ts": [
+      "bgwq",
+      "wqbg"
+    ],
+    "u": "https://bg.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Croatian Wikiquote",
+    "d": "hr.wikiquote.org",
+    "t": "hrwikiquote",
+    "ts": [
+      "hrwq",
+      "wqhr"
+    ],
+    "u": "https://hr.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Igbo Wikiquote",
+    "d": "ig.wikiquote.org",
+    "t": "igwikiquote",
+    "ts": [
+      "igwq",
+      "wqig"
+    ],
+    "u": "https://ig.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Greek Wikiquote",
+    "d": "el.wikiquote.org",
+    "t": "elwikiquote",
+    "ts": [
+      "elwq",
+      "wqel"
+    ],
+    "u": "https://el.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Uzbek Wikiquote",
+    "d": "uz.wikiquote.org",
+    "t": "uzwikiquote",
+    "ts": [
+      "uzwq",
+      "wquz"
+    ],
+    "u": "https://uz.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Norwegian Nynorsk Wikiquote",
+    "d": "nn.wikiquote.org",
+    "t": "nnwikiquote",
+    "ts": [
+      "nnwq",
+      "wqnn"
+    ],
+    "u": "https://nn.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Limburgish Wikiquote",
+    "d": "li.wikiquote.org",
+    "t": "liwikiquote",
+    "ts": [
+      "liwq",
+      "wqli"
+    ],
+    "u": "https://li.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Swedish Wikiquote",
+    "d": "sv.wikiquote.org",
+    "t": "svwikiquote",
+    "ts": [
+      "svwq",
+      "wqsv"
+    ],
+    "u": "https://sv.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Vietnamese Wikiquote",
+    "d": "vi.wikiquote.org",
+    "t": "viwikiquote",
+    "ts": [
+      "viwq",
+      "wqvi"
+    ],
+    "u": "https://vi.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Banjar Wikiquote",
+    "d": "bjn.wikiquote.org",
+    "t": "bjnwikiquote",
+    "ts": [
+      "bjnwq",
+      "wqbjn"
+    ],
+    "u": "https://bjn.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Hungarian Wikiquote",
+    "d": "hu.wikiquote.org",
+    "t": "huwikiquote",
+    "ts": [
+      "huwq",
+      "wqhu"
+    ],
+    "u": "https://hu.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Assamese Wikiquote",
+    "d": "as.wikiquote.org",
+    "t": "aswikiquote",
+    "ts": [
+      "aswq",
+      "wqas"
+    ],
+    "u": "https://as.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Dutch Wikiquote",
+    "d": "nl.wikiquote.org",
+    "t": "nlwikiquote",
+    "ts": [
+      "nlwq",
+      "wqnl"
+    ],
+    "u": "https://nl.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Japanese Wikiquote",
+    "d": "ja.wikiquote.org",
+    "t": "jawikiquote",
+    "ts": [
+      "jawq",
+      "wqja"
+    ],
+    "u": "https://ja.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Korean Wikiquote",
+    "d": "ko.wikiquote.org",
+    "t": "kowikiquote",
+    "ts": [
+      "kowq",
+      "wqko"
+    ],
+    "u": "https://ko.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Yakut Wikiquote",
+    "d": "sah.wikiquote.org",
+    "t": "sahwikiquote",
+    "ts": [
+      "sahwq",
+      "wqsah"
+    ],
+    "u": "https://sah.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Latin Wikiquote",
+    "d": "la.wikiquote.org",
+    "t": "lawikiquote",
+    "ts": [
+      "lawq",
+      "wqla"
+    ],
+    "u": "https://la.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Tamil Wikiquote",
+    "d": "ta.wikiquote.org",
+    "t": "tawikiquote",
+    "ts": [
+      "tawq",
+      "wqta"
+    ],
+    "u": "https://ta.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Hindi Wikiquote",
+    "d": "hi.wikiquote.org",
+    "t": "hiwikiquote",
+    "ts": [
+      "hiwq",
+      "wqhi"
+    ],
+    "u": "https://hi.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Telugu Wikiquote",
+    "d": "te.wikiquote.org",
+    "t": "tewikiquote",
+    "ts": [
+      "tewq",
+      "wqte"
+    ],
+    "u": "https://te.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Gun Wikiquote",
+    "d": "guw.wikiquote.org",
+    "t": "guwwikiquote",
+    "ts": [
+      "guwwq",
+      "wqguw"
+    ],
+    "u": "https://guw.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Romanian Wikiquote",
+    "d": "ro.wikiquote.org",
+    "t": "rowikiquote",
+    "ts": [
+      "rowq",
+      "wqro"
+    ],
+    "u": "https://ro.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Thai Wikiquote",
+    "d": "th.wikiquote.org",
+    "t": "thwikiquote",
+    "ts": [
+      "thwq",
+      "wqth"
+    ],
+    "u": "https://th.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Urdu Wikiquote",
+    "d": "ur.wikiquote.org",
+    "t": "urwikiquote",
+    "ts": [
+      "urwq",
+      "wqur"
+    ],
+    "u": "https://ur.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Galician Wikiquote",
+    "d": "gl.wikiquote.org",
+    "t": "glwikiquote",
+    "ts": [
+      "glwq",
+      "wqgl"
+    ],
+    "u": "https://gl.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Tagalog Wikiquote",
+    "d": "tl.wikiquote.org",
+    "t": "tlwikiquote",
+    "ts": [
+      "tlwq",
+      "wqtl"
+    ],
+    "u": "https://tl.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Gujarati Wikiquote",
+    "d": "gu.wikiquote.org",
+    "t": "guwikiquote",
+    "ts": [
+      "guwq",
+      "wqgu"
+    ],
+    "u": "https://gu.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Georgian Wikiquote",
+    "d": "ka.wikiquote.org",
+    "t": "kawikiquote",
+    "ts": [
+      "kawq",
+      "wqka"
+    ],
+    "u": "https://ka.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Belarusian Wikiquote",
+    "d": "be.wikiquote.org",
+    "t": "bewikiquote",
+    "ts": [
+      "bewq",
+      "wqbe"
+    ],
+    "u": "https://be.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Kannada Wikiquote",
+    "d": "kn.wikiquote.org",
+    "t": "knwikiquote",
+    "ts": [
+      "knwq",
+      "wqkn"
+    ],
+    "u": "https://kn.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Norwegian Wikiquote",
+    "d": "no.wikiquote.org",
+    "t": "nowikiquote",
+    "ts": [
+      "nowq",
+      "wqno"
+    ],
+    "u": "https://no.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Welsh Wikiquote",
+    "d": "cy.wikiquote.org",
+    "t": "cywikiquote",
+    "ts": [
+      "cywq",
+      "wqcy"
+    ],
+    "u": "https://cy.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Nigerian Pidgin Wikiquote",
+    "d": "pcm.wikiquote.org",
+    "t": "pcmwikiquote",
+    "ts": [
+      "pcmwq",
+      "wqpcm"
+    ],
+    "u": "https://pcm.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Malayalam Wikiquote",
+    "d": "ml.wikiquote.org",
+    "t": "mlwikiquote",
+    "ts": [
+      "mlwq",
+      "wqml"
+    ],
+    "u": "https://ml.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Albanian Wikiquote",
+    "d": "sq.wikiquote.org",
+    "t": "sqwikiquote",
+    "ts": [
+      "sqwq",
+      "wqsq"
+    ],
+    "u": "https://sq.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Basque Wikiquote",
+    "d": "eu.wikiquote.org",
+    "t": "euwikiquote",
+    "ts": [
+      "euwq",
+      "wqeu"
+    ],
+    "u": "https://eu.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Kurdish Wikiquote",
+    "d": "ku.wikiquote.org",
+    "t": "kuwikiquote",
+    "ts": [
+      "kuwq",
+      "wqku"
+    ],
+    "u": "https://ku.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Malay Wikiquote",
+    "d": "ms.wikiquote.org",
+    "t": "mswikiquote",
+    "ts": [
+      "mswq",
+      "wqms"
+    ],
+    "u": "https://ms.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Danish Wikiquote",
+    "d": "da.wikiquote.org",
+    "t": "dawikiquote",
+    "ts": [
+      "dawq",
+      "wqda"
+    ],
+    "u": "https://da.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Central Bikol Wikiquote",
+    "d": "bcl.wikiquote.org",
+    "t": "bclwikiquote",
+    "ts": [
+      "bclwq",
+      "wqbcl"
+    ],
+    "u": "https://bcl.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Sanskrit Wikiquote",
+    "d": "sa.wikiquote.org",
+    "t": "sawikiquote",
+    "ts": [
+      "sawq",
+      "wqsa"
+    ],
+    "u": "https://sa.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Icelandic Wikiquote",
+    "d": "is.wikiquote.org",
+    "t": "iswikiquote",
+    "ts": [
+      "iswq",
+      "wqis"
+    ],
+    "u": "https://is.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Gorontalo Wikiquote",
+    "d": "gor.wikiquote.org",
+    "t": "gorwikiquote",
+    "ts": [
+      "gorwq",
+      "wqgor"
+    ],
+    "u": "https://gor.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Breton Wikiquote",
+    "d": "br.wikiquote.org",
+    "t": "brwikiquote",
+    "ts": [
+      "brwq",
+      "wqbr"
+    ],
+    "u": "https://br.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Marathi Wikiquote",
+    "d": "mr.wikiquote.org",
+    "t": "mrwikiquote",
+    "ts": [
+      "mrwq",
+      "wqmr"
+    ],
+    "u": "https://mr.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Afrikaans Wikiquote",
+    "d": "af.wikiquote.org",
+    "t": "afwikiquote",
+    "ts": [
+      "afwq",
+      "wqaf"
+    ],
+    "u": "https://af.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Minangkabau Wikiquote",
+    "d": "min.wikiquote.org",
+    "t": "minwikiquote",
+    "ts": [
+      "minwq",
+      "wqmin"
+    ],
+    "u": "https://min.wikiquote.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Kyrgyz Wikiquote",
+    "d": "ky.wikiquote.org",
+    "t": "kywikiquote",
+    "ts": [
+      "kywq",
+      "wqky"
+    ],
+    "u": "https://ky.wikiquote.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Reference"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -86272,7 +86272,7 @@
       "dewv",
       "wvde"
     ],
-    "u": "de.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://de.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86284,7 +86284,7 @@
       "enwv",
       "wven"
     ],
-    "u": "en.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://en.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86296,7 +86296,7 @@
       "frwv",
       "wvfr"
     ],
-    "u": "fr.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://fr.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86308,7 +86308,7 @@
       "zhwv",
       "wvzh"
     ],
-    "u": "zh.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://zh.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86320,7 +86320,7 @@
       "itwv",
       "wvit"
     ],
-    "u": "it.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://it.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86332,7 +86332,7 @@
       "ptwv",
       "wvpt"
     ],
-    "u": "pt.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://pt.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86344,7 +86344,7 @@
       "cswv",
       "wvcs"
     ],
-    "u": "cs.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://cs.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86356,7 +86356,7 @@
       "ruwv",
       "wvru"
     ],
-    "u": "ru.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://ru.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86368,7 +86368,7 @@
       "eswv",
       "wves"
     ],
-    "u": "es.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://es.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86380,7 +86380,7 @@
       "betawv",
       "wvbeta"
     ],
-    "u": "beta.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://beta.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86392,7 +86392,7 @@
       "slwv",
       "wvsl"
     ],
-    "u": "sl.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://sl.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86404,7 +86404,7 @@
       "arwv",
       "wvar"
     ],
-    "u": "ar.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://ar.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86416,7 +86416,7 @@
       "svwv",
       "wvsv"
     ],
-    "u": "sv.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://sv.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86428,7 +86428,7 @@
       "fiwv",
       "wvfi"
     ],
-    "u": "fi.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://fi.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86440,7 +86440,7 @@
       "elwv",
       "wvel"
     ],
-    "u": "el.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://el.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86452,7 +86452,7 @@
       "hiwv",
       "wvhi"
     ],
-    "u": "hi.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://hi.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86464,7 +86464,7 @@
       "kowv",
       "wvko"
     ],
-    "u": "ko.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://ko.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },
@@ -86476,7 +86476,7 @@
       "jawv",
       "wvja"
     ],
-    "u": "ja.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "https://ja.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -42400,14 +42400,6 @@
     "sc": "Reference"
   },
   {
-    "s": "Japanese Wikiversity",
-    "d": "ja.wikiversity.org",
-    "t": "jawv",
-    "u": "https://ja.wikiversity.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
     "s": "JAX Docs",
     "d": "jax.readthedocs.io",
     "t": "jax",
@@ -86273,15 +86265,220 @@
     "sc": "Games (specific)"
   },
   {
-    "s": "Wikiversity",
-    "d": "en.wikiversity.org",
-    "t": "wikiversity",
+    "s": "German Wikiversity",
+    "d": "de.wikiversity.org",
+    "t": "dewikiversity",
     "ts": [
-      "wvers"
+      "dewv",
+      "wvde"
     ],
-    "u": "https://en.wikiversity.org/w/index.php?search={{{s}}}",
+    "u": "de.wikiversity.org/w/index.php?search={{{s}}}",
     "c": "Research",
-    "sc": "Academic"
+    "sc": "Learning"
+  },
+  {
+    "s": "English Wikiversity",
+    "d": "en.wikiversity.org",
+    "t": "enwikiversity",
+    "ts": [
+      "enwv",
+      "wven"
+    ],
+    "u": "en.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "French Wikiversity",
+    "d": "fr.wikiversity.org",
+    "t": "frwikiversity",
+    "ts": [
+      "frwv",
+      "wvfr"
+    ],
+    "u": "fr.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Chinese Wikiversity",
+    "d": "zh.wikiversity.org",
+    "t": "zhwikiversity",
+    "ts": [
+      "zhwv",
+      "wvzh"
+    ],
+    "u": "zh.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Italian Wikiversity",
+    "d": "it.wikiversity.org",
+    "t": "itwikiversity",
+    "ts": [
+      "itwv",
+      "wvit"
+    ],
+    "u": "it.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Portuguese Wikiversity",
+    "d": "pt.wikiversity.org",
+    "t": "ptwikiversity",
+    "ts": [
+      "ptwv",
+      "wvpt"
+    ],
+    "u": "pt.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Czech Wikiversity",
+    "d": "cs.wikiversity.org",
+    "t": "cswikiversity",
+    "ts": [
+      "cswv",
+      "wvcs"
+    ],
+    "u": "cs.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Russian Wikiversity",
+    "d": "ru.wikiversity.org",
+    "t": "ruwikiversity",
+    "ts": [
+      "ruwv",
+      "wvru"
+    ],
+    "u": "ru.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Spanish Wikiversity",
+    "d": "es.wikiversity.org",
+    "t": "eswikiversity",
+    "ts": [
+      "eswv",
+      "wves"
+    ],
+    "u": "es.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Beta Wikiversity",
+    "d": "beta.wikiversity.org",
+    "t": "betawikiversity",
+    "ts": [
+      "betawv",
+      "wvbeta"
+    ],
+    "u": "beta.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Slovenian Wikiversity",
+    "d": "sl.wikiversity.org",
+    "t": "slwikiversity",
+    "ts": [
+      "slwv",
+      "wvsl"
+    ],
+    "u": "sl.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Arabic Wikiversity",
+    "d": "ar.wikiversity.org",
+    "t": "arwikiversity",
+    "ts": [
+      "arwv",
+      "wvar"
+    ],
+    "u": "ar.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Swedish Wikiversity",
+    "d": "sv.wikiversity.org",
+    "t": "svwikiversity",
+    "ts": [
+      "svwv",
+      "wvsv"
+    ],
+    "u": "sv.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Finnish Wikiversity",
+    "d": "fi.wikiversity.org",
+    "t": "fiwikiversity",
+    "ts": [
+      "fiwv",
+      "wvfi"
+    ],
+    "u": "fi.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Greek Wikiversity",
+    "d": "el.wikiversity.org",
+    "t": "elwikiversity",
+    "ts": [
+      "elwv",
+      "wvel"
+    ],
+    "u": "el.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Hindi Wikiversity",
+    "d": "hi.wikiversity.org",
+    "t": "hiwikiversity",
+    "ts": [
+      "hiwv",
+      "wvhi"
+    ],
+    "u": "hi.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Korean Wikiversity",
+    "d": "ko.wikiversity.org",
+    "t": "kowikiversity",
+    "ts": [
+      "kowv",
+      "wvko"
+    ],
+    "u": "ko.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Japanese Wikiversity",
+    "d": "ja.wikiversity.org",
+    "t": "jawikiversity",
+    "ts": [
+      "jawv",
+      "wvja"
+    ],
+    "u": "ja.wikiversity.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
   },
   {
     "s": "Wikivoyage (Deutsch)",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -45849,10 +45849,10 @@
     "sc": "Online"
   },
   {
-    "s": "LaTeX - Wikibooks",
+    "s": "English Wikibooks LaTeX",
     "d": "en.wikibooks.org",
-    "t": "latexwb",
-    "u": "https://en.wikibooks.org/wiki/Search?search={{{s}}}&prefix=LaTeX",
+    "t": "enwblatex",
+    "u": "https://en.wikibooks.org/w/index.php?search={{{s}}}&prefix=LaTeX",
     "c": "Tech",
     "sc": "Languages (latex)"
   },
@@ -85998,10 +85998,10 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "Wiki Cookbook",
+    "s": "English Wikibooks Cookbook",
     "d": "en.wikibooks.org",
-    "t": "wikicook",
-    "u": "https://en.wikibooks.org/wiki/Special:Search?search={{{s}}}&prefix=Cookbook:&fulltext=Search+Cookbook&fulltext=Search",
+    "t": "enwbcook",
+    "u": "https://en.wikibooks.org/w/index.php?search={{{s}}}&prefix=Cookbook:",
     "c": "Research",
     "sc": "Food"
   },
@@ -86670,8 +86670,7 @@
     "d": "ur.wikibooks.org",
     "t": "urwikibooks",
     "ts": [
-      "urwb",
-      "wbur"
+      "urwb"
     ],
     "u": "https://ur.wikibooks.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -94477,8 +94476,7 @@
       "barwp",
       "barw",
       "wikibar",
-      "wpbar",
-      "wbar"
+      "wpbar"
     ],
     "u": "https://bar.wikipedia.org/w/index.php?search={{{s}}}",
     "c": "Research",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -54291,14 +54291,6 @@
     "sc": "Audio"
   },
   {
-    "s": "Wikimedia Meta",
-    "d": "meta.wikimedia.org",
-    "t": "mwm",
-    "u": "https://meta.wikimedia.org/w/index.php?&title=Special:Search&go=Go&search={{{s}}}",
-    "c": "Multimedia",
-    "sc": "General"
-  },
-  {
     "s": "Thesaurus by Merriam-Webster",
     "d": "www.merriam-webster.com",
     "t": "mwt",
@@ -85050,9 +85042,9 @@
   {
     "s": "Wikidata",
     "d": "www.wikidata.org",
-    "t": "wd",
+    "t": "wikidata",
     "ts": [
-      "wikidata",
+      "wd",
       "wdt"
     ],
     "u": "https://www.wikidata.org/w/index.php?search={{{s}}}",
@@ -86181,6 +86173,17 @@
     "sc": "Blogs"
   },
   {
+    "s": "Wikifunctions",
+    "d": "www.wikifunctions.org",
+    "t": "wikifunctions",
+    "ts": [
+      "wf"
+    ],
+    "u": "https://www.wikifunctions.org/w/index.php?search={{{s}}}",
+    "c": "Tech",
+    "sc": "Tools"
+  },
+  {
     "s": "Wikiquote",
     "d": "en.wikiquote.org",
     "t": "wikiquote",
@@ -86897,11 +86900,11 @@
   {
     "s": "Wikispecies",
     "d": "species.wikimedia.org",
-    "t": "wksp",
+    "t": "wikispecies",
     "ts": [
       "wks",
       "wspec",
-      "wikispecies"
+      "wksp"
     ],
     "u": "https://species.wikimedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
@@ -86969,8 +86972,12 @@
   {
     "s": "Wikimedia Meta-Wiki",
     "d": "meta.wikimedia.org",
-    "t": "wmeta",
-    "u": "https://meta.wikimedia.org/w/index.php?title=Special:Search&search={{{s}}}",
+    "t": "metawikimedia",
+    "ts": [
+      "wmeta",
+      "mwm"
+    ],
+    "u": "https://meta.wikimedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Academic"
   },
@@ -86999,7 +87006,7 @@
     "sc": "Reference (science)"
   },
   {
-    "s": "Wikimedia Phabricator installation",
+    "s": "Wikimedia Phabricator",
     "d": "phabricator.wikimedia.org",
     "t": "wmphab",
     "u": "https://phabricator.wikimedia.org/search/?query={{{s}}}",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -42368,14 +42368,6 @@
     "sc": "Companies"
   },
   {
-    "s": "Japanese Wikisource",
-    "d": "ja.wikisource.org",
-    "t": "jaws",
-    "u": "https://ja.wikisource.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
     "s": "Japanese Wiktionary",
     "d": "ja.wiktionary.org",
     "t": "jawt",
@@ -87064,17 +87056,6 @@
     "sc": "Search"
   },
   {
-    "s": "Wikisource",
-    "d": "en.wikisource.org",
-    "t": "wikisource",
-    "ts": [
-      "ws"
-    ],
-    "u": "https://en.wikisource.org/w/index.php?search={{{s}}}&title=Special:Search&go=Go",
-    "c": "Research",
-    "sc": "Academic"
-  },
-  {
     "s": "wiki.splunk.com",
     "d": "wiki.splunk.com",
     "t": "wiki.splunk",
@@ -90144,28 +90125,12 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "Wikisource Deutsch",
-    "d": "de.wikisource.org",
-    "t": "wsde",
-    "u": "https://de.wikisource.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
     "s": "Wesley Theological Seminary",
     "d": "www.wesleyseminary.edu",
     "t": "wsem",
     "u": "https://www.wesleyseminary.edu/?s={{{s}}}",
     "c": "Research",
     "sc": "Academic"
-  },
-  {
-    "s": "Wikisource (FR)",
-    "d": "fr.wikisource.org",
-    "t": "wsfr",
-    "u": "https://fr.wikisource.org/w/index.php?search={{{s}}}&title=Spécial:Recherche&go=Lire",
-    "c": "Research",
-    "sc": "Reference"
   },
   {
     "s": "Widescreen Gaming Forum",
@@ -90230,14 +90195,6 @@
     "u": "https://www.wsws.org/en/search.html?sectionId=&maxResults=100&phrase={{{s}}}&submit=Search",
     "c": "News",
     "sc": "International"
-  },
-  {
-    "s": "Wikisource (ZH)",
-    "d": "zh.wikisource.org",
-    "t": "wszh",
-    "u": "https://zh.wikisource.org/wiki/Special:Search?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
   },
   {
     "s": "WTA Tennis",
@@ -92621,12 +92578,1010 @@
     "sc": "Tech"
   },
   {
-    "s": "Israeli Open Law project at Hebrew Wikisource",
+    "s": "Hebrew Wikisource Israeli Law",
     "d": "he.wikisource.org",
     "t": "חוק",
     "u": "https://he.wikisource.org/w/index.php?search=חוק+{{{s}}}",
     "c": "Research",
     "sc": "Law"
+  },
+  {
+    "s": "Chinese Wikisource",
+    "d": "zh.wikisource.org",
+    "t": "zhwikisource",
+    "ts": [
+      "zhws",
+      "wszh"
+    ],
+    "u": "https://zh.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Polish Wikisource",
+    "d": "pl.wikisource.org",
+    "t": "plwikisource",
+    "ts": [
+      "plws",
+      "wspl"
+    ],
+    "u": "https://pl.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "English Wikisource",
+    "d": "en.wikisource.org",
+    "t": "enwikisource",
+    "ts": [
+      "enws",
+      "wsen"
+    ],
+    "u": "https://en.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "French Wikisource",
+    "d": "fr.wikisource.org",
+    "t": "frwikisource",
+    "ts": [
+      "frws",
+      "wsfr"
+    ],
+    "u": "https://fr.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "German Wikisource",
+    "d": "de.wikisource.org",
+    "t": "dewikisource",
+    "ts": [
+      "dews",
+      "wsde"
+    ],
+    "u": "https://de.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Russian Wikisource",
+    "d": "ru.wikisource.org",
+    "t": "ruwikisource",
+    "ts": [
+      "ruws",
+      "wsru"
+    ],
+    "u": "https://ru.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Ukrainian Wikisource",
+    "d": "uk.wikisource.org",
+    "t": "ukwikisource",
+    "ts": [
+      "ukws",
+      "wsuk"
+    ],
+    "u": "https://uk.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Hebrew Wikisource",
+    "d": "he.wikisource.org",
+    "t": "hewikisource",
+    "ts": [
+      "hews",
+      "wshe"
+    ],
+    "u": "https://he.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Italian Wikisource",
+    "d": "it.wikisource.org",
+    "t": "itwikisource",
+    "ts": [
+      "itws",
+      "wsit"
+    ],
+    "u": "https://it.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Arabic Wikisource",
+    "d": "ar.wikisource.org",
+    "t": "arwikisource",
+    "ts": [
+      "arws",
+      "wsar"
+    ],
+    "u": "https://ar.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Spanish Wikisource",
+    "d": "es.wikisource.org",
+    "t": "eswikisource",
+    "ts": [
+      "esws",
+      "wses"
+    ],
+    "u": "https://es.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Gujarati Wikisource",
+    "d": "gu.wikisource.org",
+    "t": "guwikisource",
+    "ts": [
+      "guws",
+      "wsgu"
+    ],
+    "u": "https://gu.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Multilingual Wikisource",
+    "d": "www.wikisource.org",
+    "t": "wikisource",
+    "ts": [
+      "ws",
+      "wwwwikisource",
+      "wwwws",
+      "wswww"
+    ],
+    "u": "https://www.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Czech Wikisource",
+    "d": "cs.wikisource.org",
+    "t": "cswikisource",
+    "ts": [
+      "csws",
+      "wscs"
+    ],
+    "u": "https://cs.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Serbian Wikisource",
+    "d": "sr.wikisource.org",
+    "t": "srwikisource",
+    "ts": [
+      "srws",
+      "wssr"
+    ],
+    "u": "https://sr.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Portuguese Wikisource",
+    "d": "pt.wikisource.org",
+    "t": "ptwikisource",
+    "ts": [
+      "ptws",
+      "wspt"
+    ],
+    "u": "https://pt.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Bangla Wikisource",
+    "d": "bn.wikisource.org",
+    "t": "bnwikisource",
+    "ts": [
+      "bnws",
+      "wsbn"
+    ],
+    "u": "https://bn.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Tamil Wikisource",
+    "d": "ta.wikisource.org",
+    "t": "tawikisource",
+    "ts": [
+      "taws",
+      "wsta"
+    ],
+    "u": "https://ta.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Armenian Wikisource",
+    "d": "hy.wikisource.org",
+    "t": "hywikisource",
+    "ts": [
+      "hyws",
+      "wshy"
+    ],
+    "u": "https://hy.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Swedish Wikisource",
+    "d": "sv.wikisource.org",
+    "t": "svwikisource",
+    "ts": [
+      "svws",
+      "wssv"
+    ],
+    "u": "https://sv.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Persian Wikisource",
+    "d": "fa.wikisource.org",
+    "t": "fawikisource",
+    "ts": [
+      "faws",
+      "wsfa"
+    ],
+    "u": "https://fa.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Belarusian Wikisource",
+    "d": "be.wikisource.org",
+    "t": "bewikisource",
+    "ts": [
+      "bews",
+      "wsbe"
+    ],
+    "u": "https://be.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Korean Wikisource",
+    "d": "ko.wikisource.org",
+    "t": "kowikisource",
+    "ts": [
+      "kows",
+      "wsko"
+    ],
+    "u": "https://ko.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Telugu Wikisource",
+    "d": "te.wikisource.org",
+    "t": "tewikisource",
+    "ts": [
+      "tews",
+      "wste"
+    ],
+    "u": "https://te.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Hungarian Wikisource",
+    "d": "hu.wikisource.org",
+    "t": "huwikisource",
+    "ts": [
+      "huws",
+      "wshu"
+    ],
+    "u": "https://hu.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Dutch Wikisource",
+    "d": "nl.wikisource.org",
+    "t": "nlwikisource",
+    "ts": [
+      "nlws",
+      "wsnl"
+    ],
+    "u": "https://nl.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Latin Wikisource",
+    "d": "la.wikisource.org",
+    "t": "lawikisource",
+    "ts": [
+      "laws",
+      "wsla"
+    ],
+    "u": "https://la.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Malayalam Wikisource",
+    "d": "ml.wikisource.org",
+    "t": "mlwikisource",
+    "ts": [
+      "mlws",
+      "wsml"
+    ],
+    "u": "https://ml.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Sanskrit Wikisource",
+    "d": "sa.wikisource.org",
+    "t": "sawikisource",
+    "ts": [
+      "saws",
+      "wssa"
+    ],
+    "u": "https://sa.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Turkish Wikisource",
+    "d": "tr.wikisource.org",
+    "t": "trwikisource",
+    "ts": [
+      "trws",
+      "wstr"
+    ],
+    "u": "https://tr.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Vietnamese Wikisource",
+    "d": "vi.wikisource.org",
+    "t": "viwikisource",
+    "ts": [
+      "viws",
+      "wsvi"
+    ],
+    "u": "https://vi.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Japanese Wikisource",
+    "d": "ja.wikisource.org",
+    "t": "jawikisource",
+    "ts": [
+      "jaws",
+      "wsja"
+    ],
+    "u": "https://ja.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Slovenian Wikisource",
+    "d": "sl.wikisource.org",
+    "t": "slwikisource",
+    "ts": [
+      "slws",
+      "wssl"
+    ],
+    "u": "https://sl.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Welsh Wikisource",
+    "d": "cy.wikisource.org",
+    "t": "cywikisource",
+    "ts": [
+      "cyws",
+      "wscy"
+    ],
+    "u": "https://cy.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Romanian Wikisource",
+    "d": "ro.wikisource.org",
+    "t": "rowikisource",
+    "ts": [
+      "rows",
+      "wsro"
+    ],
+    "u": "https://ro.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Norwegian Wikisource",
+    "d": "no.wikisource.org",
+    "t": "nowikisource",
+    "ts": [
+      "nows",
+      "wsno"
+    ],
+    "u": "https://no.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Finnish Wikisource",
+    "d": "fi.wikisource.org",
+    "t": "fiwikisource",
+    "ts": [
+      "fiws",
+      "wsfi"
+    ],
+    "u": "https://fi.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Esperanto Wikisource",
+    "d": "eo.wikisource.org",
+    "t": "eowikisource",
+    "ts": [
+      "eows",
+      "wseo"
+    ],
+    "u": "https://eo.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Indonesian Wikisource",
+    "d": "id.wikisource.org",
+    "t": "idwikisource",
+    "ts": [
+      "idws",
+      "wsid"
+    ],
+    "u": "https://id.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Neapolitan Wikisource",
+    "d": "nap.wikisource.org",
+    "t": "napwikisource",
+    "ts": [
+      "napws",
+      "wsnap"
+    ],
+    "u": "https://nap.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Greek Wikisource",
+    "d": "el.wikisource.org",
+    "t": "elwikisource",
+    "ts": [
+      "elws",
+      "wsel"
+    ],
+    "u": "https://el.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Urdu Wikisource",
+    "d": "ur.wikisource.org",
+    "t": "urwikisource",
+    "ts": [
+      "urws",
+      "wsur"
+    ],
+    "u": "https://ur.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Azerbaijani Wikisource",
+    "d": "az.wikisource.org",
+    "t": "azwikisource",
+    "ts": [
+      "azws",
+      "wsaz"
+    ],
+    "u": "https://az.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Breton Wikisource",
+    "d": "br.wikisource.org",
+    "t": "brwikisource",
+    "ts": [
+      "brws",
+      "wsbr"
+    ],
+    "u": "https://br.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Catalan Wikisource",
+    "d": "ca.wikisource.org",
+    "t": "cawikisource",
+    "ts": [
+      "caws",
+      "wsca"
+    ],
+    "u": "https://ca.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Thai Wikisource",
+    "d": "th.wikisource.org",
+    "t": "thwikisource",
+    "ts": [
+      "thws",
+      "wsth"
+    ],
+    "u": "https://th.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Croatian Wikisource",
+    "d": "hr.wikisource.org",
+    "t": "hrwikisource",
+    "ts": [
+      "hrws",
+      "wshr"
+    ],
+    "u": "https://hr.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Georgian Wikisource",
+    "d": "ka.wikisource.org",
+    "t": "kawikisource",
+    "ts": [
+      "kaws",
+      "wska"
+    ],
+    "u": "https://ka.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Hindi Wikisource",
+    "d": "hi.wikisource.org",
+    "t": "hiwikisource",
+    "ts": [
+      "hiws",
+      "wshi"
+    ],
+    "u": "https://hi.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Venetian Wikisource",
+    "d": "vec.wikisource.org",
+    "t": "vecwikisource",
+    "ts": [
+      "vecws",
+      "wsvec"
+    ],
+    "u": "https://vec.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Marathi Wikisource",
+    "d": "mr.wikisource.org",
+    "t": "mrwikisource",
+    "ts": [
+      "mrws",
+      "wsmr"
+    ],
+    "u": "https://mr.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Balinese Wikisource",
+    "d": "ban.wikisource.org",
+    "t": "banwikisource",
+    "ts": [
+      "banws",
+      "wsban"
+    ],
+    "u": "https://ban.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Burmese Wikisource",
+    "d": "my.wikisource.org",
+    "t": "mywikisource",
+    "ts": [
+      "myws",
+      "wsmy"
+    ],
+    "u": "https://my.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Icelandic Wikisource",
+    "d": "is.wikisource.org",
+    "t": "iswikisource",
+    "ts": [
+      "isws",
+      "wsis"
+    ],
+    "u": "https://is.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Piedmontese Wikisource",
+    "d": "pms.wikisource.org",
+    "t": "pmswikisource",
+    "ts": [
+      "pmsws",
+      "wspms"
+    ],
+    "u": "https://pms.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Ligurian Wikisource",
+    "d": "lij.wikisource.org",
+    "t": "lijwikisource",
+    "ts": [
+      "lijws",
+      "wslij"
+    ],
+    "u": "https://lij.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Assamese Wikisource",
+    "d": "as.wikisource.org",
+    "t": "aswikisource",
+    "ts": [
+      "asws",
+      "wsas"
+    ],
+    "u": "https://as.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Danish Wikisource",
+    "d": "da.wikisource.org",
+    "t": "dawikisource",
+    "ts": [
+      "daws",
+      "wsda"
+    ],
+    "u": "https://da.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Macedonian Wikisource",
+    "d": "mk.wikisource.org",
+    "t": "mkwikisource",
+    "ts": [
+      "mkws",
+      "wsmk"
+    ],
+    "u": "https://mk.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Estonian Wikisource",
+    "d": "et.wikisource.org",
+    "t": "etwikisource",
+    "ts": [
+      "etws",
+      "wset"
+    ],
+    "u": "https://et.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Javanese Wikisource",
+    "d": "jv.wikisource.org",
+    "t": "jvwikisource",
+    "ts": [
+      "jvws",
+      "wsjv"
+    ],
+    "u": "https://jv.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Yiddish Wikisource",
+    "d": "yi.wikisource.org",
+    "t": "yiwikisource",
+    "ts": [
+      "yiws",
+      "wsyi"
+    ],
+    "u": "https://yi.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Walloon Wikisource",
+    "d": "wa.wikisource.org",
+    "t": "wawikisource",
+    "ts": [
+      "waws",
+      "wswa"
+    ],
+    "u": "https://wa.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Punjabi Wikisource",
+    "d": "pa.wikisource.org",
+    "t": "pawikisource",
+    "ts": [
+      "paws",
+      "wspa"
+    ],
+    "u": "https://pa.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Bulgarian Wikisource",
+    "d": "bg.wikisource.org",
+    "t": "bgwikisource",
+    "ts": [
+      "bgws",
+      "wsbg"
+    ],
+    "u": "https://bg.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Limburgish Wikisource",
+    "d": "li.wikisource.org",
+    "t": "liwikisource",
+    "ts": [
+      "liws",
+      "wsli"
+    ],
+    "u": "https://li.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Lithuanian Wikisource",
+    "d": "lt.wikisource.org",
+    "t": "ltwikisource",
+    "ts": [
+      "ltws",
+      "wslt"
+    ],
+    "u": "https://lt.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Kannada Wikisource",
+    "d": "kn.wikisource.org",
+    "t": "knwikisource",
+    "ts": [
+      "knws",
+      "wskn"
+    ],
+    "u": "https://kn.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Basque Wikisource",
+    "d": "eu.wikisource.org",
+    "t": "euwikisource",
+    "ts": [
+      "euws",
+      "wseu"
+    ],
+    "u": "https://eu.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Odia Wikisource",
+    "d": "or.wikisource.org",
+    "t": "orwikisource",
+    "ts": [
+      "orws",
+      "wsor"
+    ],
+    "u": "https://or.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Malay Wikisource",
+    "d": "ms.wikisource.org",
+    "t": "mswikisource",
+    "ts": [
+      "msws",
+      "wsms"
+    ],
+    "u": "https://ms.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Yakut Wikisource",
+    "d": "sah.wikisource.org",
+    "t": "sahwikisource",
+    "ts": [
+      "sahws",
+      "wssah"
+    ],
+    "u": "https://sah.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Galician Wikisource",
+    "d": "gl.wikisource.org",
+    "t": "glwikisource",
+    "ts": [
+      "glws",
+      "wsgl"
+    ],
+    "u": "https://gl.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Bosnian Wikisource",
+    "d": "bs.wikisource.org",
+    "t": "bswikisource",
+    "ts": [
+      "bsws",
+      "wsbs"
+    ],
+    "u": "https://bs.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Slovak Wikisource",
+    "d": "sk.wikisource.org",
+    "t": "skwikisource",
+    "ts": [
+      "skws",
+      "wssk"
+    ],
+    "u": "https://sk.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Minangkabau Wikisource",
+    "d": "min.wikisource.org",
+    "t": "minwikisource",
+    "ts": [
+      "minws",
+      "wsmin"
+    ],
+    "u": "https://min.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Sundanese Wikisource",
+    "d": "su.wikisource.org",
+    "t": "suwikisource",
+    "ts": [
+      "suws",
+      "wssu"
+    ],
+    "u": "https://su.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Tagalog Wikisource",
+    "d": "tl.wikisource.org",
+    "t": "tlwikisource",
+    "ts": [
+      "tlws",
+      "wstl"
+    ],
+    "u": "https://tl.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Madurese Wikisource",
+    "d": "mad.wikisource.org",
+    "t": "madwikisource",
+    "ts": [
+      "madws",
+      "wsmad"
+    ],
+    "u": "https://mad.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Minnan Wikisource",
+    "d": "zh-min-nan.wikisource.org",
+    "t": "zh-min-nanwikisource",
+    "ts": [
+      "zh-min-nanws",
+      "wszh-min-nan"
+    ],
+    "u": "https://zh-min-nan.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Central Bikol Wikisource",
+    "d": "bcl.wikisource.org",
+    "t": "bclwikisource",
+    "ts": [
+      "bclws",
+      "wsbcl"
+    ],
+    "u": "https://bcl.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Tulu Wikisource",
+    "d": "tcy.wikisource.org",
+    "t": "tcywikisource",
+    "ts": [
+      "tcyws",
+      "wstcy"
+    ],
+    "u": "https://tcy.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
+  },
+  {
+    "s": "Faroese Wikisource",
+    "d": "fo.wikisource.org",
+    "t": "fowikisource",
+    "ts": [
+      "fows",
+      "wsfo"
+    ],
+    "u": "https://fo.wikisource.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference"
   },
   {
     "s": "Вики-учебник Английского Языка",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -29684,23 +29684,6 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Wiktionary Français",
-    "d": "fr.wiktionary.org",
-    "t": "fr.wiktionary",
-    "ts": [
-      "wifr",
-      "wiktfr",
-      "wtfr"
-    ],
-    "u": "https://fr.wiktionary.org/wiki/{{{s}}}",
-    "c": "Online Services",
-    "sc": "Tools",
-    "fmt": [
-      "open_base_path",
-      "url_encode_placeholder"
-    ]
-  },
-  {
     "s": "Food Standards Agency - Food Hygiene Ratings",
     "d": "ratings.food.gov.uk",
     "t": "fsarating",
@@ -42366,14 +42349,6 @@
     "u": "https://developer.mozilla.org/search?q={{{s}}}",
     "c": "Tech",
     "sc": "Companies"
-  },
-  {
-    "s": "Japanese Wiktionary",
-    "d": "ja.wiktionary.org",
-    "t": "jawt",
-    "u": "https://ja.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
   },
   {
     "s": "JAX Docs",
@@ -87672,165 +87647,12 @@
     ]
   },
   {
-    "s": "wikizionario",
-    "d": "it.wiktionary.org",
-    "t": "wikizionario",
-    "u": "https://it.wiktionary.org/wiki/{{{s}}}",
-    "c": "Online Services",
-    "sc": "Tools"
-  },
-  {
-    "s": "Викисловарь",
-    "d": "ru.wiktionary.org",
-    "t": "wikru",
-    "ts": [
-      "wiktru",
-      "вс"
-    ],
-    "u": "https://ru.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
-    "s": "Wikeriadur",
-    "d": "br.wiktionary.org",
-    "t": "wiktbr",
-    "u": "https://br.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
-    "s": "Wiktionary, das freie Wörterbuch",
-    "d": "de.wiktionary.org",
-    "t": "wiktde",
-    "u": "https://de.wiktionary.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
-    "s": "Wiktionary Search",
-    "d": "en.wiktionary.org",
-    "t": "wikten",
-    "ts": [
-      "wiktionary",
-      "wikt",
-      "wten",
-      "wtla"
-    ],
-    "u": "https://en.wiktionary.org/wiki/Special:Search?search={{{s}}}&go=Define",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
-    "s": "Vikivortaro",
-    "d": "eo.wiktionary.org",
-    "t": "wikteo",
-    "ts": [
-      "wteo"
-    ],
-    "u": "https://eo.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
-    "s": "Wikcionario",
-    "d": "es.wiktionary.org",
-    "t": "wiktes",
-    "ts": [
-      "wtes"
-    ],
-    "u": "https://es.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
-    "s": "Wiktionary (hu)",
-    "d": "hu.wiktionary.org",
-    "t": "wikthu",
-    "u": "https://hu.wiktionary.org/w/index.php?search={{{s}}}&title=Speciális:Keresés",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
-    "s": "Wikizionario",
-    "d": "it.wiktionary.org",
-    "t": "wiktit",
-    "ts": [
-      "wtit"
-    ],
-    "u": "https://it.wiktionary.org/w/index.php?search={{{s}}}&title=Speciale:Ricerca",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
-    "s": "Wiktionary (Japan)",
-    "d": "ja.wiktionary.org",
-    "t": "wiktja",
-    "ts": [
-      "wtja"
-    ],
-    "u": "https://ja.wiktionary.org/wiki/{{{s}}}",
-    "c": "Online Services",
-    "sc": "Search"
-  },
-  {
-    "s": "위키낱말사전",
-    "d": "ko.wiktionary.org",
-    "t": "wiktko",
-    "u": "https://ko.wiktionary.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
-    "s": "Latin Wiktionary",
-    "d": "la.wiktionary.org",
-    "t": "wiktla",
-    "u": "https://la.wiktionary.org/wiki/Special:Search?search={{{s}}}&go=Define",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
     "s": "Dutch News",
     "d": "www.dutchnews.nl",
     "t": "dutchnews",
     "u": "https://www.dutchnews.nl/?s={{{s}}}&post_type=post",
     "c": "News",
     "sc": "Online"
-  },
-  {
-    "s": "Dutch Wiktionary",
-    "d": "nl.wiktionary.org",
-    "t": "wiktnl",
-    "u": "https://nl.wiktionary.org/w/index.php?search={{{s}}}&title=Speciaal:Zoeken",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
-    "s": "Norwegian Wiktionary (book language)",
-    "d": "no.wiktionary.org",
-    "t": "wiktno",
-    "u": "https://no.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
-    "s": "Wikcionário (PT)",
-    "d": "pt.wiktionary.org",
-    "t": "wiktpt",
-    "ts": [
-      "wtpt"
-    ],
-    "u": "https://pt.wiktionary.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
-    "s": "Swedish Wiktionary",
-    "d": "sv.wiktionary.org",
-    "t": "wiktsv",
-    "u": "https://sv.wiktionary.org/w/index.php?search={{{s}}}&title=Special:Sök",
-    "c": "Research",
-    "sc": "Reference (words intl)"
   },
   {
     "s": "Wiley Online Library",
@@ -88040,14 +87862,6 @@
     "sc": "Academic"
   },
   {
-    "s": "wiktionary pl",
-    "d": "pl.wiktionary.org",
-    "t": "witpl",
-    "u": "https://pl.wiktionary.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
     "s": "WJEC",
     "d": "www.wjec.co.uk",
     "t": "wjec",
@@ -88080,22 +87894,6 @@
     "sc": "Libraries/Frameworks"
   },
   {
-    "s": "Wiktionary (Italian)",
-    "d": "it.wiktionary.org",
-    "t": "wkit",
-    "u": "https://it.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Online Services",
-    "sc": "Tools (URLs)"
-  },
-  {
-    "s": "Lithuanian Wiktionary (Vikižodynas)",
-    "d": "lt.wiktionary.org",
-    "t": "wklt",
-    "u": "https://lt.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
     "s": "Wykop.pl",
     "d": "www.wykop.pl",
     "t": "wkp",
@@ -88119,17 +87917,6 @@
     "u": "https://species.wikimedia.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Learning"
-  },
-  {
-    "s": "Wiktionary German",
-    "d": "de.wiktionary.org",
-    "t": "wktde",
-    "ts": [
-      "wtde"
-    ],
-    "u": "https://de.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words intl)"
   },
   {
     "s": "TV Wunschliste",
@@ -90205,46 +89992,6 @@
     "sc": "Sports"
   },
   {
-    "s": "Уикиречник",
-    "d": "bg.wiktionary.org",
-    "t": "wtbg",
-    "u": "https://bg.wiktionary.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
-    "s": "Wiktkionary e brezhoneg",
-    "d": "br.wiktionary.org",
-    "t": "wtbr",
-    "u": "https://br.wiktionary.org/wiki/{{{s}}}",
-    "c": "Online Services",
-    "sc": "Search"
-  },
-  {
-    "s": "Wiktionary Catalan",
-    "d": "ca.wiktionary.org",
-    "t": "wtca",
-    "u": "https://ca.wiktionary.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Learning"
-  },
-  {
-    "s": "Wiktionary (Czech)",
-    "d": "cs.wiktionary.org",
-    "t": "wtcz",
-    "u": "https://cs.wiktionary.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
-    "s": "Wiktionary (Greek)",
-    "d": "el.wiktionary.org",
-    "t": "wtel",
-    "u": "https://el.wiktionary.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
     "s": "Stiftung Warentest",
     "d": "www.test.de",
     "t": "wtest",
@@ -90253,40 +90000,10 @@
     "sc": "Services"
   },
   {
-    "s": "Wiktionary (Finnish)",
-    "d": "fi.wiktionary.org",
-    "t": "wtfi",
-    "u": "https://fi.wiktionary.org/w/index.php?search={{{s}}}&title=Toiminnot:Haku",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
     "s": "MirBSD Acronyms Database",
     "d": "www.mirbsd.org",
     "t": "wtf",
     "u": "https://www.mirbsd.org/wtf.cgi?q={{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
-    "s": "Wiktionary (Hindi)",
-    "d": "hi.wiktionary.org",
-    "t": "hiwiktionary",
-    "u": "https://hi.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
-    "s": "Wiktionary",
-    "d": "en.wiktionary.org",
-    "t": "wtionary",
-    "ts": [
-      "wt",
-      "wdic",
-      "wictionary",
-      "wkten"
-    ],
-    "u": "https://en.wiktionary.org/w/index.php?search={{{s}}}&title=Special:Search&go=Go",
     "c": "Research",
     "sc": "Reference (words)"
   },
@@ -90299,68 +90016,12 @@
     "sc": "Audio"
   },
   {
-    "s": "WikiWoordenboek",
-    "d": "nl.wiktionary.org",
-    "t": "wtnl",
-    "u": "https://nl.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
-    "s": "Wiktionary (Norwegian)",
-    "d": "no.wiktionary.org",
-    "t": "wtno",
-    "u": "https://no.wiktionary.org/wiki/index.php?title=Special:Search&search={{{s}}}",
-    "c": "Research",
-    "sc": "Learning (intl)"
-  },
-  {
-    "s": "Wiktionary (PL)",
-    "d": "pl.wiktionary.org",
-    "t": "wtpl",
-    "u": "https://pl.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
-    "s": "Wiktionary (RO)",
-    "d": "ro.wiktionary.org",
-    "t": "wtro",
-    "u": "https://ro.wiktionary.org/wiki/{{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
-    "s": "ru.wiktionary.org",
-    "d": "ru.wiktionary.org",
-    "t": "wtru",
-    "u": "https://ru.wiktionary.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
     "s": "Westminster Bookstore",
     "d": "www.wtsbooks.com",
     "t": "wtsbooks",
     "u": "https://www.wtsbooks.com/index/page/search?FullText={{{s}}}",
     "c": "Shopping",
     "sc": "Online"
-  },
-  {
-    "s": "Wiktionary (SV)",
-    "d": "sv.wiktionary.org",
-    "t": "wtsv",
-    "u": "https://sv.wiktionary.org/w/index.php?search={{{s}}}&button=&title=Special:Sök",
-    "c": "Research",
-    "sc": "Reference (words intl)"
-  },
-  {
-    "s": "விக்சனரி (Wiktionary Tamil)",
-    "d": "ta.wiktionary.org",
-    "t": "wtta",
-    "u": "https://ta.wiktionary.org/wiki/Special:Search?search={{{s}}}&go=Go",
-    "c": "Research",
-    "sc": "Reference (words intl)"
   },
   {
     "s": "wttr.in",
@@ -90374,14 +90035,6 @@
     "sc": "Weather"
   },
   {
-    "s": "Wiktionary tiếng Việt",
-    "d": "vi.wiktionary.org",
-    "t": "wtvi",
-    "u": "https://vi.wiktionary.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference (words)"
-  },
-  {
     "s": "War Thunder Wiki",
     "d": "wiki.warthunder.com",
     "t": "wtw",
@@ -90390,10 +90043,2090 @@
     "sc": "Games (general)"
   },
   {
-    "s": "Wiktionary (Chinese)",
+    "s": "English Wiktionary",
+    "d": "en.wiktionary.org",
+    "t": "enwiktionary",
+    "ts": [
+      "enwikt",
+      "wikten"
+    ],
+    "u": "https://en.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "French Wiktionary",
+    "d": "fr.wiktionary.org",
+    "t": "frwiktionary",
+    "ts": [
+      "frwikt",
+      "wiktfr"
+    ],
+    "u": "https://fr.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Malagasy Wiktionary",
+    "d": "mg.wiktionary.org",
+    "t": "mgwiktionary",
+    "ts": [
+      "mgwikt",
+      "wiktmg"
+    ],
+    "u": "https://mg.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Chinese Wiktionary",
     "d": "zh.wiktionary.org",
-    "t": "wtzh",
+    "t": "zhwiktionary",
+    "ts": [
+      "zhwikt",
+      "wiktzh"
+    ],
     "u": "https://zh.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Thai Wiktionary",
+    "d": "th.wiktionary.org",
+    "t": "thwiktionary",
+    "ts": [
+      "thwikt",
+      "wiktth"
+    ],
+    "u": "https://th.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Greek Wiktionary",
+    "d": "el.wiktionary.org",
+    "t": "elwiktionary",
+    "ts": [
+      "elwikt",
+      "wiktel"
+    ],
+    "u": "https://el.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Russian Wiktionary",
+    "d": "ru.wiktionary.org",
+    "t": "ruwiktionary",
+    "ts": [
+      "ruwikt",
+      "wiktru"
+    ],
+    "u": "https://ru.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Turkish Wiktionary",
+    "d": "tr.wiktionary.org",
+    "t": "trwiktionary",
+    "ts": [
+      "trwikt",
+      "wikttr"
+    ],
+    "u": "https://tr.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "German Wiktionary",
+    "d": "de.wiktionary.org",
+    "t": "dewiktionary",
+    "ts": [
+      "dewikt",
+      "wiktde"
+    ],
+    "u": "https://de.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Dutch Wiktionary",
+    "d": "nl.wiktionary.org",
+    "t": "nlwiktionary",
+    "ts": [
+      "nlwikt",
+      "wiktnl"
+    ],
+    "u": "https://nl.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Kurdish Wiktionary",
+    "d": "ku.wiktionary.org",
+    "t": "kuwiktionary",
+    "ts": [
+      "kuwikt",
+      "wiktku"
+    ],
+    "u": "https://ku.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Swedish Wiktionary",
+    "d": "sv.wiktionary.org",
+    "t": "svwiktionary",
+    "ts": [
+      "svwikt",
+      "wiktsv"
+    ],
+    "u": "https://sv.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Spanish Wiktionary",
+    "d": "es.wiktionary.org",
+    "t": "eswiktionary",
+    "ts": [
+      "eswikt",
+      "wiktes"
+    ],
+    "u": "https://es.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Serbo-Croatian Wiktionary",
+    "d": "sh.wiktionary.org",
+    "t": "shwiktionary",
+    "ts": [
+      "shwikt",
+      "wiktsh"
+    ],
+    "u": "https://sh.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Polish Wiktionary",
+    "d": "pl.wiktionary.org",
+    "t": "plwiktionary",
+    "ts": [
+      "plwikt",
+      "wiktpl"
+    ],
+    "u": "https://pl.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Italian Wiktionary",
+    "d": "it.wiktionary.org",
+    "t": "itwiktionary",
+    "ts": [
+      "itwikt",
+      "wiktit"
+    ],
+    "u": "https://it.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Finnish Wiktionary",
+    "d": "fi.wiktionary.org",
+    "t": "fiwiktionary",
+    "ts": [
+      "fiwikt",
+      "wiktfi"
+    ],
+    "u": "https://fi.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Lithuanian Wiktionary",
+    "d": "lt.wiktionary.org",
+    "t": "ltwiktionary",
+    "ts": [
+      "ltwikt",
+      "wiktlt"
+    ],
+    "u": "https://lt.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Catalan Wiktionary",
+    "d": "ca.wiktionary.org",
+    "t": "cawiktionary",
+    "ts": [
+      "cawikt",
+      "wiktca"
+    ],
+    "u": "https://ca.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Hungarian Wiktionary",
+    "d": "hu.wiktionary.org",
+    "t": "huwiktionary",
+    "ts": [
+      "huwikt",
+      "wikthu"
+    ],
+    "u": "https://hu.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Portuguese Wiktionary",
+    "d": "pt.wiktionary.org",
+    "t": "ptwiktionary",
+    "ts": [
+      "ptwikt",
+      "wiktpt"
+    ],
+    "u": "https://pt.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Japanese Wiktionary",
+    "d": "ja.wiktionary.org",
+    "t": "jawiktionary",
+    "ts": [
+      "jawikt",
+      "wiktja"
+    ],
+    "u": "https://ja.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Tamil Wiktionary",
+    "d": "ta.wiktionary.org",
+    "t": "tawiktionary",
+    "ts": [
+      "tawikt",
+      "wiktta"
+    ],
+    "u": "https://ta.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Vietnamese Wiktionary",
+    "d": "vi.wiktionary.org",
+    "t": "viwiktionary",
+    "ts": [
+      "viwikt",
+      "wiktvi"
+    ],
+    "u": "https://vi.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Ido Wiktionary",
+    "d": "io.wiktionary.org",
+    "t": "iowiktionary",
+    "ts": [
+      "iowikt",
+      "wiktio"
+    ],
+    "u": "https://io.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Armenian Wiktionary",
+    "d": "hy.wiktionary.org",
+    "t": "hywiktionary",
+    "ts": [
+      "hywikt",
+      "wikthy"
+    ],
+    "u": "https://hy.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Korean Wiktionary",
+    "d": "ko.wiktionary.org",
+    "t": "kowiktionary",
+    "ts": [
+      "kowikt",
+      "wiktko"
+    ],
+    "u": "https://ko.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Kannada Wiktionary",
+    "d": "kn.wiktionary.org",
+    "t": "knwiktionary",
+    "ts": [
+      "knwikt",
+      "wiktkn"
+    ],
+    "u": "https://kn.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Indonesian Wiktionary",
+    "d": "id.wiktionary.org",
+    "t": "idwiktionary",
+    "ts": [
+      "idwikt",
+      "wiktid"
+    ],
+    "u": "https://id.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Serbian Wiktionary",
+    "d": "sr.wiktionary.org",
+    "t": "srwiktionary",
+    "ts": [
+      "srwikt",
+      "wiktsr"
+    ],
+    "u": "https://sr.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Esperanto Wiktionary",
+    "d": "eo.wiktionary.org",
+    "t": "eowiktionary",
+    "ts": [
+      "eowikt",
+      "wikteo"
+    ],
+    "u": "https://eo.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Mon Wiktionary",
+    "d": "mnw.wiktionary.org",
+    "t": "mnwwiktionary",
+    "ts": [
+      "mnwwikt",
+      "wiktmnw"
+    ],
+    "u": "https://mnw.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Hindi Wiktionary",
+    "d": "hi.wiktionary.org",
+    "t": "hiwiktionary",
+    "ts": [
+      "hiwikt",
+      "wikthi"
+    ],
+    "u": "https://hi.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Romanian Wiktionary",
+    "d": "ro.wiktionary.org",
+    "t": "rowiktionary",
+    "ts": [
+      "rowikt",
+      "wiktro"
+    ],
+    "u": "https://ro.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Estonian Wiktionary",
+    "d": "et.wiktionary.org",
+    "t": "etwiktionary",
+    "ts": [
+      "etwikt",
+      "wiktet"
+    ],
+    "u": "https://et.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Czech Wiktionary",
+    "d": "cs.wiktionary.org",
+    "t": "cswiktionary",
+    "ts": [
+      "cswikt",
+      "wiktcs"
+    ],
+    "u": "https://cs.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Norwegian Wiktionary",
+    "d": "no.wiktionary.org",
+    "t": "nowiktionary",
+    "ts": [
+      "nowikt",
+      "wiktno"
+    ],
+    "u": "https://no.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Saraiki Wiktionary",
+    "d": "skr.wiktionary.org",
+    "t": "skrwiktionary",
+    "ts": [
+      "skrwikt",
+      "wiktskr"
+    ],
+    "u": "https://skr.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Malayalam Wiktionary",
+    "d": "ml.wiktionary.org",
+    "t": "mlwiktionary",
+    "ts": [
+      "mlwikt",
+      "wiktml"
+    ],
+    "u": "https://ml.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Limburgish Wiktionary",
+    "d": "li.wiktionary.org",
+    "t": "liwiktionary",
+    "ts": [
+      "liwikt",
+      "wiktli"
+    ],
+    "u": "https://li.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Uzbek Wiktionary",
+    "d": "uz.wiktionary.org",
+    "t": "uzwiktionary",
+    "ts": [
+      "uzwikt",
+      "wiktuz"
+    ],
+    "u": "https://uz.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Persian Wiktionary",
+    "d": "fa.wiktionary.org",
+    "t": "fawiktionary",
+    "ts": [
+      "fawikt",
+      "wiktfa"
+    ],
+    "u": "https://fa.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Odia Wiktionary",
+    "d": "or.wiktionary.org",
+    "t": "orwiktionary",
+    "ts": [
+      "orwikt",
+      "wiktor"
+    ],
+    "u": "https://or.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Telugu Wiktionary",
+    "d": "te.wiktionary.org",
+    "t": "tewiktionary",
+    "ts": [
+      "tewikt",
+      "wiktte"
+    ],
+    "u": "https://te.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Bangla Wiktionary",
+    "d": "bn.wiktionary.org",
+    "t": "bnwiktionary",
+    "ts": [
+      "bnwikt",
+      "wiktbn"
+    ],
+    "u": "https://bn.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Icelandic Wiktionary",
+    "d": "is.wiktionary.org",
+    "t": "iswiktionary",
+    "ts": [
+      "iswikt",
+      "wiktis"
+    ],
+    "u": "https://is.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Burmese Wiktionary",
+    "d": "my.wiktionary.org",
+    "t": "mywiktionary",
+    "ts": [
+      "mywikt",
+      "wiktmy"
+    ],
+    "u": "https://my.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Swahili Wiktionary",
+    "d": "sw.wiktionary.org",
+    "t": "swwiktionary",
+    "ts": [
+      "swwikt",
+      "wiktsw"
+    ],
+    "u": "https://sw.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Galician Wiktionary",
+    "d": "gl.wiktionary.org",
+    "t": "glwiktionary",
+    "ts": [
+      "glwikt",
+      "wiktgl"
+    ],
+    "u": "https://gl.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Sango Wiktionary",
+    "d": "sg.wiktionary.org",
+    "t": "sgwiktionary",
+    "ts": [
+      "sgwikt",
+      "wiktsg"
+    ],
+    "u": "https://sg.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Javanese Wiktionary",
+    "d": "jv.wiktionary.org",
+    "t": "jvwiktionary",
+    "ts": [
+      "jvwikt",
+      "wiktjv"
+    ],
+    "u": "https://jv.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Asturian Wiktionary",
+    "d": "ast.wiktionary.org",
+    "t": "astwiktionary",
+    "ts": [
+      "astwikt",
+      "wiktast"
+    ],
+    "u": "https://ast.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Occitan Wiktionary",
+    "d": "oc.wiktionary.org",
+    "t": "ocwiktionary",
+    "ts": [
+      "ocwikt",
+      "wiktoc"
+    ],
+    "u": "https://oc.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Arabic Wiktionary",
+    "d": "ar.wiktionary.org",
+    "t": "arwiktionary",
+    "ts": [
+      "arwikt",
+      "wiktar"
+    ],
+    "u": "https://ar.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Ukrainian Wiktionary",
+    "d": "uk.wiktionary.org",
+    "t": "ukwiktionary",
+    "ts": [
+      "ukwikt",
+      "wiktuk"
+    ],
+    "u": "https://uk.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Azerbaijani Wiktionary",
+    "d": "az.wiktionary.org",
+    "t": "azwiktionary",
+    "ts": [
+      "azwikt",
+      "wiktaz"
+    ],
+    "u": "https://az.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Basque Wiktionary",
+    "d": "eu.wiktionary.org",
+    "t": "euwiktionary",
+    "ts": [
+      "euwikt",
+      "wikteu"
+    ],
+    "u": "https://eu.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Simple English Wiktionary",
+    "d": "simple.wiktionary.org",
+    "t": "simplewiktionary",
+    "ts": [
+      "simplewikt",
+      "wiktsimple"
+    ],
+    "u": "https://simple.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Breton Wiktionary",
+    "d": "br.wiktionary.org",
+    "t": "brwiktionary",
+    "ts": [
+      "brwikt",
+      "wiktbr"
+    ],
+    "u": "https://br.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Oromo Wiktionary",
+    "d": "om.wiktionary.org",
+    "t": "omwiktionary",
+    "ts": [
+      "omwikt",
+      "wiktom"
+    ],
+    "u": "https://om.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Shan Wiktionary",
+    "d": "shn.wiktionary.org",
+    "t": "shnwiktionary",
+    "ts": [
+      "shnwikt",
+      "wiktshn"
+    ],
+    "u": "https://shn.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Danish Wiktionary",
+    "d": "da.wiktionary.org",
+    "t": "dawiktionary",
+    "ts": [
+      "dawikt",
+      "wiktda"
+    ],
+    "u": "https://da.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Malay Wiktionary",
+    "d": "ms.wiktionary.org",
+    "t": "mswiktionary",
+    "ts": [
+      "mswikt",
+      "wiktms"
+    ],
+    "u": "https://ms.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Kabardian Wiktionary",
+    "d": "kbd.wiktionary.org",
+    "t": "kbdwiktionary",
+    "ts": [
+      "kbdwikt",
+      "wiktkbd"
+    ],
+    "u": "https://kbd.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Slovak Wiktionary",
+    "d": "sk.wiktionary.org",
+    "t": "skwiktionary",
+    "ts": [
+      "skwikt",
+      "wiktsk"
+    ],
+    "u": "https://sk.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Latin Wiktionary",
+    "d": "la.wiktionary.org",
+    "t": "lawiktionary",
+    "ts": [
+      "lawikt",
+      "wiktla"
+    ],
+    "u": "https://la.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Walloon Wiktionary",
+    "d": "wa.wiktionary.org",
+    "t": "wawiktionary",
+    "ts": [
+      "wawikt",
+      "wiktwa"
+    ],
+    "u": "https://wa.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Lombard Wiktionary",
+    "d": "lmo.wiktionary.org",
+    "t": "lmowiktionary",
+    "ts": [
+      "lmowikt",
+      "wiktlmo"
+    ],
+    "u": "https://lmo.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Kyrgyz Wiktionary",
+    "d": "ky.wiktionary.org",
+    "t": "kywiktionary",
+    "ts": [
+      "kywikt",
+      "wiktky"
+    ],
+    "u": "https://ky.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Croatian Wiktionary",
+    "d": "hr.wiktionary.org",
+    "t": "hrwiktionary",
+    "ts": [
+      "hrwikt",
+      "wikthr"
+    ],
+    "u": "https://hr.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Fijian Wiktionary",
+    "d": "fj.wiktionary.org",
+    "t": "fjwiktionary",
+    "ts": [
+      "fjwikt",
+      "wiktfj"
+    ],
+    "u": "https://fj.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Bulgarian Wiktionary",
+    "d": "bg.wiktionary.org",
+    "t": "bgwiktionary",
+    "ts": [
+      "bgwikt",
+      "wiktbg"
+    ],
+    "u": "https://bg.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Afrikaans Wiktionary",
+    "d": "af.wiktionary.org",
+    "t": "afwiktionary",
+    "ts": [
+      "afwikt",
+      "wiktaf"
+    ],
+    "u": "https://af.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Welsh Wiktionary",
+    "d": "cy.wiktionary.org",
+    "t": "cywiktionary",
+    "ts": [
+      "cywikt",
+      "wiktcy"
+    ],
+    "u": "https://cy.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Lao Wiktionary",
+    "d": "lo.wiktionary.org",
+    "t": "lowiktionary",
+    "ts": [
+      "lowikt",
+      "wiktlo"
+    ],
+    "u": "https://lo.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Urdu Wiktionary",
+    "d": "ur.wiktionary.org",
+    "t": "urwiktionary",
+    "ts": [
+      "urwikt",
+      "wiktur"
+    ],
+    "u": "https://ur.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Georgian Wiktionary",
+    "d": "ka.wiktionary.org",
+    "t": "kawiktionary",
+    "ts": [
+      "kawikt",
+      "wiktka"
+    ],
+    "u": "https://ka.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Tajik Wiktionary",
+    "d": "tg.wiktionary.org",
+    "t": "tgwiktionary",
+    "ts": [
+      "tgwikt",
+      "wikttg"
+    ],
+    "u": "https://tg.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Pashto Wiktionary",
+    "d": "ps.wiktionary.org",
+    "t": "pswiktionary",
+    "ts": [
+      "pswikt",
+      "wiktps"
+    ],
+    "u": "https://ps.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Hebrew Wiktionary",
+    "d": "he.wiktionary.org",
+    "t": "hewiktionary",
+    "ts": [
+      "hewikt",
+      "wikthe"
+    ],
+    "u": "https://he.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Volapük Wiktionary",
+    "d": "vo.wiktionary.org",
+    "t": "vowiktionary",
+    "ts": [
+      "vowikt",
+      "wiktvo"
+    ],
+    "u": "https://vo.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Slovenian Wiktionary",
+    "d": "sl.wiktionary.org",
+    "t": "slwiktionary",
+    "ts": [
+      "slwikt",
+      "wiktsl"
+    ],
+    "u": "https://sl.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Minnan Wiktionary",
+    "d": "zh-min-nan.wiktionary.org",
+    "t": "zh-min-nanwiktionary",
+    "ts": [
+      "zh-min-nanwikt",
+      "wiktzh-min-nan"
+    ],
+    "u": "https://zh-min-nan.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Sicilian Wiktionary",
+    "d": "scn.wiktionary.org",
+    "t": "scnwiktionary",
+    "ts": [
+      "scnwikt",
+      "wiktscn"
+    ],
+    "u": "https://scn.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Tagalog Wiktionary",
+    "d": "tl.wiktionary.org",
+    "t": "tlwiktionary",
+    "ts": [
+      "tlwikt",
+      "wikttl"
+    ],
+    "u": "https://tl.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Punjabi Wiktionary",
+    "d": "pa.wiktionary.org",
+    "t": "pawiktionary",
+    "ts": [
+      "pawikt",
+      "wiktpa"
+    ],
+    "u": "https://pa.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Western Frisian Wiktionary",
+    "d": "fy.wiktionary.org",
+    "t": "fywiktionary",
+    "ts": [
+      "fywikt",
+      "wiktfy"
+    ],
+    "u": "https://fy.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Minangkabau Wiktionary",
+    "d": "min.wiktionary.org",
+    "t": "minwiktionary",
+    "ts": [
+      "minwikt",
+      "wiktmin"
+    ],
+    "u": "https://min.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Kazakh Wiktionary",
+    "d": "kk.wiktionary.org",
+    "t": "kkwiktionary",
+    "ts": [
+      "kkwikt",
+      "wiktkk"
+    ],
+    "u": "https://kk.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Gorontalo Wiktionary",
+    "d": "gor.wiktionary.org",
+    "t": "gorwiktionary",
+    "ts": [
+      "gorwikt",
+      "wiktgor"
+    ],
+    "u": "https://gor.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Norwegian Nynorsk Wiktionary",
+    "d": "nn.wiktionary.org",
+    "t": "nnwiktionary",
+    "ts": [
+      "nnwikt",
+      "wiktnn"
+    ],
+    "u": "https://nn.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Latvian Wiktionary",
+    "d": "lv.wiktionary.org",
+    "t": "lvwiktionary",
+    "ts": [
+      "lvwikt",
+      "wiktlv"
+    ],
+    "u": "https://lv.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Sinhala Wiktionary",
+    "d": "si.wiktionary.org",
+    "t": "siwiktionary",
+    "ts": [
+      "siwikt",
+      "wiktsi"
+    ],
+    "u": "https://si.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Luxembourgish Wiktionary",
+    "d": "lb.wiktionary.org",
+    "t": "lbwiktionary",
+    "ts": [
+      "lbwikt",
+      "wiktlb"
+    ],
+    "u": "https://lb.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Albanian Wiktionary",
+    "d": "sq.wiktionary.org",
+    "t": "sqwiktionary",
+    "ts": [
+      "sqwikt",
+      "wiktsq"
+    ],
+    "u": "https://sq.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Low German Wiktionary",
+    "d": "nds.wiktionary.org",
+    "t": "ndswiktionary",
+    "ts": [
+      "ndswikt",
+      "wiktnds"
+    ],
+    "u": "https://nds.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Mongolian Wiktionary",
+    "d": "mn.wiktionary.org",
+    "t": "mnwiktionary",
+    "ts": [
+      "mnwikt",
+      "wiktmn"
+    ],
+    "u": "https://mn.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Corsican Wiktionary",
+    "d": "co.wiktionary.org",
+    "t": "cowiktionary",
+    "ts": [
+      "cowikt",
+      "wiktco"
+    ],
+    "u": "https://co.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Madurese Wiktionary",
+    "d": "mad.wiktionary.org",
+    "t": "madwiktionary",
+    "ts": [
+      "madwikt",
+      "wiktmad"
+    ],
+    "u": "https://mad.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Western Punjabi Wiktionary",
+    "d": "pnb.wiktionary.org",
+    "t": "pnbwiktionary",
+    "ts": [
+      "pnbwikt",
+      "wiktpnb"
+    ],
+    "u": "https://pnb.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Dimli Wiktionary",
+    "d": "diq.wiktionary.org",
+    "t": "diqwiktionary",
+    "ts": [
+      "diqwikt",
+      "wiktdiq"
+    ],
+    "u": "https://diq.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Nahuatl Wiktionary",
+    "d": "nah.wiktionary.org",
+    "t": "nahwiktionary",
+    "ts": [
+      "nahwikt",
+      "wiktnah"
+    ],
+    "u": "https://nah.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Cantonese Wiktionary",
+    "d": "yue.wiktionary.org",
+    "t": "yuewiktionary",
+    "ts": [
+      "yuewikt",
+      "wiktyue"
+    ],
+    "u": "https://yue.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Belarusian Wiktionary",
+    "d": "be.wiktionary.org",
+    "t": "bewiktionary",
+    "ts": [
+      "bewikt",
+      "wiktbe"
+    ],
+    "u": "https://be.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Nias Wiktionary",
+    "d": "nia.wiktionary.org",
+    "t": "niawiktionary",
+    "ts": [
+      "niawikt",
+      "wiktnia"
+    ],
+    "u": "https://nia.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Khmer Wiktionary",
+    "d": "km.wiktionary.org",
+    "t": "kmwiktionary",
+    "ts": [
+      "kmwikt",
+      "wiktkm"
+    ],
+    "u": "https://km.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Central Bikol Wiktionary",
+    "d": "bcl.wiktionary.org",
+    "t": "bclwiktionary",
+    "ts": [
+      "bclwikt",
+      "wiktbcl"
+    ],
+    "u": "https://bcl.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Kara-Kalpak Wiktionary",
+    "d": "kaa.wiktionary.org",
+    "t": "kaawiktionary",
+    "ts": [
+      "kaawikt",
+      "wiktkaa"
+    ],
+    "u": "https://kaa.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Macedonian Wiktionary",
+    "d": "mk.wiktionary.org",
+    "t": "mkwiktionary",
+    "ts": [
+      "mkwikt",
+      "wiktmk"
+    ],
+    "u": "https://mk.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Betawi Wiktionary",
+    "d": "bew.wiktionary.org",
+    "t": "bewwiktionary",
+    "ts": [
+      "bewwikt",
+      "wiktbew"
+    ],
+    "u": "https://bew.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Sanskrit Wiktionary",
+    "d": "sa.wiktionary.org",
+    "t": "sawiktionary",
+    "ts": [
+      "sawikt",
+      "wiktsa"
+    ],
+    "u": "https://sa.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Venetian Wiktionary",
+    "d": "vec.wiktionary.org",
+    "t": "vecwiktionary",
+    "ts": [
+      "vecwikt",
+      "wiktvec"
+    ],
+    "u": "https://vec.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Turkmen Wiktionary",
+    "d": "tk.wiktionary.org",
+    "t": "tkwiktionary",
+    "ts": [
+      "tkwikt",
+      "wikttk"
+    ],
+    "u": "https://tk.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Somali Wiktionary",
+    "d": "so.wiktionary.org",
+    "t": "sowiktionary",
+    "ts": [
+      "sowikt",
+      "wiktso"
+    ],
+    "u": "https://so.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Kashmiri Wiktionary",
+    "d": "ks.wiktionary.org",
+    "t": "kswiktionary",
+    "ts": [
+      "kswikt",
+      "wiktks"
+    ],
+    "u": "https://ks.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Samoan Wiktionary",
+    "d": "sm.wiktionary.org",
+    "t": "smwiktionary",
+    "ts": [
+      "smwikt",
+      "wiktsm"
+    ],
+    "u": "https://sm.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Upper Sorbian Wiktionary",
+    "d": "hsb.wiktionary.org",
+    "t": "hsbwiktionary",
+    "ts": [
+      "hsbwikt",
+      "wikthsb"
+    ],
+    "u": "https://hsb.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Batak Mandailing Wiktionary",
+    "d": "btm.wiktionary.org",
+    "t": "btmwiktionary",
+    "ts": [
+      "btmwikt",
+      "wiktbtm"
+    ],
+    "u": "https://btm.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Hausa Wiktionary",
+    "d": "ha.wiktionary.org",
+    "t": "hawiktionary",
+    "ts": [
+      "hawikt",
+      "wiktha"
+    ],
+    "u": "https://ha.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Banjar Wiktionary",
+    "d": "bjn.wiktionary.org",
+    "t": "bjnwiktionary",
+    "ts": [
+      "bjnwikt",
+      "wiktbjn"
+    ],
+    "u": "https://bjn.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Sundanese Wiktionary",
+    "d": "su.wiktionary.org",
+    "t": "suwiktionary",
+    "ts": [
+      "suwikt",
+      "wiktsu"
+    ],
+    "u": "https://su.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Shawiya Wiktionary",
+    "d": "shy.wiktionary.org",
+    "t": "shywiktionary",
+    "ts": [
+      "shywikt",
+      "wiktshy"
+    ],
+    "u": "https://shy.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Central Kurdish Wiktionary",
+    "d": "ckb.wiktionary.org",
+    "t": "ckbwiktionary",
+    "ts": [
+      "ckbwikt",
+      "wiktckb"
+    ],
+    "u": "https://ckb.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Irish Wiktionary",
+    "d": "ga.wiktionary.org",
+    "t": "gawiktionary",
+    "ts": [
+      "gawikt",
+      "wiktga"
+    ],
+    "u": "https://ga.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Scottish Gaelic Wiktionary",
+    "d": "gd.wiktionary.org",
+    "t": "gdwiktionary",
+    "ts": [
+      "gdwikt",
+      "wiktgd"
+    ],
+    "u": "https://gd.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Pa'O Wiktionary",
+    "d": "blk.wiktionary.org",
+    "t": "blkwiktionary",
+    "ts": [
+      "blkwikt",
+      "wiktblk"
+    ],
+    "u": "https://blk.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Aragonese Wiktionary",
+    "d": "an.wiktionary.org",
+    "t": "anwiktionary",
+    "ts": [
+      "anwikt",
+      "wiktan"
+    ],
+    "u": "https://an.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Goan Konkani Wiktionary",
+    "d": "gom.wiktionary.org",
+    "t": "gomwiktionary",
+    "ts": [
+      "gomwikt",
+      "wiktgom"
+    ],
+    "u": "https://gom.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Marathi Wiktionary",
+    "d": "mr.wiktionary.org",
+    "t": "mrwiktionary",
+    "ts": [
+      "mrwikt",
+      "wiktmr"
+    ],
+    "u": "https://mr.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Wolof Wiktionary",
+    "d": "wo.wiktionary.org",
+    "t": "wowiktionary",
+    "ts": [
+      "wowikt",
+      "wiktwo"
+    ],
+    "u": "https://wo.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Manipuri Wiktionary",
+    "d": "mni.wiktionary.org",
+    "t": "mniwiktionary",
+    "ts": [
+      "mniwikt",
+      "wiktmni"
+    ],
+    "u": "https://mni.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Interlingua Wiktionary",
+    "d": "ia.wiktionary.org",
+    "t": "iawiktionary",
+    "ts": [
+      "iawikt",
+      "wiktia"
+    ],
+    "u": "https://ia.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Maltese Wiktionary",
+    "d": "mt.wiktionary.org",
+    "t": "mtwiktionary",
+    "ts": [
+      "mtwikt",
+      "wiktmt"
+    ],
+    "u": "https://mt.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Sindhi Wiktionary",
+    "d": "sd.wiktionary.org",
+    "t": "sdwiktionary",
+    "ts": [
+      "sdwikt",
+      "wiktsd"
+    ],
+    "u": "https://sd.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Tatar Wiktionary",
+    "d": "tt.wiktionary.org",
+    "t": "ttwiktionary",
+    "ts": [
+      "ttwikt",
+      "wikttt"
+    ],
+    "u": "https://tt.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Tyap Wiktionary",
+    "d": "kcg.wiktionary.org",
+    "t": "kcgwiktionary",
+    "ts": [
+      "kcgwikt",
+      "wiktkcg"
+    ],
+    "u": "https://kcg.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Faroese Wiktionary",
+    "d": "fo.wiktionary.org",
+    "t": "fowiktionary",
+    "ts": [
+      "fowikt",
+      "wiktfo"
+    ],
+    "u": "https://fo.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Old English Wiktionary",
+    "d": "ang.wiktionary.org",
+    "t": "angwiktionary",
+    "ts": [
+      "angwikt",
+      "wiktang"
+    ],
+    "u": "https://ang.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Guarani Wiktionary",
+    "d": "gn.wiktionary.org",
+    "t": "gnwiktionary",
+    "ts": [
+      "gnwikt",
+      "wiktgn"
+    ],
+    "u": "https://gn.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Māori Wiktionary",
+    "d": "mi.wiktionary.org",
+    "t": "miwiktionary",
+    "ts": [
+      "miwikt",
+      "wiktmi"
+    ],
+    "u": "https://mi.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Gun Wiktionary",
+    "d": "guw.wiktionary.org",
+    "t": "guwwiktionary",
+    "ts": [
+      "guwwikt",
+      "wiktguw"
+    ],
+    "u": "https://guw.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Interlingue Wiktionary",
+    "d": "ie.wiktionary.org",
+    "t": "iewiktionary",
+    "ts": [
+      "iewikt",
+      "wiktie"
+    ],
+    "u": "https://ie.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Kashubian Wiktionary",
+    "d": "csb.wiktionary.org",
+    "t": "csbwiktionary",
+    "ts": [
+      "csbwikt",
+      "wiktcsb"
+    ],
+    "u": "https://csb.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Uyghur Wiktionary",
+    "d": "ug.wiktionary.org",
+    "t": "ugwiktionary",
+    "ts": [
+      "ugwikt",
+      "wiktug"
+    ],
+    "u": "https://ug.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Lojban Wiktionary",
+    "d": "jbo.wiktionary.org",
+    "t": "jbowiktionary",
+    "ts": [
+      "jbowikt",
+      "wiktjbo"
+    ],
+    "u": "https://jbo.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Southern Sotho Wiktionary",
+    "d": "st.wiktionary.org",
+    "t": "stwiktionary",
+    "ts": [
+      "stwikt",
+      "wiktst"
+    ],
+    "u": "https://st.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Fiji Hindi Wiktionary",
+    "d": "hif.wiktionary.org",
+    "t": "hifwiktionary",
+    "ts": [
+      "hifwikt",
+      "wikthif"
+    ],
+    "u": "https://hif.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Aromanian Wiktionary",
+    "d": "roa-rup.wiktionary.org",
+    "t": "roa-rupwiktionary",
+    "ts": [
+      "roa-rupwikt",
+      "wiktroa-rup"
+    ],
+    "u": "https://roa-rup.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Santali Wiktionary",
+    "d": "sat.wiktionary.org",
+    "t": "satwiktionary",
+    "ts": [
+      "satwikt",
+      "wiktsat"
+    ],
+    "u": "https://sat.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Zulu Wiktionary",
+    "d": "zu.wiktionary.org",
+    "t": "zuwiktionary",
+    "ts": [
+      "zuwikt",
+      "wiktzu"
+    ],
+    "u": "https://zu.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Kalaallisut Wiktionary",
+    "d": "kl.wiktionary.org",
+    "t": "klwiktionary",
+    "ts": [
+      "klwikt",
+      "wiktkl"
+    ],
+    "u": "https://kl.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Standard Moroccan Tamazight Wiktionary",
+    "d": "zgh.wiktionary.org",
+    "t": "zghwiktionary",
+    "ts": [
+      "zghwikt",
+      "wiktzgh"
+    ],
+    "u": "https://zgh.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Tulu Wiktionary",
+    "d": "tcy.wiktionary.org",
+    "t": "tcywiktionary",
+    "ts": [
+      "tcywikt",
+      "wikttcy"
+    ],
+    "u": "https://tcy.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Lingala Wiktionary",
+    "d": "ln.wiktionary.org",
+    "t": "lnwiktionary",
+    "ts": [
+      "lnwikt",
+      "wiktln"
+    ],
+    "u": "https://ln.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Amharic Wiktionary",
+    "d": "am.wiktionary.org",
+    "t": "amwiktionary",
+    "ts": [
+      "amwikt",
+      "wiktam"
+    ],
+    "u": "https://am.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Aymara Wiktionary",
+    "d": "ay.wiktionary.org",
+    "t": "aywiktionary",
+    "ts": [
+      "aywikt",
+      "wiktay"
+    ],
+    "u": "https://ay.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Yiddish Wiktionary",
+    "d": "yi.wiktionary.org",
+    "t": "yiwiktionary",
+    "ts": [
+      "yiwikt",
+      "wiktyi"
+    ],
+    "u": "https://yi.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Gujarati Wiktionary",
+    "d": "gu.wiktionary.org",
+    "t": "guwiktionary",
+    "ts": [
+      "guwikt",
+      "wiktgu"
+    ],
+    "u": "https://gu.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Igbo Wiktionary",
+    "d": "ig.wiktionary.org",
+    "t": "igwiktionary",
+    "ts": [
+      "igwikt",
+      "wiktig"
+    ],
+    "u": "https://ig.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Nauru Wiktionary",
+    "d": "na.wiktionary.org",
+    "t": "nawiktionary",
+    "ts": [
+      "nawikt",
+      "wiktna"
+    ],
+    "u": "https://na.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Manx Wiktionary",
+    "d": "gv.wiktionary.org",
+    "t": "gvwiktionary",
+    "ts": [
+      "gvwikt",
+      "wiktgv"
+    ],
+    "u": "https://gv.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Nepali Wiktionary",
+    "d": "ne.wiktionary.org",
+    "t": "newiktionary",
+    "ts": [
+      "newikt",
+      "wiktne"
+    ],
+    "u": "https://ne.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Tok Pisin Wiktionary",
+    "d": "tpi.wiktionary.org",
+    "t": "tpiwiktionary",
+    "ts": [
+      "tpiwikt",
+      "wikttpi"
+    ],
+    "u": "https://tpi.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Cornish Wiktionary",
+    "d": "kw.wiktionary.org",
+    "t": "kwwiktionary",
+    "ts": [
+      "kwwikt",
+      "wiktkw"
+    ],
+    "u": "https://kw.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Kinyarwanda Wiktionary",
+    "d": "rw.wiktionary.org",
+    "t": "rwwiktionary",
+    "ts": [
+      "rwwikt",
+      "wiktrw"
+    ],
+    "u": "https://rw.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Tsonga Wiktionary",
+    "d": "ts.wiktionary.org",
+    "t": "tswiktionary",
+    "ts": [
+      "tswikt",
+      "wiktts"
+    ],
+    "u": "https://ts.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Quechua Wiktionary",
+    "d": "qu.wiktionary.org",
+    "t": "quwiktionary",
+    "ts": [
+      "quwikt",
+      "wiktqu"
+    ],
+    "u": "https://qu.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Inuktitut Wiktionary",
+    "d": "iu.wiktionary.org",
+    "t": "iuwiktionary",
+    "ts": [
+      "iuwikt",
+      "wiktiu"
+    ],
+    "u": "https://iu.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Cherokee Wiktionary",
+    "d": "chr.wiktionary.org",
+    "t": "chrwiktionary",
+    "ts": [
+      "chrwikt",
+      "wiktchr"
+    ],
+    "u": "https://chr.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Swati Wiktionary",
+    "d": "ss.wiktionary.org",
+    "t": "sswiktionary",
+    "ts": [
+      "sswikt",
+      "wiktss"
+    ],
+    "u": "https://ss.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Divehi Wiktionary",
+    "d": "dv.wiktionary.org",
+    "t": "dvwiktionary",
+    "ts": [
+      "dvwikt",
+      "wiktdv"
+    ],
+    "u": "https://dv.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Tigrinya Wiktionary",
+    "d": "ti.wiktionary.org",
+    "t": "tiwiktionary",
+    "ts": [
+      "tiwikt",
+      "wiktti"
+    ],
+    "u": "https://ti.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Tswana Wiktionary",
+    "d": "tn.wiktionary.org",
+    "t": "tnwiktionary",
+    "ts": [
+      "tnwikt",
+      "wikttn"
+    ],
+    "u": "https://tn.wiktionary.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Reference (words intl)"
+  },
+  {
+    "s": "Bosnian Wiktionary",
+    "d": "bs.wiktionary.org",
+    "t": "bswiktionary",
+    "ts": [
+      "bswikt",
+      "wiktbs"
+    ],
+    "u": "https://bs.wiktionary.org/w/index.php?search={{{s}}}",
     "c": "Research",
     "sc": "Reference (words intl)"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -92904,7 +92904,6 @@
     "d": "la.wikisource.org",
     "t": "lawikisource",
     "ts": [
-      "laws",
       "wsla"
     ],
     "u": "https://la.wikisource.org/w/index.php?search={{{s}}}",
@@ -93396,7 +93395,6 @@
     "d": "kn.wikisource.org",
     "t": "knwikisource",
     "ts": [
-      "knws",
       "wskn"
     ],
     "u": "https://kn.wikisource.org/w/index.php?search={{{s}}}",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -42368,14 +42368,6 @@
     "sc": "Companies"
   },
   {
-    "s": "Japanese Wikibooks",
-    "d": "ja.wikibooks.org",
-    "t": "jawb",
-    "u": "https://ja.wikibooks.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Reference"
-  },
-  {
     "s": "Japanese Wikisource",
     "d": "ja.wikisource.org",
     "t": "jaws",
@@ -84834,14 +84826,6 @@
     "sc": "Sports"
   },
   {
-    "s": "Wikibooks De",
-    "d": "de.wikibooks.org",
-    "t": "wbde",
-    "u": "https://de.wikibooks.org/w/index.php?search={{{s}}}",
-    "c": "Research",
-    "sc": "Academic"
-  },
-  {
     "s": "r/worldbuilding",
     "d": "www.reddit.com",
     "t": "wbd",
@@ -84866,22 +84850,6 @@
     "sc": "Design"
   },
   {
-    "s": "Wikibooks JP",
-    "d": "ja.wikibooks.org",
-    "t": "wbj",
-    "u": "https://ja.wikibooks.org/w/index.php?search={{{s}}}&title=特別:検索&go=表示",
-    "c": "Research",
-    "sc": "Learning"
-  },
-  {
-    "s": "Wikibooks Malayalam",
-    "d": "ml.wikibooks.org",
-    "t": "wbml",
-    "u": "https://ml.wikibooks.org/wiki/special:search/{{{s}}}",
-    "c": "Research",
-    "sc": "Learning (intl)"
-  },
-  {
     "s": "Webmasterparadies.de",
     "d": "webmasterparadies.de",
     "t": "wbmp",
@@ -84896,17 +84864,6 @@
     "u": "https://www.wbur.org/search?q={{{s}}}",
     "c": "News",
     "sc": "Broadcast"
-  },
-  {
-    "s": "Wikibooks",
-    "d": "en.wikibooks.org",
-    "t": "wb",
-    "ts": [
-      "wikibooks"
-    ],
-    "u": "https://en.wikibooks.org/wiki/Special:Search?search={{{s}}}",
-    "c": "Research",
-    "sc": "Academic"
   },
   {
     "s": "World Cube Association Championships",
@@ -86047,6 +86004,930 @@
     "u": "https://en.wikibooks.org/wiki/Special:Search?search={{{s}}}&prefix=Cookbook:&fulltext=Search+Cookbook&fulltext=Search",
     "c": "Research",
     "sc": "Food"
+  },
+  {
+    "s": "English Wikibooks",
+    "d": "en.wikibooks.org",
+    "t": "enwikibooks",
+    "ts": [
+      "enwb",
+      "wben"
+    ],
+    "u": "https://en.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Hungarian Wikibooks",
+    "d": "hu.wikibooks.org",
+    "t": "huwikibooks",
+    "ts": [
+      "huwb",
+      "wbhu"
+    ],
+    "u": "https://hu.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "German Wikibooks",
+    "d": "de.wikibooks.org",
+    "t": "dewikibooks",
+    "ts": [
+      "dewb",
+      "wbde"
+    ],
+    "u": "https://de.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "French Wikibooks",
+    "d": "fr.wikibooks.org",
+    "t": "frwikibooks",
+    "ts": [
+      "frwb",
+      "wbfr"
+    ],
+    "u": "https://fr.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Italian Wikibooks",
+    "d": "it.wikibooks.org",
+    "t": "itwikibooks",
+    "ts": [
+      "itwb",
+      "wbit"
+    ],
+    "u": "https://it.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Japanese Wikibooks",
+    "d": "ja.wikibooks.org",
+    "t": "jawikibooks",
+    "ts": [
+      "jawb",
+      "wbja"
+    ],
+    "u": "https://ja.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Portuguese Wikibooks",
+    "d": "pt.wikibooks.org",
+    "t": "ptwikibooks",
+    "ts": [
+      "ptwb",
+      "wbpt"
+    ],
+    "u": "https://pt.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Dutch Wikibooks",
+    "d": "nl.wikibooks.org",
+    "t": "nlwikibooks",
+    "ts": [
+      "nlwb",
+      "wbnl"
+    ],
+    "u": "https://nl.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Spanish Wikibooks",
+    "d": "es.wikibooks.org",
+    "t": "eswikibooks",
+    "ts": [
+      "eswb",
+      "wbes"
+    ],
+    "u": "https://es.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Vietnamese Wikibooks",
+    "d": "vi.wikibooks.org",
+    "t": "viwikibooks",
+    "ts": [
+      "viwb",
+      "wbvi"
+    ],
+    "u": "https://vi.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Polish Wikibooks",
+    "d": "pl.wikibooks.org",
+    "t": "plwikibooks",
+    "ts": [
+      "plwb",
+      "wbpl"
+    ],
+    "u": "https://pl.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Indonesian Wikibooks",
+    "d": "id.wikibooks.org",
+    "t": "idwikibooks",
+    "ts": [
+      "idwb",
+      "wbid"
+    ],
+    "u": "https://id.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Finnish Wikibooks",
+    "d": "fi.wikibooks.org",
+    "t": "fiwikibooks",
+    "ts": [
+      "fiwb",
+      "wbfi"
+    ],
+    "u": "https://fi.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Hebrew Wikibooks",
+    "d": "he.wikibooks.org",
+    "t": "hewikibooks",
+    "ts": [
+      "hewb",
+      "wbhe"
+    ],
+    "u": "https://he.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Bangla Wikibooks",
+    "d": "bn.wikibooks.org",
+    "t": "bnwikibooks",
+    "ts": [
+      "bnwb",
+      "wbbn"
+    ],
+    "u": "https://bn.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Chinese Wikibooks",
+    "d": "zh.wikibooks.org",
+    "t": "zhwikibooks",
+    "ts": [
+      "zhwb",
+      "wbzh"
+    ],
+    "u": "https://zh.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Lithuanian Wikibooks",
+    "d": "lt.wikibooks.org",
+    "t": "ltwikibooks",
+    "ts": [
+      "ltwb",
+      "wblt"
+    ],
+    "u": "https://lt.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Persian Wikibooks",
+    "d": "fa.wikibooks.org",
+    "t": "fawikibooks",
+    "ts": [
+      "fawb",
+      "wbfa"
+    ],
+    "u": "https://fa.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Azerbaijani Wikibooks",
+    "d": "az.wikibooks.org",
+    "t": "azwikibooks",
+    "ts": [
+      "azwb",
+      "wbaz"
+    ],
+    "u": "https://az.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Albanian Wikibooks",
+    "d": "sq.wikibooks.org",
+    "t": "sqwikibooks",
+    "ts": [
+      "sqwb",
+      "wbsq"
+    ],
+    "u": "https://sq.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Russian Wikibooks",
+    "d": "ru.wikibooks.org",
+    "t": "ruwikibooks",
+    "ts": [
+      "ruwb",
+      "wbru"
+    ],
+    "u": "https://ru.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Catalan Wikibooks",
+    "d": "ca.wikibooks.org",
+    "t": "cawikibooks",
+    "ts": [
+      "cawb",
+      "wbca"
+    ],
+    "u": "https://ca.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Basque Wikibooks",
+    "d": "eu.wikibooks.org",
+    "t": "euwikibooks",
+    "ts": [
+      "euwb",
+      "wbeu"
+    ],
+    "u": "https://eu.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Thai Wikibooks",
+    "d": "th.wikibooks.org",
+    "t": "thwikibooks",
+    "ts": [
+      "thwb",
+      "wbth"
+    ],
+    "u": "https://th.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Czech Wikibooks",
+    "d": "cs.wikibooks.org",
+    "t": "cswikibooks",
+    "ts": [
+      "cswb",
+      "wbcs"
+    ],
+    "u": "https://cs.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Sinhala Wikibooks",
+    "d": "si.wikibooks.org",
+    "t": "siwikibooks",
+    "ts": [
+      "siwb",
+      "wbsi"
+    ],
+    "u": "https://si.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Danish Wikibooks",
+    "d": "da.wikibooks.org",
+    "t": "dawikibooks",
+    "ts": [
+      "dawb",
+      "wbda"
+    ],
+    "u": "https://da.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Korean Wikibooks",
+    "d": "ko.wikibooks.org",
+    "t": "kowikibooks",
+    "ts": [
+      "kowb",
+      "wbko"
+    ],
+    "u": "https://ko.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Hindi Wikibooks",
+    "d": "hi.wikibooks.org",
+    "t": "hiwikibooks",
+    "ts": [
+      "hiwb",
+      "wbhi"
+    ],
+    "u": "https://hi.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Bashkir Wikibooks",
+    "d": "ba.wikibooks.org",
+    "t": "bawikibooks",
+    "ts": [
+      "bawb",
+      "wbba"
+    ],
+    "u": "https://ba.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Swedish Wikibooks",
+    "d": "sv.wikibooks.org",
+    "t": "svwikibooks",
+    "ts": [
+      "svwb",
+      "wbsv"
+    ],
+    "u": "https://sv.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Galician Wikibooks",
+    "d": "gl.wikibooks.org",
+    "t": "glwikibooks",
+    "ts": [
+      "glwb",
+      "wbgl"
+    ],
+    "u": "https://gl.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Ukrainian Wikibooks",
+    "d": "uk.wikibooks.org",
+    "t": "ukwikibooks",
+    "ts": [
+      "ukwb",
+      "wbuk"
+    ],
+    "u": "https://uk.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Serbian Wikibooks",
+    "d": "sr.wikibooks.org",
+    "t": "srwikibooks",
+    "ts": [
+      "srwb",
+      "wbsr"
+    ],
+    "u": "https://sr.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Turkish Wikibooks",
+    "d": "tr.wikibooks.org",
+    "t": "trwikibooks",
+    "ts": [
+      "trwb",
+      "wbtr"
+    ],
+    "u": "https://tr.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Croatian Wikibooks",
+    "d": "hr.wikibooks.org",
+    "t": "hrwikibooks",
+    "ts": [
+      "hrwb",
+      "wbhr"
+    ],
+    "u": "https://hr.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Norwegian Wikibooks",
+    "d": "no.wikibooks.org",
+    "t": "nowikibooks",
+    "ts": [
+      "nowb",
+      "wbno"
+    ],
+    "u": "https://no.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Arabic Wikibooks",
+    "d": "ar.wikibooks.org",
+    "t": "arwikibooks",
+    "ts": [
+      "arwb",
+      "wbar"
+    ],
+    "u": "https://ar.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Sanskrit Wikibooks",
+    "d": "sa.wikibooks.org",
+    "t": "sawikibooks",
+    "ts": [
+      "sawb",
+      "wbsa"
+    ],
+    "u": "https://sa.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Tamil Wikibooks",
+    "d": "ta.wikibooks.org",
+    "t": "tawikibooks",
+    "ts": [
+      "tawb",
+      "wbta"
+    ],
+    "u": "https://ta.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Esperanto Wikibooks",
+    "d": "eo.wikibooks.org",
+    "t": "eowikibooks",
+    "ts": [
+      "eowb",
+      "wbeo"
+    ],
+    "u": "https://eo.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Minangkabau Wikibooks",
+    "d": "min.wikibooks.org",
+    "t": "minwikibooks",
+    "ts": [
+      "minwb",
+      "wbmin"
+    ],
+    "u": "https://min.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Malay Wikibooks",
+    "d": "ms.wikibooks.org",
+    "t": "mswikibooks",
+    "ts": [
+      "mswb",
+      "wbms"
+    ],
+    "u": "https://ms.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Icelandic Wikibooks",
+    "d": "is.wikibooks.org",
+    "t": "iswikibooks",
+    "ts": [
+      "iswb",
+      "wbis"
+    ],
+    "u": "https://is.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Slovak Wikibooks",
+    "d": "sk.wikibooks.org",
+    "t": "skwikibooks",
+    "ts": [
+      "skwb",
+      "wbsk"
+    ],
+    "u": "https://sk.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Romanian Wikibooks",
+    "d": "ro.wikibooks.org",
+    "t": "rowikibooks",
+    "ts": [
+      "rowb",
+      "wbro"
+    ],
+    "u": "https://ro.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Shan Wikibooks",
+    "d": "shn.wikibooks.org",
+    "t": "shnwikibooks",
+    "ts": [
+      "shnwb",
+      "wbshn"
+    ],
+    "u": "https://shn.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Bulgarian Wikibooks",
+    "d": "bg.wikibooks.org",
+    "t": "bgwikibooks",
+    "ts": [
+      "bgwb",
+      "wbbg"
+    ],
+    "u": "https://bg.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Georgian Wikibooks",
+    "d": "ka.wikibooks.org",
+    "t": "kawikibooks",
+    "ts": [
+      "kawb",
+      "wbka"
+    ],
+    "u": "https://ka.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Telugu Wikibooks",
+    "d": "te.wikibooks.org",
+    "t": "tewikibooks",
+    "ts": [
+      "tewb",
+      "wbte"
+    ],
+    "u": "https://te.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Tatar Wikibooks",
+    "d": "tt.wikibooks.org",
+    "t": "ttwikibooks",
+    "ts": [
+      "ttwb",
+      "wbtt"
+    ],
+    "u": "https://tt.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Greek Wikibooks",
+    "d": "el.wikibooks.org",
+    "t": "elwikibooks",
+    "ts": [
+      "elwb",
+      "wbel"
+    ],
+    "u": "https://el.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Slovenian Wikibooks",
+    "d": "sl.wikibooks.org",
+    "t": "slwikibooks",
+    "ts": [
+      "slwb",
+      "wbsl"
+    ],
+    "u": "https://sl.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Limburgish Wikibooks",
+    "d": "li.wikibooks.org",
+    "t": "liwikibooks",
+    "ts": [
+      "liwb",
+      "wbli"
+    ],
+    "u": "https://li.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Tagalog Wikibooks",
+    "d": "tl.wikibooks.org",
+    "t": "tlwikibooks",
+    "ts": [
+      "tlwb",
+      "wbtl"
+    ],
+    "u": "https://tl.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Urdu Wikibooks",
+    "d": "ur.wikibooks.org",
+    "t": "urwikibooks",
+    "ts": [
+      "urwb",
+      "wbur"
+    ],
+    "u": "https://ur.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Latin Wikibooks",
+    "d": "la.wikibooks.org",
+    "t": "lawikibooks",
+    "ts": [
+      "lawb",
+      "wbla"
+    ],
+    "u": "https://la.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Belarusian Wikibooks",
+    "d": "be.wikibooks.org",
+    "t": "bewikibooks",
+    "ts": [
+      "bewb",
+      "wbbe"
+    ],
+    "u": "https://be.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Khmer Wikibooks",
+    "d": "km.wikibooks.org",
+    "t": "kmwikibooks",
+    "ts": [
+      "kmwb",
+      "wbkm"
+    ],
+    "u": "https://km.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Marathi Wikibooks",
+    "d": "mr.wikibooks.org",
+    "t": "mrwikibooks",
+    "ts": [
+      "mrwb",
+      "wbmr"
+    ],
+    "u": "https://mr.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Kazakh Wikibooks",
+    "d": "kk.wikibooks.org",
+    "t": "kkwikibooks",
+    "ts": [
+      "kkwb",
+      "wbkk"
+    ],
+    "u": "https://kk.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Estonian Wikibooks",
+    "d": "et.wikibooks.org",
+    "t": "etwikibooks",
+    "ts": [
+      "etwb",
+      "wbet"
+    ],
+    "u": "https://et.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Macedonian Wikibooks",
+    "d": "mk.wikibooks.org",
+    "t": "mkwikibooks",
+    "ts": [
+      "mkwb",
+      "wbmk"
+    ],
+    "u": "https://mk.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Interlingua Wikibooks",
+    "d": "ia.wikibooks.org",
+    "t": "iawikibooks",
+    "ts": [
+      "iawb",
+      "wbia"
+    ],
+    "u": "https://ia.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Malayalam Wikibooks",
+    "d": "ml.wikibooks.org",
+    "t": "mlwikibooks",
+    "ts": [
+      "mlwb",
+      "wbml"
+    ],
+    "u": "https://ml.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Occitan Wikibooks",
+    "d": "oc.wikibooks.org",
+    "t": "ocwikibooks",
+    "ts": [
+      "ocwb",
+      "wboc"
+    ],
+    "u": "https://oc.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Nepali Wikibooks",
+    "d": "ne.wikibooks.org",
+    "t": "newikibooks",
+    "ts": [
+      "newb",
+      "wbne"
+    ],
+    "u": "https://ne.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Punjabi Wikibooks",
+    "d": "pa.wikibooks.org",
+    "t": "pawikibooks",
+    "ts": [
+      "pawb",
+      "wbpa"
+    ],
+    "u": "https://pa.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Armenian Wikibooks",
+    "d": "hy.wikibooks.org",
+    "t": "hywikibooks",
+    "ts": [
+      "hywb",
+      "wbhy"
+    ],
+    "u": "https://hy.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Tajik Wikibooks",
+    "d": "tg.wikibooks.org",
+    "t": "tgwikibooks",
+    "ts": [
+      "tgwb",
+      "wbtg"
+    ],
+    "u": "https://tg.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Kurdish Wikibooks",
+    "d": "ku.wikibooks.org",
+    "t": "kuwikibooks",
+    "ts": [
+      "kuwb",
+      "wbku"
+    ],
+    "u": "https://ku.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Western Frisian Wikibooks",
+    "d": "fy.wikibooks.org",
+    "t": "fywikibooks",
+    "ts": [
+      "fywb",
+      "wbfy"
+    ],
+    "u": "https://fy.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Malagasy Wikibooks",
+    "d": "mg.wikibooks.org",
+    "t": "mgwikibooks",
+    "ts": [
+      "mgwb",
+      "wbmg"
+    ],
+    "u": "https://mg.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Chuvash Wikibooks",
+    "d": "cv.wikibooks.org",
+    "t": "cvwikibooks",
+    "ts": [
+      "cvwb",
+      "wbcv"
+    ],
+    "u": "https://cv.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Afrikaans Wikibooks",
+    "d": "af.wikibooks.org",
+    "t": "afwikibooks",
+    "ts": [
+      "afwb",
+      "wbaf"
+    ],
+    "u": "https://af.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Bosnian Wikibooks",
+    "d": "bs.wikibooks.org",
+    "t": "bswikibooks",
+    "ts": [
+      "bswb",
+      "wbbs"
+    ],
+    "u": "https://bs.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
+  },
+  {
+    "s": "Welsh Wikibooks",
+    "d": "cy.wikibooks.org",
+    "t": "cywikibooks",
+    "ts": [
+      "cywb",
+      "wbcy"
+    ],
+    "u": "https://cy.wikibooks.org/w/index.php?search={{{s}}}",
+    "c": "Research",
+    "sc": "Learning"
   },
   {
     "s": "WikiDex",


### PR DESCRIPTION
- the `m.` subdomain, previously serving mobile versions of the sites, [was deprecated](https://phabricator.wikimedia.org/T214998) and now, both desktop & mobile versions are served under the same language subdomains. hence, `m.` bangs don't need to be kept anymore.
- standardized bangs' `s`, `t` and `ts` properties
- removed duplicate bangs
- english bangs now explicitly mention the language name instead of the mere project name
- added missing languages