### PR TITLE
Add KLIPY

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -44630,6 +44630,14 @@
     "sc": "Online"
   },
   {
+    "s": "KLIPY",
+    "d": "klipy.com",
+    "t": "klipy",
+    "u": "https://klipy.com/search/{{{s}}}",
+    "c": "Multimedia",
+    "sc": "Images"
+  },
+  {
     "s": "Konsolentreff.de",
     "d": "www.konsolentreff.de",
     "t": "kon",


### PR DESCRIPTION
Lots of services with integrated gif search have switched from [tenor](https://tenor.com/) to [klipy](https://klipy.com/) recently, which has made it quite popular, yet it has no bangs!