### PR TITLE
Add bang for Avakot Wiki

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -93633,5 +93633,16 @@
     "u": "https://tesaurus.kemendikdasmen.go.id/tematis/lema/{{{s}}}",
     "c": "Research",
     "sc": "Reference (words)"
+  },
+  {
+    "s": "Avakot Wiki",
+    "d": "wiki.avakot.org",
+    "t": "avakotw",
+    "ts": [
+      "wavakot"
+    ],
+    "u": "https://wiki.avakot.org/?search={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (specific)"
   }
 ]

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -84815,6 +84815,17 @@
     "sc": "Games (specific)"
   },
   {
+    "s": "Avakot Wiki",
+    "d": "wiki.avakot.org",
+    "t": "avakotw",
+    "ts": [
+      "wavakot"
+    ],
+    "u": "https://wiki.avakot.org/?search={{{s}}}",
+    "c": "Entertainment",
+    "sc": "Games (specific)"
+  },
+  {
     "s": "Total war Warhammer Wiki",
     "d": "totalwarwarhammer.gamepedia.com",
     "t": "warhammer",
@@ -93633,16 +93644,5 @@
     "u": "https://tesaurus.kemendikdasmen.go.id/tematis/lema/{{{s}}}",
     "c": "Research",
     "sc": "Reference (words)"
-  },
-  {
-    "s": "Avakot Wiki",
-    "d": "wiki.avakot.org",
-    "t": "avakotw",
-    "ts": [
-      "wavakot"
-    ],
-    "u": "https://wiki.avakot.org/?search={{{s}}}",
-    "c": "Entertainment",
-    "sc": "Games (specific)"
   }
 ]


### PR DESCRIPTION
Avakot Wiki is the community-driven wiki for Soulframe, a game made by Digital Extremes.

As the other DE game, Warframe, already has its own wiki as a bang, I believe it would be of value to have this one too.