### PR TITLE
Add nbarapm.com bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -55067,6 +55067,21 @@
     "sc": "Search"
   },
   {
+    "s": "nbarapm.com",
+    "d": "nbarapm.com",
+    "t": "nbarapm",
+    "ts": [
+      "rapm"
+    ],
+    "u": "https://nbarapm.com/player/{{{s}}}",
+    "c": "Entertainment",
+    "sc": "Sports",
+    "fmt": [
+      "open_base_path",
+      "url_encode_placeholder"
+    ]
+  },
+  {
     "s": "Notebookcheck(DE)",
     "d": "www.notebookcheck.com",
     "t": "nbcde",


### PR DESCRIPTION
adds `!nbarapm` (and `!rapm`) bang for [nbarapm.com](https://nbarapm.com), an NBA advanced stats website