### PR TITLE
feat(bangs): add a dedicated bang for films section of Rate Your Music

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -66003,12 +66003,22 @@
     "d": "rateyourmusic.com",
     "t": "rym",
     "ts": [
-      "rymf",
       "rateyourmusic"
     ],
     "u": "https://rateyourmusic.com/search?searchterm={{{s}}}",
     "c": "Entertainment",
     "sc": "Audio"
+  },
+  {
+    "s": "Rate Your Music (films)",
+    "d": "rateyourmusic.com",
+    "t": "rymf",
+    "ts": [
+      "rymfilms", "rateyourfilms"
+    ],
+    "u": "https://rateyourmusic.com/search?searchtype=F&searchterm={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Movies"
   },
   {
     "s": "TopRatgeber24",

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -66003,12 +66003,23 @@
     "d": "rateyourmusic.com",
     "t": "rym",
     "ts": [
-      "rymf",
       "rateyourmusic"
     ],
     "u": "https://rateyourmusic.com/search?searchterm={{{s}}}",
     "c": "Entertainment",
     "sc": "Audio"
+  },
+  {
+    "s": "Rate Your Music (films)",
+    "d": "rateyourmusic.com",
+    "t": "rymf",
+    "ts": [
+      "rymfilms",
+      "rateyourfilms"
+    ],
+    "u": "https://rateyourmusic.com/search?searchtype=F&searchterm={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Movies"
   },
   {
     "s": "TopRatgeber24",


### PR DESCRIPTION
The DuckDuckGo version of !rymf queries the Films section of Rate Your Music, while the Kagi version instead queries the default Music section, adding manual steps in case a movie is what the user seeks to search. This commit splits !rymf into its own dedicated bang, with added aliases to match the existing RYM-related tags in the list.