### PR TITLE
Added kagi bang using regex to determine a search year

### DIFF
--- a/data/kagi_bangs.json
+++ b/data/kagi_bangs.json
@@ -739,7 +739,7 @@
     "s": "Kagi (year defined search)",
     "d": "kagi.com",
     "t": "years",
-    "u": " https://kagi.com/search?q=$2&from_date=$1-01-01&to_date=$1-12-31",
+    "u": "https://kagi.com/search?q=$2&from_date=$1-01-01&to_date=$1-12-31",
     "x": "\\b((?:20|19)[0-9]{2})\\b\\s+(.*)"
   },
   {

--- a/data/kagi_bangs.json
+++ b/data/kagi_bangs.json
@@ -736,6 +736,13 @@
     "u": "/search?q={{{s}}}&dr=4"
   },
   {
+    "s": "Kagi (year defined search)",
+    "d": "kagi.com",
+    "t": "years",
+    "u": " https://kagi.com/search?q=$2&from_date=$1-01-01&to_date=$1-12-31",
+    "x": "\\b((?:20|19)[0-9]{2})\\b\\s+(.*)"
+  },
+  {
     "s": "Kagi (calculator)",
     "d": "kagi.com",
     "t": "calc",


### PR DESCRIPTION
Using URL:  https://kagi.com/search?q=$2&from_date=$1-01-01&to_date=$1-12-31
REGEX: \b((?:20|19)[0-9]{2})\b\s+(.*)
Syntax !years YEAR QUERY 

Allows searching not just !year but a whole year in the past.  
  
I.e  
```!years 2006 World Cup```