### PR TITLE
Add !openrouter trigger for OpenRouter bang

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -13319,6 +13319,9 @@
     "s": "OpenRouter",
     "d": "openrouter.ai",
     "t": "opr",
+    "ts": [
+      "openrouter"
+    ],
     "u": "https://openrouter.ai/models?q={{{s}}}",
     "c": "Online Services",
     "sc": "AI Chatbots"


### PR DESCRIPTION
Adds `!openrouter` as an additional trigger so the existing OpenRouter bang !opr is also discoverable by its full name.