### PR TITLE
Fix/amend VirusTotal bangs

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -83740,10 +83740,7 @@
   {
     "s": "VirusTotal",
     "d": "www.virustotal.com",
-    "t": "virustotalfilesearch",
-    "ts": [
-      "virustotal"
-    ],
+    "t": "virustotal",
     "u": "https://www.virustotal.com/gui/search?query={{{s}}}",
     "c": "Tech",
     "sc": "Sysadmin"

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -84294,6 +84294,25 @@
     "sc": "Sysadmin"
   },
   {
+    "s": "www.virustotal.com",
+    "d": "www.virustotal.com",
+    "t": "vtdomain",
+    "u": "https://www.virustotal.com/gui/domain/{{{s}}}",
+    "c": "Tech",
+    "sc": "Sysadmin"
+  },
+  {
+    "s": "www.virustotal.com",
+    "d": "www.virustotal.com",
+    "t": "vtfile",
+    "ts": [
+      "vthash"
+    ],
+    "u": "https://www.virustotal.com/gui/file/{{{s}}}",
+    "c": "Tech",
+    "sc": "Sysadmin"
+  },
+  {
     "s": "Visualization Toolkit (VTK) class documentation (devel)",
     "d": "www.vtk.org",
     "t": "vtkcd",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -83741,6 +83741,9 @@
     "s": "VirusTotal",
     "d": "www.virustotal.com",
     "t": "virustotal",
+    "ts": [
+      "vt"
+    ],
     "u": "https://www.virustotal.com/gui/search?query={{{s}}}",
     "c": "Tech",
     "sc": "Sysadmin"
@@ -84332,14 +84335,6 @@
     "u": "https://vtmb.wikia.com/wiki/Special:Search?query={{{s}}}",
     "c": "Entertainment",
     "sc": "Games (specific)"
-  },
-  {
-    "s": "Vulgum Techus",
-    "d": "www.vulgumtechus.com",
-    "t": "vt",
-    "u": "https://www.vulgumtechus.com/index.php?title=Spécial:Recherche&search={{{s}}}",
-    "c": "Tech",
-    "sc": "Blogs"
   },
   {
     "s": "Bibliotheek van de Vrije Univesiteit Brussel",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -84283,7 +84283,7 @@
     "sc": "Reference (words intl)"
   },
   {
-    "s": "www.virustotal.com",
+    "s": "VirusTotal IP",
     "d": "www.virustotal.com",
     "t": "vtip",
     "u": "https://www.virustotal.com/gui/ip-address/{{{s}}}",
@@ -84291,7 +84291,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "www.virustotal.com",
+    "s": "VirusTotal Domain",
     "d": "www.virustotal.com",
     "t": "vtdomain",
     "u": "https://www.virustotal.com/gui/domain/{{{s}}}",
@@ -84299,7 +84299,7 @@
     "sc": "Sysadmin"
   },
   {
-    "s": "www.virustotal.com",
+    "s": "VirusTotal File",
     "d": "www.virustotal.com",
     "t": "vtfile",
     "ts": [

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -83744,7 +83744,7 @@
     "ts": [
       "virustotal"
     ],
-    "u": "https://www.virustotal.com/en/search?query={{{s}}}",
+    "u": "https://www.virustotal.com/gui/search?query={{{s}}}",
     "c": "Tech",
     "sc": "Sysadmin"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -84289,7 +84289,7 @@
     "s": "www.virustotal.com",
     "d": "www.virustotal.com",
     "t": "vtip",
-    "u": "https://www.virustotal.com/en/ip-address/{{{s}}}/information/",
+    "u": "https://www.virustotal.com/gui/ip-address/{{{s}}}",
     "c": "Tech",
     "sc": "Sysadmin"
   },


### PR DESCRIPTION
Hello!  I just realised that Kagi bangs are actually maintained (unlike DDG...), so I was hoping to improve the searching over VirusTotal.  It seems that the current VirusTotal bang (`!virustotal`) no longer works, and the other supported type (searching over IPs; `!vtip`) is outdated.  I have corrected `!virustotal`, updated `!vtip`, and added searches for the other trivial data types, `!vtdomain` and `!vtfile`.

Please let me know if this is alright or if you need anything else.

*NOTE*: I have also removed the old `!vt` bang as that query is no longer functional.  Feel free to revert b44702f if you don't want to remove this yet—just trying my luck!