### PR TITLE
Fix prisjakt urls

### DIFF
--- a/data/bangs.json
+++ b/data/bangs.json
@@ -19289,7 +19289,7 @@
     "s": "Le Dénicheur",
     "d": "ledenicheur.fr",
     "t": "denicheur",
-    "u": "https://ledenicheur.fr/#rparams=ss={{{s}}}",
+    "u": "https://ledenicheur.fr/search?query={{{s}}}",
     "c": "Shopping",
     "sc": "Online (deals)"
   },
@@ -62404,7 +62404,7 @@
     "s": "Prisjakt (Norway)",
     "d": "www.prisjakt.no",
     "t": "pjno",
-    "u": "https://www.prisjakt.no/search?search={{{s}}}",
+    "u": "https://www.prisjakt.no/search?query={{{s}}}",
     "c": "Shopping",
     "sc": "Online (deals)"
   },
@@ -62416,7 +62416,7 @@
       "prisjakt",
       "pris"
     ],
-    "u": "https://www.prisjakt.nu/search?search={{{s}}}",
+    "u": "https://www.prisjakt.nu/search?query={{{s}}}",
     "c": "Shopping",
     "sc": "Online (deals)"
   },
@@ -64068,7 +64068,7 @@
     "s": "pricespy.co.nz",
     "d": "pricespy.co.nz",
     "t": "pricespy",
-    "u": "https://pricespy.co.nz/search?search={{{s}}}",
+    "u": "https://pricespy.co.nz/search?query={{{s}}}",
     "c": "Shopping",
     "sc": "Online (deals)"
   },
@@ -64591,7 +64591,7 @@
     "s": "PriceSpy",
     "d": "pricespy.co.nz",
     "t": "psnz",
-    "u": "https://pricespy.co.nz/search?q={{{s}}}",
+    "u": "https://pricespy.co.nz/search?query={{{s}}}",
     "c": "Shopping",
     "sc": "Online"
   },
@@ -64623,7 +64623,7 @@
     "s": "pricespyuk",
     "d": "pricespy.co.uk",
     "t": "psuk",
-    "u": "https://pricespy.co.uk/search?q={{{s}}}",
+    "u": "https://pricespy.co.uk/search?query={{{s}}}",
     "c": "Shopping",
     "sc": "Online (deals)"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -64079,6 +64079,9 @@
     "s": "pricespy.co.nz",
     "d": "pricespy.co.nz",
     "t": "pricespy",
+    "ts": [
+      "psnz"
+    ],
     "u": "https://pricespy.co.nz/search?query={{{s}}}",
     "c": "Shopping",
     "sc": "Online (deals)"
@@ -64595,14 +64598,6 @@
     "d": "store.playstation.com",
     "t": "psnuk",
     "u": "https://store.playstation.com/#!/en-gb/search/q={{{s}}}",
-    "c": "Shopping",
-    "sc": "Online"
-  },
-  {
-    "s": "PriceSpy",
-    "d": "pricespy.co.nz",
-    "t": "psnz",
-    "u": "https://pricespy.co.nz/search?query={{{s}}}",
     "c": "Shopping",
     "sc": "Online"
   },

--- a/data/bangs.json
+++ b/data/bangs.json
@@ -62401,6 +62401,17 @@
     "sc": "Specialty"
   },
   {
+    "s": "Prisjagt",
+    "d": "www.prisjagt.dk",
+    "t": "pjdk",
+    "ts": [
+      "prisjagt"
+    ],
+    "u": "https://www.prisjagt.dk/search?query={{{s}}}",
+    "c": "Shopping",
+    "sc": "Online (deals)"
+  },
+  {
     "s": "Prisjakt (Norway)",
     "d": "www.prisjakt.no",
     "t": "pjno",


### PR DESCRIPTION
Websites by the Prisjakt/PriceSpy company have changed search URLs from a `search` param to `query`.

Also adds https://prisjagt.dk, the Danish version of the site. All other sites (based on the list on [Prisjakt's Swedish Wikipedia](https://sv.wikipedia.org/wiki/Prisjakt) are already included.