### PR TITLE
fix: `!ark`  (Intel ARK product specifications) redirects to empty Intel website search

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -5394,9 +5394,9 @@
   },
   {
     "s": "Intel Processor Specification",
-    "d": "ark.intel.com",
+    "d": "www.intel.com",
     "t": "ark",
-    "u": "https://ark.intel.com/search?q={{{s}}}",
+    "u": "https://www.intel.com/content/www/us/en/search.html#cf-tabfilter=Products&q={{{s}}}",
     "c": "Tech",
     "sc": "Companies"
   },


### PR DESCRIPTION
Intel ARK has been [integrated into the main website](https://www.intel.com/content/www/us/en/ark.html) and the old search at https://ark.intel.com/search forwards to the website search which is URL incompatible, because it uses hash parameters instead of query parameters.

I also added the "Product Information" filter, because imho that fits best as a replacement for ARK search.